### PR TITLE
feat: [Backlog #77] Rewind/Zeitreise

### DIFF
--- a/game.js
+++ b/game.js
@@ -3768,6 +3768,61 @@
         });
     }
 
+    // === REWIND / ZEITREISE (Backlog #77) ===
+    // Baugeschichte rückwärts abspielen wie Kassettenrekorder
+    const rewindBtn = document.getElementById('rewind-btn');
+    if (rewindBtn) {
+        rewindBtn.addEventListener('click', () => {
+            if (undoStack.length === 0) {
+                showToast('⏪ Keine Geschichte zum Zurückspulen!');
+                return;
+            }
+            rewindBtn.disabled = true;
+            rewindBtn.textContent = '⏳';
+
+            // Aktuellen Zustand merken für Forward am Ende
+            const currentGrid = JSON.stringify(grid);
+            const snapshots = undoStack.slice(); // Kopie
+            snapshots.push(currentGrid); // Aktuell als letzten Frame
+
+            // Rückwärts abspielen
+            let idx = snapshots.length - 1;
+            const STEP_MS = Math.max(80, Math.min(300, 5000 / snapshots.length));
+
+            function stepRewind() {
+                if (idx < 0) {
+                    // Vorwärts zurück zum Ist-Zustand
+                    let fwd = 0;
+                    function stepForward() {
+                        if (fwd >= snapshots.length) {
+                            rewindBtn.disabled = false;
+                            rewindBtn.textContent = '⏪';
+                            showToast('⏪ Zeitreise beendet!');
+                            return;
+                        }
+                        grid = JSON.parse(snapshots[fwd]);
+                        window.grid = grid;
+                        requestRedraw();
+                        if (!INSEL_SOUND.isMuted()) INSEL_SOUND.soundBuild('qi');
+                        fwd++;
+                        setTimeout(stepForward, STEP_MS / 2);
+                    }
+                    setTimeout(stepForward, 400);
+                    return;
+                }
+                grid = JSON.parse(snapshots[idx]);
+                window.grid = grid;
+                requestRedraw();
+                if (!INSEL_SOUND.isMuted()) INSEL_SOUND.soundDemolish(() => ({ percent: (idx / snapshots.length) * 100 }));
+                idx--;
+                setTimeout(stepRewind, STEP_MS);
+            }
+
+            showToast('⏪ Zeitreise...');
+            stepRewind();
+        });
+    }
+
     // Kurzes Highlight auf einer Canvas-Zelle (weißer Flash)
     function replayHighlight(r, c) {
         const x = (c + WATER_BORDER) * CELL_SIZE;

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
                 <button class="tool-btn" id="mute-btn" title="Ton an/aus">🔊</button>
                 <button class="tool-btn" id="code-view-btn" title="Code-Ansicht">&lt;/&gt;</button>
                 <button class="tool-btn" id="replay-btn" title="Bauwerk als Song abspielen">🎵</button>
+                <button class="tool-btn" id="rewind-btn" title="Zeitreise: Baugeschichte rückwärts">⏪</button>
             </div>
             <div class="toolbar-group" id="project-group">
                 <input type="text" id="project-name" placeholder="Mein Bauwerk" maxlength="30">


### PR DESCRIPTION
## Summary
- Neuer Toolbar-Button (⏪) fuer Zeitreise/Rewind
- Spielt Undo-History rueckwaerts ab (Demolish-Sound), dann vorwaerts zurueck (Build-Sound)
- Kassettenrekorder-Feeling: erst alles weg, dann alles wieder da
- Tempo passt sich automatisch an (80-300ms pro Frame)

## Test plan
- [ ] Ein paar Bloecke platzieren, dann ⏪ druecken
- [ ] Animation laeuft rueckwaerts, dann vorwaerts
- [ ] Button ist disabled waehrend Animation
- [ ] Toast zeigt "Zeitreise..." und "Zeitreise beendet!"
- [ ] Bei leerer Undo-History: Toast "Keine Geschichte"

🤖 Generated with [Claude Code](https://claude.com/claude-code)