### PR TITLE
feat: Conway→Gameplay Integration — Blumen, Steine, Wolken

### DIFF
--- a/conway.js
+++ b/conway.js
@@ -39,6 +39,136 @@
         return pool[Math.floor(Math.random() * pool.length)];
     }
 
+    // ============================================================
+    // === GAMEPLAY-INTEGRATION: Muster-Erkennung & Events ========
+    // ============================================================
+
+    // Generationszähler pro Zelle — für "3+ Generationen stabil"
+    let cellStableCount = null; // 2D-Array: wie viele Generationen war diese Zelle durchgehend lebendig
+
+    // Glider-Tracking: Zellen die sich bewegt haben
+    let prevCells = null; // Set von "r,c"-Strings der lebendigen Zellen aus dem letzten Schritt
+    let gliderCooldown = 0;  // Schritte bis nächster Glider-Event erlaubt
+    let bloomCooldown  = 0;  // Schritte bis nächster Bloom-Event erlaubt
+    let stoneCooldown  = 0;  // Schritte bis nächster Stone-Event erlaubt
+
+    function initGameplayTracking(ROWS, COLS) {
+        cellStableCount = Array.from({ length: ROWS }, () => Array(COLS).fill(0));
+        prevCells = new Set();
+        gliderCooldown = 0;
+        bloomCooldown  = 0;
+        stoneCooldown  = 0;
+    }
+
+    // Prüft ob eine 2x2-Region komplett lebendig ist (Still Life Block)
+    function findStillLifeBlocks(overlay, ROWS, COLS) {
+        const blocks = [];
+        for (let r = 0; r < ROWS - 1; r++)
+            for (let c = 0; c < COLS - 1; c++)
+                if (overlay[r][c] && overlay[r+1][c] && overlay[r][c+1] && overlay[r+1][c+1])
+                    blocks.push({ r, c });
+        return blocks;
+    }
+
+    // Gameplay-Analyse nach jedem Step — gibt Events auf dem Bus aus
+    function analyzeGameplay(overlay, nextOverlay, ROWS, COLS) {
+        if (!cellStableCount || !bus) return;
+        const grid = window.grid;
+        if (!grid) return;
+
+        // Cooldowns herunterzählen
+        if (gliderCooldown > 0) gliderCooldown--;
+        if (bloomCooldown  > 0) bloomCooldown--;
+        if (stoneCooldown  > 0) stoneCooldown--;
+
+        const nextCells = new Set();
+        for (let r = 0; r < ROWS; r++)
+            for (let c = 0; c < COLS; c++)
+                if (nextOverlay[r][c]) nextCells.add(r + ',' + c);
+
+        // --- Stabile Zellen: waren UND bleiben lebendig ---
+        for (let r = 0; r < ROWS; r++) {
+            for (let c = 0; c < COLS; c++) {
+                if (overlay[r][c] && nextOverlay[r][c]) {
+                    cellStableCount[r][c]++;
+                } else {
+                    cellStableCount[r][c] = 0;
+                }
+            }
+        }
+
+        // --- BLOOM: Zelle seit 3+ Generationen stabil → Blume wächst auf leerer Nachbarzelle ---
+        if (bloomCooldown === 0) {
+            const bloomCandidates = [];
+            for (let r = 2; r < ROWS - 2; r++) {
+                for (let c = 2; c < COLS - 2; c++) {
+                    if (cellStableCount[r][c] >= 3 && grid[r][c] === null) {
+                        const neighbors = [[-1,0],[1,0],[0,-1],[0,1],[-1,-1],[-1,1],[1,-1],[1,1]];
+                        for (const [dr, dc] of neighbors) {
+                            const nr = r + dr, nc = c + dc;
+                            if (nr >= 2 && nr < ROWS-2 && nc >= 2 && nc < COLS-2 && grid[nr][nc] === null && !nextOverlay[nr]?.[nc]) {
+                                bloomCandidates.push({ r: nr, c: nc });
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            if (bloomCandidates.length > 0) {
+                const pick = bloomCandidates[Math.floor(Math.random() * bloomCandidates.length)];
+                bus.emit('conway:bloom', { r: pick.r, c: pick.c });
+                bloomCooldown = 8; // 8 Schritte Pause (~5s)
+            }
+        }
+
+        // --- STILL LIFE: 2x2-Block stabil (alle 4 Zellen ≥2 Generationen) → Stein ---
+        if (stoneCooldown === 0) {
+            const blocks = findStillLifeBlocks(nextOverlay, ROWS, COLS);
+            const stableBlocks = blocks.filter(({ r, c }) =>
+                cellStableCount[r][c] >= 2 && cellStableCount[r+1][c] >= 2 &&
+                cellStableCount[r][c+1] >= 2 && cellStableCount[r+1][c+1] >= 2
+            );
+            if (stableBlocks.length > 0) {
+                const blk = stableBlocks[Math.floor(Math.random() * stableBlocks.length)];
+                const candidates = [];
+                for (let dr = -1; dr <= 2; dr++)
+                    for (let dc = -1; dc <= 2; dc++) {
+                        if (dr >= 0 && dr <= 1 && dc >= 0 && dc <= 1) continue; // Block selbst überspringen
+                        const nr = blk.r + dr, nc = blk.c + dc;
+                        if (nr >= 2 && nr < ROWS-2 && nc >= 2 && nc < COLS-2 && grid[nr][nc] === null)
+                            candidates.push({ r: nr, c: nc });
+                    }
+                if (candidates.length > 0) {
+                    const pick = candidates[Math.floor(Math.random() * candidates.length)];
+                    bus.emit('conway:stone', { r: pick.r, c: pick.c, blockR: blk.r, blockC: blk.c });
+                    stoneCooldown = 12; // ~8s Pause
+                }
+            }
+        }
+
+        // --- GLIDER: Zellen bewegen sich (hohe Mobilität, stabile Population) → Wolke ---
+        if (gliderCooldown === 0 && prevCells.size > 0) {
+            const departed = [...prevCells].filter(k => !nextCells.has(k)).length;
+            const arrived  = [...nextCells].filter(k => !prevCells.has(k)).length;
+            const total    = Math.max(prevCells.size, nextCells.size) || 1;
+            const mobility = (departed + arrived) / 2 / total;
+            // Glider-Heuristik: >35% der Zellen bewegt, Population stabil (±20%)
+            const popRatio = nextCells.size / (prevCells.size || 1);
+            if (mobility > 0.35 && popRatio > 0.8 && popRatio < 1.25 && nextCells.size >= 3) {
+                const movers = [...nextCells].filter(k => !prevCells.has(k));
+                if (movers.length >= 2) {
+                    const positions = movers.map(k => { const [r,c] = k.split(',').map(Number); return {r,c}; });
+                    const avgR = Math.round(positions.reduce((s,p) => s+p.r, 0) / positions.length);
+                    const avgC = Math.round(positions.reduce((s,p) => s+p.c, 0) / positions.length);
+                    bus.emit('conway:glider', { r: avgR, c: avgC, size: nextCells.size });
+                    gliderCooldown = 6; // ~4s Pause
+                }
+            }
+        }
+
+        prevCells = nextCells;
+    }
+
     function startConway() {
         const { ROWS, COLS } = dims();
         const grid = window.grid;
@@ -49,6 +179,7 @@
             for (let c = 0; c < COLS; c++)
                 if (grid[r][c] === null && Math.random() < 0.18)
                     conwayOverlay[r][c] = conwayCreature(r, c);
+        initGameplayTracking(ROWS, COLS);
         conwayInterval = setInterval(conwayStep, 650);
         bus && bus.emit('idle:start');
     }
@@ -76,6 +207,7 @@
                 }
             }
         }
+        analyzeGameplay(conwayOverlay, next, ROWS, COLS);
         conwayOverlay = next;
         redraw();
     }
@@ -105,6 +237,11 @@
         conwayInterval = null;
         conwayOverlay = null;
         conwayFading = false;
+        cellStableCount = null;
+        prevCells = null;
+        gliderCooldown = 0;
+        bloomCooldown  = 0;
+        stoneCooldown  = 0;
         redraw();
     }
 
@@ -121,6 +258,84 @@
         if (!conwayInterval && !conwayFading && idle > CONWAY_IDLE_MS) startConway();
         if (idle > AMBIENT_IDLE_MS && window.INSEL_SOUND) window.INSEL_SOUND.playAmbient();
     }, 5000);
+
+    // ============================================================
+    // === GAMEPLAY-EVENT-HANDLER ==================================
+    // ============================================================
+
+    // conway:bloom — stabile Zelle → Blume wächst auf leerer Nachbarzelle
+    bus && bus.on('conway:bloom', ({ r, c }) => {
+        if (!conwayOverlay) return; // nur während Screensaver aktiv
+        const grid = window.grid;
+        if (!grid || grid[r]?.[c] !== null) return;
+        grid[r][c] = 'flower';
+        window.grid = grid;
+        redraw();
+        // Blume verwelkt nach 20-30s wieder (temporärer Screensaver-Effekt)
+        setTimeout(() => {
+            if (!conwayOverlay) return; // Screensaver weg → nicht anfassen
+            if (grid[r]?.[c] === 'flower') {
+                grid[r][c] = null;
+                window.grid = grid;
+                redraw();
+            }
+        }, 20000 + Math.random() * 10000);
+    });
+
+    // conway:stone — Still-Life-Block → Stein-Formation
+    bus && bus.on('conway:stone', ({ r, c }) => {
+        if (!conwayOverlay) return;
+        const grid = window.grid;
+        if (!grid || grid[r]?.[c] !== null) return;
+        grid[r][c] = 'stone';
+        window.grid = grid;
+        redraw();
+        // Stein löst sich nach 40-60s auf
+        setTimeout(() => {
+            if (!conwayOverlay) return;
+            if (grid[r]?.[c] === 'stone') {
+                grid[r][c] = null;
+                window.grid = grid;
+                redraw();
+            }
+        }, 40000 + Math.random() * 20000);
+    });
+
+    // conway:glider — sich bewegende Muster → temporäre Wolken-Animation
+    bus && bus.on('conway:glider', ({ r, c }) => {
+        if (!conwayOverlay) return;
+        const grid = window.grid;
+        const { ROWS, COLS } = dims();
+        if (!grid) return;
+        // Wolke auf Glider-Position + 1-2 Nachbarn für ~8s
+        const positions = [[r, c]];
+        const neighbors = [[-1,0],[1,0],[0,-1],[0,1]];
+        for (const [dr, dc] of neighbors) {
+            const nr = r + dr, nc = c + dc;
+            if (nr >= 2 && nr < ROWS-2 && nc >= 2 && nc < COLS-2 && grid[nr][nc] === null)
+                positions.push([nr, nc]);
+            if (positions.length >= 3) break;
+        }
+        const placed = [];
+        for (const [cr, cc] of positions) {
+            if (grid[cr]?.[cc] === null) {
+                grid[cr][cc] = 'cloud';
+                placed.push([cr, cc]);
+            }
+        }
+        if (placed.length > 0) {
+            window.grid = grid;
+            redraw();
+            setTimeout(() => {
+                if (!conwayOverlay) return;
+                for (const [cr, cc] of placed) {
+                    if (grid[cr]?.[cc] === 'cloud') grid[cr][cc] = null;
+                }
+                window.grid = grid;
+                redraw();
+            }, 7000 + Math.random() * 3000);
+        }
+    });
 
     // Overlay-Zugriff für game.js draw-Loop
     function getOverlay() { return conwayOverlay; }


### PR DESCRIPTION
## Was wurde gebaut

Conway Game of Life Screensaver wird jetzt gameplay-relevant: Muster in der Simulation erzeugen echte Blöcke auf dem Grid.

## Drei neue Effekte

- **conway:bloom** — Zellen die 3+ Generationen stabil leben, lassen eine Blume auf einer benachbarten leeren Grid-Zelle wachsen. Verwelkt nach 20-30s.
- **conway:stone** — Stabile 2x2-Blöcke (Still Life) triggern eine Stein-Formation neben dem Block. Löst sich nach 40-60s auf.
- **conway:glider** — Sich bewegende Muster (>35% Mobilität, stabile Population) erzeugen 1-3 temporäre Wolken an der Bewegungsposition. Verschwinden nach 7-10s.

## Implementierung

Alle Effekte passieren nur solange `conwayOverlay !== null` (Screensaver aktiv). Events laufen über `window.INSEL_BUS`. Cooldowns verhindern Spam (bloom: 8 Steps, stone: 12 Steps, glider: 6 Steps).

## Testplan

- [ ] Spiel 30s nicht bedienen — Screensaver startet
- [ ] Nach 2-3 Minuten: Blumen erscheinen kurz auf dem Grid
- [ ] Stabile 2x2-Muster im Overlay — Stein erscheint daneben
- [ ] Grid berühren — Screensaver faded, temporäre Blöcke räumen sich zeitgesteuert auf

🤖 Generated with [Claude Code](https://claude.com/claude-code)