### PR TITLE
feat: INSEL Namespace mit Event-Bus und Modul-Registry

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,7 @@
 
     </div>
 
+    <script src="insel.js"></script>
     <script src="storage.js"></script>
     <script src="materials.js"></script>
     <script src="achievements.js"></script>

--- a/insel.js
+++ b/insel.js
@@ -1,0 +1,47 @@
+// === INSEL — Zentraler Namespace ===
+// Der Zellkern. Alle Module registrieren sich hier.
+// Phase 1 aus EVOLUTION.md: Prokaryot → Eukaryot
+(function() {
+    'use strict';
+
+    const INSEL = window.INSEL || {};
+
+    // Event-Bus: einfaches Pub/Sub
+    const listeners = {};
+
+    INSEL.on = function(event, handler) {
+        if (!listeners[event]) listeners[event] = [];
+        listeners[event].push(handler);
+    };
+
+    INSEL.off = function(event, handler) {
+        if (!listeners[event]) return;
+        listeners[event] = listeners[event].filter(h => h !== handler);
+    };
+
+    INSEL.emit = function(event, data) {
+        if (!listeners[event]) return;
+        listeners[event].forEach(h => {
+            try { h(data); } catch (e) { console.error('INSEL event error:', event, e); }
+        });
+    };
+
+    // Modul-Registry: Module registrieren sich mit Namen
+    INSEL.register = function(name, module) {
+        if (INSEL[name]) {
+            console.warn('INSEL: Modul ' + name + ' wird überschrieben');
+        }
+        INSEL[name] = module;
+    };
+
+    // Version & Debug
+    INSEL.version = '1.0.0';
+    INSEL.debug = function() {
+        const modules = Object.keys(INSEL).filter(k =>
+            typeof INSEL[k] === 'object' && k !== 'version'
+        );
+        return { modules, listeners: Object.keys(listeners), version: INSEL.version };
+    };
+
+    window.INSEL = INSEL;
+})();


### PR DESCRIPTION
## Summary\n- Neues `insel.js` mit zentralem INSEL-Objekt\n- Event-Bus: on/off/emit mit Error-Isolation\n- Modul-Registry: register(name, module)\n- Debug-Funktion listet registrierte Module und Listener\n- Backlog #11 Mitochondrium 3: Namespace statt 41 Globals\n\n## Test plan\n- [ ] `INSEL.register('test', {})` → Modul registriert\n- [ ] `INSEL.on('event', fn)` + `INSEL.emit('event', data)` → fn wird aufgerufen\n- [ ] `INSEL.off('event', fn)` → fn wird nicht mehr aufgerufen\n- [ ] `INSEL.debug()` → zeigt Module und Listener in Console\n- [ ] Bestehende Funktionalität unverändert (insel.js ist additiv)\n\nhttps://claude.ai/code/session_018Rsx6YK2bL6gR14tqPf2qV