### PR TITLE
fix: Service Worker Cache-Invalidation

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,7 @@
 // Service Worker for Schatzinsel — offline play support
-const CACHE_NAME = 'schatzinsel-v1';
+// Stale-While-Revalidate: zeigt Cache sofort, lädt im Hintergrund neu
+const CACHE_VERSION = 2;
+const CACHE_NAME = `schatzinsel-v${CACHE_VERSION}`;
 
 const STATIC_ASSETS = [
     '/',
@@ -7,6 +9,11 @@ const STATIC_ASSETS = [
     '/style.css',
     '/game.js',
     '/chat.js',
+    '/bus.js',
+    '/conway.js',
+    '/tts.js',
+    '/save.js',
+    '/npc-craft.js',
     '/materials.js',
     '/achievements.js',
     '/quests.js',
@@ -14,6 +21,14 @@ const STATIC_ASSETS = [
     '/automerge.js',
     '/screensaver.js',
     '/sound.js',
+    '/effects.js',
+    '/nature.js',
+    '/stories.js',
+    '/voice.js',
+    '/marketplace.js',
+    '/blueprints.js',
+    '/analytics.js',
+    '/qr.js',
     '/healthcheck.js',
     '/eliza.js',
     '/eliza-scripts.js',
@@ -22,13 +37,13 @@ const STATIC_ASSETS = [
 ];
 
 // External API hosts — these get network-first strategy
-const API_HOSTS = ['requesty', 'anthropic', 'open-meteo', 'workers.dev', 'googleapis.com'];
+const API_HOSTS = ['requesty', 'anthropic', 'open-meteo', 'workers.dev', 'googleapis.com', 'mmxplorer', 'xchscan'];
 
 function isApiRequest(url) {
     return API_HOSTS.some(host => url.hostname.includes(host));
 }
 
-// Install: pre-cache static assets
+// Install: pre-cache static assets, activate immediately
 self.addEventListener('install', event => {
     event.waitUntil(
         caches.open(CACHE_NAME)
@@ -37,7 +52,7 @@ self.addEventListener('install', event => {
     );
 });
 
-// Activate: clean up old caches
+// Activate: clean up ALL old caches, claim clients
 self.addEventListener('activate', event => {
     event.waitUntil(
         caches.keys()
@@ -49,7 +64,7 @@ self.addEventListener('activate', event => {
     );
 });
 
-// Fetch: cache-first for static, network-first for API
+// Fetch: network-first for API, stale-while-revalidate for static
 self.addEventListener('fetch', event => {
     const url = new URL(event.request.url);
 
@@ -62,16 +77,21 @@ self.addEventListener('fetch', event => {
         return;
     }
 
-    // Cache-first for static assets
+    // Stale-While-Revalidate for static assets
+    // 1. Sofort aus Cache antworten (schnell)
+    // 2. Im Hintergrund vom Netzwerk laden und Cache updaten
+    // 3. Beim nächsten Laden ist die neue Version da
     event.respondWith(
-        caches.match(event.request)
-            .then(cached => cached || fetch(event.request).then(response => {
-                // Cache successful GET responses
-                if (response.ok && event.request.method === 'GET') {
-                    const clone = response.clone();
-                    caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
-                }
-                return response;
-            }))
+        caches.open(CACHE_NAME).then(cache =>
+            cache.match(event.request).then(cached => {
+                const fetched = fetch(event.request).then(response => {
+                    if (response.ok && event.request.method === 'GET') {
+                        cache.put(event.request, response.clone());
+                    }
+                    return response;
+                });
+                return cached || fetched;
+            })
+        )
     );
 });


### PR DESCRIPTION
## Summary
- Cache-First → Stale-While-Revalidate (sofort antworten, im Hintergrund updaten)
- CACHE_VERSION hochzählbar statt hardcoded v1
- 13 fehlende Dateien in STATIC_ASSETS
- Crypto API Hosts ergänzt

## Test plan
- [ ] Seite laden → offline gehen → Seite funktioniert
- [ ] Feature deployen → Seite neu laden → neuer Code da (nicht erst nach SW-Tod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)