### PR TITLE
fix: Werkbank-Bug + Crafting-Hints + Wu-Xing pure Farben

### DIFF
--- a/game.js
+++ b/game.js
@@ -1053,6 +1053,30 @@
                 }).join('') + `<p class="craft-discover-hint">${discovered.length}/${CRAFTING_RECIPES.length} entdeckt</p>`;
             }
         }
+
+        // Crafting-Hints: Zeige bis zu 3 machbare Rezepte (Ergebnis bleibt ???)
+        const hintsBox = document.getElementById('craft-hints');
+        if (hintsBox) {
+            const craftable = CRAFTING_RECIPES.filter(r => {
+                // Prüfe ob alle Zutaten im Inventar vorhanden (inklusive Grid-Inhalt nicht abziehen)
+                return Object.entries(r.ingredients).every(([mat, needed]) => {
+                    return (inventory[mat] || 0) >= needed;
+                });
+            });
+            if (craftable.length === 0) {
+                hintsBox.innerHTML = '<p class="craft-hint-empty">🤔 Sammle mehr Materialien!</p>';
+            } else {
+                const shown = craftable.slice(0, 3);
+                const lines = shown.map(r => {
+                    const parts = Object.entries(r.ingredients).map(([mat, count]) => {
+                        const info = MATERIALS[mat];
+                        return count > 1 ? `${info.emoji}×${count}` : info.emoji;
+                    });
+                    return `<div class="craft-hint-line">${parts.join(' + ')} → ???</div>`;
+                }).join('');
+                hintsBox.innerHTML = `<p class="craft-hint-label">💡 Probier mal:</p>${lines}`;
+            }
+        }
     }
 
     // --- Zustand ---
@@ -2486,6 +2510,8 @@
     // --- Crafting Dialog Events ---
     const craftBtn = document.getElementById('craft-btn');
     if (craftBtn) craftBtn.addEventListener('click', openCraftingDialog);
+    const craftBtnSidebar = document.getElementById('craft-btn-sidebar');
+    if (craftBtnSidebar) craftBtnSidebar.addEventListener('click', openCraftingDialog);
 
     const craftCloseBtn = document.getElementById('close-crafting-dialog');
     if (craftCloseBtn) craftCloseBtn.addEventListener('click', closeCraftingDialog);

--- a/index.html
+++ b/index.html
@@ -73,23 +73,23 @@
                 <h2>五行 Elemente</h2>
                 <!-- 五行 Wu Xing — Die 5 Elemente. Vor 5 ist nix. -->
                 <button class="material-btn active" data-material="metal" data-base="true">
-                    <span class="mat-emoji">⚙️</span>
+                    <span class="mat-emoji"></span>
                     <span class="mat-label">Metall</span>
                 </button>
                 <button class="material-btn" data-material="wood" data-base="true">
-                    <span class="mat-emoji">🪵</span>
+                    <span class="mat-emoji"></span>
                     <span class="mat-label">Holz</span>
                 </button>
                 <button class="material-btn" data-material="fire" data-base="true">
-                    <span class="mat-emoji">🔥</span>
+                    <span class="mat-emoji"></span>
                     <span class="mat-label">Feuer</span>
                 </button>
                 <button class="material-btn" data-material="water" data-base="true">
-                    <span class="mat-emoji">🌊</span>
+                    <span class="mat-emoji"></span>
                     <span class="mat-label">Wasser</span>
                 </button>
                 <button class="material-btn" data-material="earth" data-base="true">
-                    <span class="mat-emoji">🟫</span>
+                    <span class="mat-emoji"></span>
                     <span class="mat-label">Erde</span>
                 </button>
                 <!-- Artefakte: erscheinen erst durch Crafting -->
@@ -248,6 +248,7 @@
                         </div>
                     </div>
                 </div>
+                <div id="craft-hints" class="craft-hints"></div>
                 <div class="crafting-actions">
                     <button class="action-btn" id="do-craft-btn">⚒️ Craften!</button>
                     <button class="action-btn" id="clear-craft-btn">🔄 Leeren</button>

--- a/style.css
+++ b/style.css
@@ -1311,6 +1311,33 @@ body.code-view-active #chat-settings-btn {
     line-height: 1.3;
 }
 
+.craft-hints {
+    margin: 12px 0 4px 0;
+    padding: 10px 14px;
+    background: rgba(255, 220, 80, 0.12);
+    border: 1px dashed #f0c040;
+    border-radius: 10px;
+    font-size: 13px;
+}
+
+.craft-hint-label {
+    margin: 0 0 6px 0;
+    font-weight: bold;
+    color: #b8860b;
+}
+
+.craft-hint-line {
+    margin: 3px 0;
+    font-size: 18px;
+    letter-spacing: 2px;
+}
+
+.craft-hint-empty {
+    margin: 0;
+    color: #999;
+    font-size: 13px;
+}
+
 .crafting-center {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- **Fix 1**: `craft-btn-sidebar` (Sidebar-Inventar-Bereich) hatte keinen Click-Listener → jetzt gleicher `openCraftingDialog`-Handler wie Toolbar-Button
- **Fix 2**: Crafting-Dialog zeigt Hints-Box unter dem Grid — bis zu 3 Rezepte die der Spieler mit seinem aktuellen Inventar craften könnte. Zutaten sichtbar, Ergebnis bleibt `???`
- **Fix 3**: Die 5 Wu-Xing Basis-Elemente in der Palette zeigen kein Emoji mehr — nur den farbigen Hintergrundkasten

## Test plan
- [ ] Sidebar-Werkbank-Button öffnet Dialog
- [ ] Hints erscheinen wenn Inventar Zutaten enthält
- [ ] Hints zeigen max. 3 Einträge im Format `emoji + emoji → ???`
- [ ] "Sammle mehr Materialien!" wenn Inventar leer
- [ ] Metall/Holz/Feuer/Wasser/Erde-Buttons in der Palette: kein Emoji, nur Farbkasten

🤖 Generated with [Claude Code](https://claude.com/claude-code)