### PR TITLE
feat: Apple HIG #8 — Dark Mode Support

### DIFF
--- a/game.js
+++ b/game.js
@@ -3687,9 +3687,14 @@
     const THEMES = ['tropical', 'night', 'candy', 'ocean', 'retro'];
     const THEME_NAMES = ['🏝️ Tropeninsel', '🌙 Nachtmodus', '🍭 Candy Pop', '🌊 Ozean', '🕹️ Retro'];
     let currentTheme = localStorage.getItem('insel-theme') || 'tropical';
+    const userChoseTheme = localStorage.getItem('insel-theme-manual') === '1';
 
-    function applyTheme(theme) {
+    function applyTheme(theme, manual = false) {
         document.documentElement.setAttribute('data-theme', theme);
+        if (manual) {
+            document.documentElement.setAttribute('data-theme-manual', '');
+            localStorage.setItem('insel-theme-manual', '1');
+        }
         currentTheme = theme;
         localStorage.setItem('insel-theme', theme);
         requestRedraw();
@@ -3697,11 +3702,22 @@
         trackEvent('theme_change', { theme });
     }
 
+    // Apple HIG #8: Dark Mode — respect OS preference when user hasn't chosen manually
+    if (!userChoseTheme && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        applyTheme('night');
+    }
+
+    // Live-Switch: OS wechselt zwischen Light/Dark → Theme folgt (nur wenn nicht manuell)
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+        if (localStorage.getItem('insel-theme-manual') === '1') return;
+        applyTheme(e.matches ? 'night' : 'tropical');
+    });
+
     const themeBtn = document.getElementById('theme-btn');
     if (themeBtn) {
         themeBtn.addEventListener('click', () => {
             const idx = (THEMES.indexOf(currentTheme) + 1) % THEMES.length;
-            applyTheme(THEMES[idx]);
+            applyTheme(THEMES[idx], true);
             showToast(`${THEME_NAMES[idx]} aktiviert!`);
         });
     }

--- a/style.css
+++ b/style.css
@@ -2020,3 +2020,21 @@ body.code-view-active #chat-settings-btn {
         scroll-behavior: auto !important;
     }
 }
+
+/* === DARK MODE — Apple HIG #8: Respect prefers-color-scheme === */
+/* Falls der User kein Theme manuell gewählt hat, folgt das Spiel dem OS-Setting */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme-manual]) {
+        --bg: #1a1a2e;
+        --header-bg: linear-gradient(135deg, #16213e, #0f3460);
+        --toolbar-bg: linear-gradient(135deg, #533483, #3d1d72);
+        --palette-bg: linear-gradient(180deg, #1a1a2e, #16213e);
+        --stats-bg: linear-gradient(180deg, #0f3460, #1a1a2e);
+        --canvas-bg: #16213e;
+        --accent: #e94560;
+        --accent-light: #2d1f3d;
+        --text: #eee;
+        --text-light: #e0e0e0;
+        --btn-bg: #2d1f3d;
+    }
+}


### PR DESCRIPTION
## Summary
- Automatischer Wechsel auf Night-Theme wenn OS auf Dark Mode steht (`prefers-color-scheme: dark`)
- Live-Reaktion: OS wechselt Light↔Dark → Spiel folgt sofort
- Manueller Theme-Button überschreibt den Auto-Modus (Flag `data-theme-manual` + localStorage)
- CSS `@media`-Fallback für den Fall dass JS noch nicht geladen hat

## Test plan
- [ ] iPhone/Mac auf Dark Mode stellen → Spiel startet im Night-Theme
- [ ] Theme-Button klicken → wechselt manuell, OS-Preference wird ignoriert
- [ ] OS zurück auf Light Mode → kein Wechsel (weil manuell gewählt)
- [ ] localStorage leeren → OS-Preference greift wieder

🤖 Generated with [Claude Code](https://claude.com/claude-code)