### PR TITLE
feat: iPhone Hochkant (Portrait) Layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -1425,3 +1425,63 @@ body.code-view-active #chat-settings-btn {
         height: 48px;
     }
 }
+
+/* === iPhone Portrait (Hochkant) — max-width 768px === */
+@media (orientation: portrait) and (max-width: 768px) {
+    /* Hauptlayout: von horizontal zu vertikal */
+    #main-area {
+        flex-direction: column;
+    }
+
+    /* Palette: horizontal scrollbar oben statt vertikal links */
+    #palette {
+        width: 100%;
+        height: auto;
+        flex-direction: row;
+        overflow-x: auto;
+        overflow-y: hidden;
+        padding: 4px 8px;
+        gap: 4px;
+        order: -1; /* Palette über Canvas */
+        border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+    }
+
+    /* Palette-Buttons: 52x52px — touch-freundlich */
+    #palette .material-btn {
+        min-width: 52px;
+        min-height: 52px;
+        flex-shrink: 0;
+    }
+
+    /* Canvas nimmt volle Breite */
+    #canvas-wrapper {
+        width: 100%;
+        flex: 1;
+        min-height: 0;
+    }
+
+    #game-canvas {
+        max-width: 100%;
+        max-height: 100%;
+    }
+
+    /* Stats: jetzt sichtbar unten, kompakt */
+    #stats {
+        width: 100%;
+        max-height: 200px;
+        padding: 10px;
+        overflow-y: auto;
+        display: block;
+        box-shadow: none;
+        border-top: 1px solid rgba(255, 255, 255, 0.2);
+    }
+
+    #stats h2 {
+        font-size: 14px;
+        margin-bottom: 8px;
+    }
+
+    #stats-content p {
+        font-size: 12px;
+    }
+}


### PR DESCRIPTION
## Summary
- Portrait-Modus: Palette wird horizontal scrollbar oben
- Canvas nimmt volle Breite und Höhe ein
- Stats erscheinen kompakt unter Canvas
- Buttons 52x52px (Touch-freundlich auch hochkant)

## Test plan
- [ ] iPhone Safari: schatzinsel.app hochkant öffnen → Palette oben horizontal
- [ ] Canvas füllt verfügbaren Raum zwischen Palette und Stats
- [ ] Querformat unverändert (Regression)
- [ ] Touch: Palette und Stats scrollbar funktionieren
- [ ] Stats sichtbar mit Insel-Info, Quests, Inventar

🤖 Generated with Claude Code