### PR TITLE
Krabs: Muschelwährung und Handel-System

### DIFF
--- a/game.js
+++ b/game.js
@@ -426,6 +426,9 @@
         } else if (quest) {
             showToast(`${npc.emoji} ${quest.desc}`, 5000);
             window.questSystem.accept(quest);
+        } else if (npcId === 'krabs') {
+            // Krabs: Kein Quest? Dann HANDEL! 🦀💰
+            showKrabsShop();
         } else {
             const voice = NPC_VOICES[npcId];
             if (voice) {
@@ -433,6 +436,96 @@
                 showToast(`${npc.emoji} ${voice.prefix} ${tick}`, 2000);
             }
         }
+    }
+
+    // === KRABS SHOP — Muschelhandel ===
+    function showKrabsShop() {
+        const shells = getInventoryCount('shell');
+        // Welche Materialien kann der Spieler verkaufen?
+        const sellable = Object.entries(KRABS_SHOP)
+            .filter(([mat]) => getInventoryCount(mat) > 0)
+            .map(([mat, price]) => {
+                const info = MATERIALS[mat];
+                return `${info.emoji} ${info.label}: ${price.sell} 🐚`;
+            }).slice(0, 4);
+
+        // Welche kann er kaufen?
+        const buyable = Object.entries(KRABS_SHOP)
+            .filter(([, price]) => shells >= price.buy)
+            .map(([mat, price]) => {
+                const info = MATERIALS[mat];
+                return `${info.emoji} ${info.label}: ${price.buy} 🐚`;
+            }).slice(0, 4);
+
+        // Dialog als Modal
+        let existing = document.getElementById('krabs-shop-modal');
+        if (existing) existing.remove();
+
+        const modal = document.createElement('div');
+        modal.id = 'krabs-shop-modal';
+        modal.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.7);z-index:10000;display:flex;align-items:center;justify-content:center;';
+        modal.addEventListener('click', (e) => { if (e.target === modal) modal.remove(); });
+
+        const shopItems = Object.entries(KRABS_SHOP);
+        const shopHTML = shopItems.map(([mat, price]) => {
+            const info = MATERIALS[mat];
+            if (!info) return '';
+            const have = getInventoryCount(mat);
+            return `<div style="display:flex;align-items:center;justify-content:space-between;padding:4px 0;border-bottom:1px solid #333;">
+                <span>${info.emoji} ${info.label} (${have}x)</span>
+                <span>
+                    <button class="krabs-buy" data-mat="${mat}" data-cost="${price.buy}"
+                        style="background:#2E7D32;color:white;border:none;border-radius:4px;padding:2px 8px;cursor:pointer;margin:0 2px;"
+                        ${shells < price.buy ? 'disabled style="opacity:0.4;background:#2E7D32;color:white;border:none;border-radius:4px;padding:2px 8px;cursor:pointer;margin:0 2px;"' : ''}>
+                        Kauf ${price.buy}🐚</button>
+                    <button class="krabs-sell" data-mat="${mat}" data-earn="${price.sell}"
+                        style="background:#C62828;color:white;border:none;border-radius:4px;padding:2px 8px;cursor:pointer;margin:0 2px;"
+                        ${have <= 0 ? 'disabled style="opacity:0.4;background:#C62828;color:white;border:none;border-radius:4px;padding:2px 8px;cursor:pointer;margin:0 2px;"' : ''}>
+                        Verkauf ${price.sell}🐚</button>
+                </span>
+            </div>`;
+        }).join('');
+
+        modal.innerHTML = `<div style="background:#1a1a2e;color:#eee;border-radius:12px;padding:20px;max-width:360px;width:90%;max-height:70vh;overflow-y:auto;font-family:monospace;">
+            <h3 style="margin:0 0 8px;text-align:center;">🦀 Krabben-Kontor 💰</h3>
+            <p style="text-align:center;margin:0 0 12px;font-size:1.1em;">Dein Vermögen: <strong>${shells} 🐚</strong></p>
+            <p style="text-align:center;margin:0 0 12px;font-size:0.8em;color:#aaa;">Darwin sagt: Handel ist Evolution! Muscheln findest du am Strand!</p>
+            ${shopHTML}
+            <p style="text-align:center;margin:12px 0 0;font-size:0.7em;color:#666;">Klick außerhalb zum Schließen</p>
+        </div>`;
+
+        document.body.appendChild(modal);
+
+        // Event-Handler für Kauf/Verkauf
+        modal.querySelectorAll('.krabs-buy').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const mat = btn.dataset.mat;
+                const cost = parseInt(btn.dataset.cost);
+                if (getInventoryCount('shell') >= cost) {
+                    removeFromInventory('shell', cost);
+                    addToInventory(mat, 1);
+                    unlockMaterial(mat);
+                    showToast(`🦀 DEAL! 1x ${MATERIALS[mat]?.emoji} ${MATERIALS[mat]?.label} für ${cost} 🐚!`, 2000);
+                    modal.remove();
+                    showKrabsShop(); // Refresh
+                }
+            });
+        });
+
+        modal.querySelectorAll('.krabs-sell').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const mat = btn.dataset.mat;
+                const earn = parseInt(btn.dataset.earn);
+                if (getInventoryCount(mat) > 0) {
+                    removeFromInventory(mat, 1);
+                    addToInventory('shell', earn);
+                    unlockMaterial('shell');
+                    showToast(`🦀 VERKAUFT! 1x ${MATERIALS[mat]?.emoji} für ${earn} 🐚! Ahahaha!`, 2000);
+                    modal.remove();
+                    showKrabsShop(); // Refresh
+                }
+            });
+        });
     }
 
     // --- NPC-Kommentare beim Bauen ---
@@ -1521,6 +1614,23 @@
         sapling:    { material: 'wood', count: 1 },
         palm:       { material: 'wood', count: 2 },
     };
+
+    // === KRABS: Muschelhandel — Preisliste ===
+    // Muscheln sind die Insel-Währung. Krabs kauft und verkauft.
+    const KRABS_SHOP = {
+        // material: { buy: Muscheln die Krabs verlangt, sell: Muscheln die Krabs zahlt }
+        wood:     { buy: 2,  sell: 1 },
+        stone:    { buy: 3,  sell: 1 },
+        sand:     { buy: 1,  sell: 1 },
+        planks:   { buy: 4,  sell: 2 },
+        glass:    { buy: 5,  sell: 2 },
+        flower:   { buy: 3,  sell: 1 },
+        fish:     { buy: 4,  sell: 2 },
+        diamond:  { buy: 20, sell: 8 },
+        crystal:  { buy: 15, sell: 6 },
+        honey:    { buy: 8,  sell: 3 },
+        apple:    { buy: 6,  sell: 2 },
+    };
     let isMouseDown = false;
     let hoverCell = null;
     // animations[] → effects.js
@@ -2386,6 +2496,12 @@
                 }
                 addToInventory(yield_.material, yield_.count);
                 unlockMaterial(yield_.material);
+                // Krabs: Sand/Wasser ernten → Chance auf Bonus-Muschel (Strandgut!)
+                if ((cell === 'sand' || cell === 'water') && Math.random() < 0.3) {
+                    addToInventory('shell', 1);
+                    unlockMaterial('shell');
+                    showToast('🐚 Eine Muschel! Mr. Krabs kauft die...', 2000);
+                }
                 EFFECTS.addPlaceAnimation(r, c);
                 soundChop();
                 const info = MATERIALS[yield_.material];

--- a/materials.js
+++ b/materials.js
@@ -98,6 +98,8 @@ window.INSEL_MATERIALS = {
     wave:     { emoji: '🌊', label: 'Tsunami',  color: '#2980B9', border: '#1F618D' },
     phoenix:  { emoji: '🔥', label: 'Phönix',   color: '#F39C12', border: '#E67E22' },
     ash:      { emoji: '🪨', label: 'Asche',    color: '#808080', border: '#606060' },
+    // === HANDEL (Mr. Krabs — Muschelwährung) ===
+    shell:    { emoji: '🐚', label: 'Muschel',  color: '#FADADD', border: '#E8B4B8' },
     // === UNSINN (Lindgren-approved) ===
     worm:     { emoji: '🪱', label: 'Regenwurm', color: '#CD853F', border: '#A0522D' },
     flyfish:  { emoji: '🐟', label: 'Flugfisch', color: '#87CEEB', border: '#5DADE2' },

--- a/quests.js
+++ b/quests.js
@@ -84,4 +84,7 @@ window.INSEL_QUEST_TEMPLATES = [
     { npc: 'neinhorn', title: 'Pilzwald', desc: 'NEIN keine Pilze! ...doch. Riesige Pilze. Die LEUCHTEN. Im Dunkeln. Das ist gruselig-gemütlich!', needs: { mushroom: 6, lamp: 4, tree: 3, fence: 2 }, reward: '🌈🌈🌈' },
     { npc: 'maus', title: 'Bibliothek', desc: '*pieps* Bücher! *quak* Die Ente kann nicht lesen! *pieps* Dann LERNT sie es! *quak* ...ok EINE Seite!', needs: { wood: 6, glass: 3, lamp: 4, door: 1 }, reward: '🌻🌻🌻' },
     { npc: 'maus', title: 'Honig-Bäckerei', desc: '*pieps* Honig PLUS Mehl GLEICH Kuchen! *quak* Das ist Mathe! *pieps* Das ist BACKEN! *quak* Beides!', needs: { honey: 3, bee: 2, fire: 2, wood: 4, apple: 3 }, reward: '🌻🌻🌻🌻' },
+    // Runde 9: Krabs Muschelhandel — Wirtschafts-Quests
+    { npc: 'krabs', title: 'Muschelbank', desc: 'Eine BANK! Für Muscheln! Darwin sagt: Sparsamkeit ist der erste Schritt zur WELTHERRSCHAFT! Äh... zum Wohlstand!', needs: { stone: 6, door: 2, metal: 4, lamp: 2 }, reward: '💰💰💰💰💰' },
+    { npc: 'krabs', title: 'Strand-Börse', desc: 'Angebot! Nachfrage! GEWINN! Eine Börse am Strand! Jede Muschel eine Aktie! Jeden Tag mehr WERT! Ahahaha!', needs: { sand: 6, wood: 4, flag: 3, fence: 4 }, reward: '💰💰💰💰' },
 ];

--- a/recipes.js
+++ b/recipes.js
@@ -79,6 +79,8 @@ window.INSEL_CRAFTING_RECIPES = [
     { name: 'Krone',       result: 'crown',     resultCount: 1, ingredients: { metal: 1, diamond: 1 }, desc: 'Metall + Diamant = Krone' },
     { name: 'Schlüssel',   result: 'key',       resultCount: 1, ingredients: { metal: 1, fire: 1 },    desc: 'Metall + Feuer = Schlüssel' },
     { name: 'Schatz',      result: 'treasure',  resultCount: 1, ingredients: { key: 1, earth: 2 },     desc: 'Schlüssel + 2 Erde = Schatz' },
+    // === HANDEL (Mr. Krabs — Muschelwährung) ===
+    { name: 'Muschel',     result: 'shell',  resultCount: 2, ingredients: { sand: 2, water: 1 },  desc: '2 Sand + Wasser = 2 Muscheln (Strandgut!)' },
     // === ABSURD (💩🚀👻👽🤖) ===
     { name: 'Geist',       result: 'ghost',     resultCount: 1, ingredients: { cloud: 1, moon: 1 },    desc: 'Wolke + Mond = Geist' },
     { name: 'Skelett',     result: 'skull',     resultCount: 1, ingredients: { stone: 2, lightning: 1 },desc: '2 Stein + Blitz = Skelett' },


### PR DESCRIPTION
## Summary
- Neue Währung: Muscheln (🐚) — 30% Chance beim Sand/Wasser-Ernten oder craftbar (2 Sand + Wasser)
- Krabs-Kontor: Klick auf Mr. Krabs ohne offene Quest → Shop-Modal mit Kauf/Verkauf
- Preisliste basierend auf Wu-Xing-Tier (Holz billig, Diamant teuer)
- 2 neue Krabs-Quests: Muschelbank und Strand-Börse

Mr. Krabs: "Darwin sagt: Handel ist EVOLUTION!"

## Test plan
- [ ] Sand/Wasser ernten → manchmal Muschel-Bonus
- [ ] Muscheln craften (2 Sand + Wasser = 2 Muscheln)
- [ ] Alle Krabs-Quests abschließen → dann Krabs anklicken → Shop öffnet
- [ ] Material kaufen (Muscheln bezahlen)
- [ ] Material verkaufen (Muscheln erhalten)
- [ ] Shop-Modal schließen per Klick außerhalb

https://claude.ai/code/session_01FAhc9bc3prZrsTah4g2pqf