### PR TITLE
fix: GitHub Actions — Smoke-Test + Preview repariert

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,9 @@ jobs:
       - name: JS Syntax-Check
         run: |
           FAIL=0
+          SKIP="worker.js gemini-voice-worker.js playwright.config.js"
           for f in *.js; do
-            [ "$f" = "worker.js" ] && continue  # Cloudflare Worker — eigener Runtime
+            echo "$SKIP" | grep -qw "$f" && continue  # Cloudflare Worker / Dev-Config
             if ! node -c "$f" 2>&1; then
               FAIL=1
             fi
@@ -37,8 +38,8 @@ jobs:
 
       - name: Smoke-Test — Seite lädt ohne Fehler
         run: |
-          npm i -g puppeteer@latest 2>/dev/null || true
-          npx --yes puppeteer browsers install chrome 2>/dev/null || true
+          npm install puppeteer --no-save
+          npx puppeteer browsers install chrome
           node --input-type=module <<'SMOKE'
           import puppeteer from 'puppeteer';
           import { readFileSync } from 'fs';

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,10 +11,14 @@ jobs:
       contents: read
       pull-requests: write
       deployments: write
+    env:
+      CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Deploy to Cloudflare Pages
+        if: ${{ env.CF_API_TOKEN != '' }}
         uses: cloudflare/wrangler-action@v3
         id: deploy
         with:
@@ -22,7 +26,12 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy . --project-name=schatzinsel --branch=${{ github.head_ref }}
 
+      - name: Skip notice
+        if: ${{ env.CF_API_TOKEN == '' }}
+        run: echo "⚠️ CLOUDFLARE_API_TOKEN nicht gesetzt — Preview-Deploy übersprungen"
+
       - name: Comment Preview URL
+        if: ${{ steps.deploy.outcome == 'success' }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Was kaputt war

Alle PRs (#105, #106, #107) scheitern an CI. Zwei Ursachen:

### 1. Smoke-Test (deploy.yml)
`npm i -g puppeteer@latest` installiert global, aber ESM `import puppeteer from 'puppeteer'` sucht nur in `node_modules/`. Ergebnis: `ERR_MODULE_NOT_FOUND` → sofortiger Crash nach ~16 Sekunden.

**Fix:** `npm install puppeteer --no-save` (lokal). Fehler-Suppression (`2>/dev/null || true`) entfernt — wenn Puppeteer nicht installiert, soll CI laut scheitern statt leise.

### 2. Syntax-Check (deploy.yml)
`worker.js` war excluded, aber `gemini-voice-worker.js` (Cloudflare Worker) und `playwright.config.js` (Dev-Dependency) nicht.

**Fix:** Skip-Liste erweitert.

### 3. Preview-Deploy (preview.yml)
Scheitert wenn `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` nicht als Secrets gesetzt sind.

**Fix:** Deploy-Step nur ausführen wenn Secrets vorhanden. Sonst Skip-Notice statt rotem X.

## Test plan

- [ ] Dieser PR: Check-Job geht durch (Syntax + Smoke-Test)
- [ ] Preview-Deploy: grün (Skip-Notice) oder deployed wenn Secrets gesetzt
- [ ] Danach: PRs #105, #106, #107 re-run → Check sollte durchgehen (gleiche main-Workflows)