### PR TITLE
feat: Wu-Xing NPC-Events (#95)

### DIFF
--- a/game.js
+++ b/game.js
@@ -2468,6 +2468,12 @@
                 }
                 if (!undoPushedThisStroke) { pushUndo(); undoPushedThisStroke = true; }
                 grid[r][c] = currentMaterial;
+                // Wu-Xing Element-Events auf den Bus
+                if (window.INSEL_BUS) {
+                    var wu = { fire: 'fire', water: 'water', wood: 'wood', metal: 'metal', earth: 'earth' };
+                    if (wu[currentMaterial]) window.INSEL_BUS.emit('element:' + currentMaterial, { r: r, c: c, material: currentMaterial });
+                    window.INSEL_BUS.emit('block:placed', { r: r, c: c, material: currentMaterial });
+                }
                 checkAutomerge(r, c);
                 checkBlueprintMatch(r, c);
                 const hint = document.getElementById('genesis-hint');
@@ -2492,7 +2498,10 @@
                             const [fr, fc] = empty.splice(idx, 1)[0];
                             grid[fr][fc] = Math.random() < 0.5 ? 'flower' : 'plant';
                         }
-                        if (count > 0) requestRedraw();
+                        if (count > 0) {
+                            requestRedraw();
+                            if (window.INSEL_BUS) window.INSEL_BUS.emit('consequence:flowers', { r: r, c: c, count: count });
+                        }
                     }, 10000);
                 }
                 // Konsequenz: Feuer neben Holz → Holz verbrennt nach 3s
@@ -2502,7 +2511,10 @@
                         const nr = r+dr, nc = c+dc;
                         if (nr >= 0 && nr < ROWS && nc >= 0 && nc < COLS && grid[nr]?.[nc] === 'wood') {
                             setTimeout(() => {
-                                if (grid[nr][nc] === 'wood' && grid[r]?.[c] === 'fire') { grid[nr][nc] = 'ash'; requestRedraw(); }
+                                if (grid[nr][nc] === 'wood' && grid[r]?.[c] === 'fire') {
+                                    grid[nr][nc] = 'ash'; requestRedraw();
+                                    if (window.INSEL_BUS) window.INSEL_BUS.emit('consequence:ash', { r: nr, c: nc });
+                                }
                             }, 3000);
                         }
                     });
@@ -2726,6 +2738,7 @@
         showToast(merge.msg);
         soundCraft();
         unlockMaterial(merge.result);
+        if (window.INSEL_BUS) window.INSEL_BUS.emit('merge:result', { result: merge.result, from: fromMats, type: merge.type });
         if (typeof updateGenesisVisibility === 'function') updateGenesisVisibility();
         requestRedraw();
 

--- a/index.html
+++ b/index.html
@@ -443,6 +443,7 @@
     </div>
 
     <script src="bus.js"></script>
+    <script src="npc-events.js"></script>
     <script src="qr.js"></script>
     <script src="insel.js"></script>
     <script src="storage.js"></script>

--- a/nature.js
+++ b/nature.js
@@ -138,6 +138,7 @@
         if (changed) {
             callbacks.updateStats();
             callbacks.showToast('🌺 Brunnen-Magie! Blumen wachsen...');
+            if (window.INSEL_BUS) window.INSEL_BUS.emit('consequence:flowers', { count: -1 });
         }
     }
 

--- a/npc-events.js
+++ b/npc-events.js
@@ -1,0 +1,108 @@
+// === NPC-EVENTS — NPCs reagieren auf Wu-Xing Element-Events ===
+// Lauscht auf INSEL_BUS Events und zeigt kontextbezogene NPC-Reaktionen als Toast.
+// 30% Chance pro Event, max 1 Reaktion alle 15 Sekunden.
+
+(function() {
+    'use strict';
+
+    var COOLDOWN_MS = 15000;
+    var TRIGGER_CHANCE = 0.3;
+
+    /** @type {number} */
+    var lastReactionTime = 0;
+
+    /**
+     * NPC-Reaktions-Tabelle: Event → Array von {npc, emoji, text}
+     * @type {Record<string, Array<{npc: string, emoji: string, text: string}>>}
+     */
+    var REACTIONS = {
+        'consequence:ash': [
+            { npc: 'spongebob', emoji: '🧽', text: 'Hey, mein Grill! 🔥' },
+            { npc: 'krabs', emoji: '🦀', text: 'Mein Holz! Das war teuer! 💸' },
+        ],
+        'consequence:flowers': [
+            { npc: 'maus', emoji: '🐭', text: 'Schön hier! 🌺' },
+            { npc: 'elefant', emoji: '🐘', text: 'Blumen! Die riechen gut! 🌸' },
+            { npc: 'neinhorn', emoji: '🦄', text: 'NEIN! ...ok, die sind hübsch. 🌼' },
+        ],
+        'element:water': [
+            { npc: 'elefant', emoji: '🐘', text: 'Brauche ich! 💦' },
+            { npc: 'spongebob', emoji: '🧽', text: 'Wasser! Ich saug das auf! 💧' },
+        ],
+        'element:fire': [
+            { npc: 'spongebob', emoji: '🧽', text: 'Feuer! Wo ist mein Eimer? 🪣' },
+            { npc: 'mephisto', emoji: '😈', text: 'Ah, Feuer... mein Element. 🔥' },
+        ],
+        'element:metal': [
+            { npc: 'krabs', emoji: '🦀', text: 'Metall! Das ist was wert! 💰' },
+            { npc: 'tommy', emoji: '🦞', text: 'Glänzend! Kann man verkaufen? 🪙' },
+        ],
+        'element:wood': [
+            { npc: 'spongebob', emoji: '🧽', text: 'Holz! Kann man drauf wohnen! 🏠' },
+            { npc: 'maus', emoji: '🐭', text: 'Davon bau ich mir ein Nest! 🪹' },
+        ],
+        'element:earth': [
+            { npc: 'elefant', emoji: '🐘', text: 'Erde! Gut für die Füße! 🐾' },
+            { npc: 'maus', emoji: '🐭', text: 'Da kann man buddeln! 🕳️' },
+        ],
+        'merge:result': [
+            { npc: 'mephisto', emoji: '😈', text: 'Interessant... was hast du da gemacht? 🧪' },
+            { npc: 'neinhorn', emoji: '🦄', text: 'NEIN! ...ok, das war cool. ✨' },
+        ],
+        'craft:success': [
+            { npc: 'mephisto', emoji: '😈', text: 'Interessant... 🧪' },
+            { npc: 'krabs', emoji: '🦀', text: 'Kann man das verkaufen? 💰' },
+            { npc: 'tommy', emoji: '🦞', text: 'Nicht schlecht! Klick-klack! 🦞' },
+        ],
+    };
+
+    /**
+     * Prüft Cooldown und Chance, zeigt ggf. NPC-Toast
+     * @param {string} eventName
+     * @param {Object} [data]
+     */
+    function maybeReact(eventName, data) {
+        var now = Date.now();
+        if (now - lastReactionTime < COOLDOWN_MS) return;
+        if (Math.random() > TRIGGER_CHANCE) return;
+
+        var pool = REACTIONS[eventName];
+        if (!pool || pool.length === 0) return;
+
+        var pick = pool[Math.floor(Math.random() * pool.length)];
+        lastReactionTime = now;
+
+        if (typeof window.showToast === 'function') {
+            window.showToast(pick.emoji + ' ' + pick.npc.charAt(0).toUpperCase() + pick.npc.slice(1) + ': ' + pick.text, 3500);
+        }
+    }
+
+    /**
+     * Bus-Listener registrieren
+     */
+    function init() {
+        var bus = window.INSEL_BUS;
+        if (!bus) return;
+
+        var events = Object.keys(REACTIONS);
+        for (var i = 0; i < events.length; i++) {
+            (function(evt) {
+                bus.on(evt, function(data) { maybeReact(evt, data); });
+            })(events[i]);
+        }
+    }
+
+    // Init wenn DOM ready
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+    // Public API (für Tests / Debugging)
+    window.INSEL_NPC_EVENTS = {
+        REACTIONS: REACTIONS,
+        COOLDOWN_MS: COOLDOWN_MS,
+        TRIGGER_CHANCE: TRIGGER_CHANCE,
+    };
+})();


### PR DESCRIPTION
## Summary
- NPCs reagieren kontextbezogen auf Element-Events via INSEL_BUS
- Bus-Events emittiert bei: Block-Platzierung (`element:*`), Feuer→Asche (`consequence:ash`), Brunnen→Blumen (`consequence:flowers`), Automerge (`merge:result`)
- `npc-events.js`: 30% Trigger-Chance, 15s Cooldown, vordefinierte NPC-Texte pro Event-Typ

## Test plan
- [ ] Feuer platzieren → gelegentlich SpongeBob/Mephisto-Kommentar
- [ ] Wasser platzieren → gelegentlich Elefant-Kommentar
- [ ] Feuer neben Holz → Asche-Konsequenz → SpongeBob/Krabs-Reaktion
- [ ] Brunnen → Blumen → Maus/Elefant/NEINhorn-Reaktion
- [ ] Crafting → Mephisto/Krabs/Tommy-Kommentar
- [ ] Cooldown: max 1 NPC-Toast alle 15s
- [ ] `node --check` + `tsc --noEmit` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)