### PR TITLE
feat: Eltern-Dashboard — Chat-Nutzung + Materialien (#17)

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -1018,6 +1018,13 @@ ${budgetInfo}`;
         input.value = '';
         addMessage(text, 'user');
 
+        // Chat-Nutzung pro NPC tracken (Dashboard #17)
+        try {
+            const chatStats = JSON.parse(localStorage.getItem('insel-chat-stats') || '{}');
+            chatStats[currentNpcId] = (chatStats[currentNpcId] || 0) + 1;
+            localStorage.setItem('insel-chat-stats', JSON.stringify(chatStats));
+        } catch (_) { /* localStorage voll — kein Drama */ }
+
         // Quest-Annahme erkennen
         const lower = text.toLowerCase();
         if (lower.match(/^(ja|ok|klar|mach ich|los|gerne|auf geht|let.?s go)/)) {

--- a/game.js
+++ b/game.js
@@ -4780,9 +4780,47 @@
         set('dash-fav-material', favLabel);
         set('dash-baustil', baustil);
         set('dash-engagement', engagement + ' / 100');
+        set('dash-materials', Object.keys(matUsage).length > 0 ? Object.keys(matUsage).length.toString() : '—');
 
         const fill = document.getElementById('dash-engagement-fill');
         if (fill) fill.style.width = engagement + '%';
+
+        // Chat-Nutzung pro NPC
+        const chatStatsEl = document.getElementById('dash-chat-stats');
+        if (chatStatsEl) {
+            const chatStats = JSON.parse(localStorage.getItem('insel-chat-stats') || '{}');
+            const chatEntries = Object.entries(chatStats).sort((a, b) => b[1] - a[1]);
+            chatStatsEl.textContent = '';
+            if (chatEntries.length === 0) {
+                var emptyP = document.createElement('p');
+                emptyP.className = 'dashboard-empty';
+                emptyP.textContent = 'Noch keine Chat-Nachrichten gesendet.';
+                chatStatsEl.appendChild(emptyP);
+            } else {
+                var chars = window.INSEL_CHARACTERS || {};
+                chatEntries.forEach(function (entry) {
+                    var npcId = entry[0], count = entry[1];
+                    var npcVoice = NPC_VOICES[npcId];
+                    var charInfo = chars[npcId];
+                    var emoji = (npcVoice && npcVoice.emoji) || (charInfo && charInfo.emoji) || '';
+                    var name = (charInfo && charInfo.name) || (npcVoice && npcVoice.prefix.replace(':', '')) || npcId;
+
+                    var row = document.createElement('div');
+                    row.className = 'dashboard-session-row';
+                    var nameSpan = document.createElement('span');
+                    nameSpan.className = 'dashboard-session-date';
+                    nameSpan.textContent = emoji + ' ' + name;
+                    var metaSpan = document.createElement('span');
+                    metaSpan.className = 'dashboard-session-meta';
+                    var countSpan = document.createElement('span');
+                    countSpan.textContent = count + ' Nachrichten';
+                    metaSpan.appendChild(countSpan);
+                    row.appendChild(nameSpan);
+                    row.appendChild(metaSpan);
+                    chatStatsEl.appendChild(row);
+                });
+            }
+        }
 
         // Session-Verlauf
         const listEl = document.getElementById('dash-sessions-list');

--- a/index.html
+++ b/index.html
@@ -397,6 +397,10 @@
                     <div class="dashboard-card-label">Baustil</div>
                     <div class="dashboard-card-value" id="dash-baustil">&#x2014;</div>
                 </div>
+                <div class="dashboard-card">
+                    <div class="dashboard-card-label">Materialien entdeckt</div>
+                    <div class="dashboard-card-value" id="dash-materials">&#x2014;</div>
+                </div>
                 <div class="dashboard-card dashboard-card-wide">
                     <div class="dashboard-card-label">Engagement-Score</div>
                     <div class="dashboard-engagement">
@@ -411,6 +415,12 @@
                 <h3 class="dashboard-section-title">Letzte 5 Sessions</h3>
                 <div id="dash-sessions-list" class="dashboard-sessions-list">
                     <p class="dashboard-empty">Noch keine Session-Daten gespeichert.</p>
+                </div>
+            </div>
+            <div class="dashboard-sessions-section">
+                <h3 class="dashboard-section-title">Chat-Nutzung</h3>
+                <div id="dash-chat-stats" class="dashboard-sessions-list">
+                    <p class="dashboard-empty">Noch keine Chat-Nachrichten gesendet.</p>
                 </div>
             </div>
             <div class="dashboard-footer">


### PR DESCRIPTION
## Summary
- **Chat-Tracking pro NPC**: Jede gesendete Nachricht wird in `localStorage` (`insel-chat-stats`) pro NPC-ID gezaehlt
- **Materialien entdeckt**: Neue Dashboard-Karte zeigt Anzahl verschiedener verwendeter Materialien
- **Chat-Nutzung Sektion**: Neue Sektion im Dashboard listet alle NPCs mit Nachrichtenanzahl (absteigend sortiert)

Daten kommen ausschliesslich aus localStorage — kein Server-Call.

## Geaenderte Dateien
- `chat.js` — Tracking-Counter bei `sendMessage()`
- `game.js` — `openDashboard()` befuellt neue Felder (DOM-API, kein innerHTML)
- `index.html` — Neue Karte "Materialien entdeckt" + Chat-Nutzung Sektion

## Test plan
- [ ] Dashboard oeffnen (Bernd anklicken oder Toolbar-Button)
- [ ] Materialien-Karte zeigt Anzahl verschiedener Materialien
- [ ] Chat mit verschiedenen NPCs fuehren, Dashboard erneut oeffnen
- [ ] Chat-Nutzung zeigt NPCs mit korrekter Nachrichtenanzahl
- [ ] `node --check` gruen
- [ ] `tsc --noEmit` gruen

Generated with Claude Code