### PR TITLE
feat: Backlog #87 — TTS Hörspiele respektiert Mute-Button

### DIFF
--- a/game.js
+++ b/game.js
@@ -752,7 +752,7 @@
     let hoerspielSpeaking = false;
 
     function speakLines(lines, onDone) {
-        if (!window.speechSynthesis) {
+        if (!window.speechSynthesis || INSEL_SOUND.isMuted()) {
             if (onDone) onDone();
             return;
         }
@@ -772,7 +772,7 @@
             if (index === 0) soundAchievement();
             index++;
 
-            if (!text) { setTimeout(speakNext, 500); return; }
+            if (!text || INSEL_SOUND.isMuted()) { setTimeout(speakNext, 500); return; }
 
             const utter = new SpeechSynthesisUtterance(text);
             utter.lang = 'de-DE';
@@ -3729,6 +3729,7 @@
         muteBtn.addEventListener('click', () => {
             const nowMuted = !INSEL_SOUND.isMuted();
             INSEL_SOUND.setMuted(nowMuted);
+            if (nowMuted && window.speechSynthesis) window.speechSynthesis.cancel();
             muteBtn.textContent = nowMuted ? '🔇' : '🔊';
             showToast(nowMuted ? 'Ton aus' : 'Ton an');
         });


### PR DESCRIPTION
## Summary
- TTS-Grundfunktionen (speakLines, stripForTTS, speechSynthesis-Check) waren bereits implementiert
- **Neu**: `speakLines` prüft `INSEL_SOUND.isMuted()` vor dem Start und bei jeder neuen Zeile — gemutete Spieler hören keine Sprachausgabe
- **Neu**: Mute-Button ruft `speechSynthesis.cancel()` auf — bricht laufende TTS sofort ab
- Graceful degradation: kein speechSynthesis = kein Fehler, Toasts laufen weiter

## Test plan
- [ ] Hörspiel triggern (1. Block platzieren) — TTS spricht auf Deutsch
- [ ] Mute-Button drücken während Hörspiel läuft — Sprache stoppt sofort
- [ ] Mute aktivieren, dann Hörspiel triggern — keine Sprachausgabe, Toasts erscheinen trotzdem
- [ ] Browser ohne speechSynthesis-Support — kein Fehler, Toasts laufen normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)