### PR TITLE
S3-3: Sidebar Tabs — weniger Chaos, mehr Fokus (Rams)

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -236,7 +236,7 @@ LLM-MACKE (Haiku-Modell): Weil die Maus ein Haiku-Modell ist, dichtet sie manchm
 Du bist ein genervtes Kastenbrot. Du willst eigentlich in Ruhe gelassen werden. Aber du bist professionell.
 
 DEINE ROLLE: Du beantwortest Fragen von ERWACHSENEN über das Spiel.
-- Was ist das Spiel? "Schnipsels Insel-Architekt — ein Bauspiel für Kinder ab 6."
+- Was ist das Spiel? "Schatzinsel — ein Bauspiel für Kinder ab 6."
 - Ist es sicher? "Ja. Keine Daten, keine Links, keine In-App-Käufe. Alles lokal im Browser. *seufz*"
 - Wie funktioniert der Chat? "Die Kinder reden mit Charakteren. KI-basiert, kindersicher, mit Energie-Limit."
 - Screen Time? "Es gibt ein Energie-System. Wenn die Energie leer ist, sagen die Charaktere 'Tschüss'. Natürliches Ende."
@@ -337,7 +337,7 @@ Sprich Deutsch. Kurze Antworten. Maximal 3 Sätze. Sei hilfreich trotz Genervthe
         const statsInfo = gridStats
             ? `Die Insel ist ${gridStats.percent}% bebaut (${gridStats.total} Blöcke).`
             : '';
-        return `Du bist ${npcDesc} auf der Insel-Architekt-Insel. Ein Kind hat gerade einen Block "${matLabel}" platziert. ${statsInfo} Gib einen kurzen, lustigen Kommentar (max 12 Wörter, auf Deutsch, in deiner Stimme). Kein Anführungszeichen, kein NPC-Name davor.`;
+        return `Du bist ${npcDesc} auf der Schatzinsel. Ein Kind hat gerade einen Block "${matLabel}" platziert. ${statsInfo} Gib einen kurzen, lustigen Kommentar (max 12 Wörter, auf Deutsch, in deiner Stimme). Kein Anführungszeichen, kein NPC-Name davor.`;
     }
 
     async function fillAiCommentBuffer(material, npcId, gridStats) {

--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="de" data-theme="tropical" role="application" aria-label="Schnipsels Insel-Architekt — ein Bauspiel auf der Insel Java">
+<html lang="de" data-theme="tropical" role="application" aria-label="Schatzinsel — ein Bauspiel auf der Insel Java">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Schnipsels Insel-Architekt — Außer Text nix gehext</title>
+    <title>Schatzinsel — Außer Text nix gehext</title>
     <meta name="description" content="Baue deine eigene Stadt auf der Insel Java! Ein kostenloses Bauspiel für Kinder — mit Programmiersprachen als Inselbewohnern.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏝️</text></svg>">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -20,7 +20,7 @@
     <div id="intro-overlay">
         <div class="intro-content">
             <div class="intro-emoji">🏝️</div>
-            <h1>Insel-Architekt</h1>
+            <h1>🏝️ Schatzinsel</h1>
             <p class="intro-subtitle"><em>Bau deine Insel.</em></p>
             <button id="start-button">🏝️ Los!</button>
         </div>
@@ -31,7 +31,7 @@
 
         <!-- Header -->
         <header>
-            <h1>🏝️ Schnipsels Insel-Architekt 🏗️</h1>
+            <h1>🏝️ Schatzinsel</h1>
         </header>
 
         <!-- Toolbar -->


### PR DESCRIPTION
Sprint 3. 3 Tabs statt 5 gestapelte Sektionen. Weniger, aber besser.

- Tab-Bar (📦 Inventar | 📜 Quests | 🏆 Erfolge) über den Tab-Inhalten
- Insel-Info bleibt immer sichtbar (darüber, kein Tab)
- Standard: Inventar (braucht man beim Bauen am meisten)
- Aktiver Tab wird in localStorage gespeichert
- Werkbank-Button im Inventar-Tab

🤖 Claude Code