### PR TITLE
feat: Neutrino-Score für stille Spieler (#65)

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -123,6 +123,9 @@
             demolishes: events.filter(e => e.e === 'demolish').length,
             zauber: events.filter(e => e.e === 'code_zauber').length,
             postcards: events.filter(e => e.e === 'postcard').length,
+            // Neutrino-Metrik: Crafting- und Chat-Events zählen
+            crafts_count: events.filter(e => e.e === 'craft' || e.e === 'quick-craft' || e.e === 'llm-craft').length,
+            chats_count: events.filter(e => e.e === 'chat' || e.e === 'npc_chat').length,
         };
     }
 
@@ -137,6 +140,14 @@
         // 2. Cloudflare Worker D1 — immer senden
         try {
             var proxy = (window.INSEL_CONFIG && window.INSEL_CONFIG.proxy) || 'https://schatzinsel.hoffmeyer-zlotnik.workers.dev';
+            // Neutrino-Score: 1.0 = nur gebaut/geschaut, 0.5 = wenig Interaktion, 0.0 = viel interagiert
+            var crafts = data.crafts_count || 0;
+            var chats = data.chats_count || 0;
+            var hasChat = data.ms_firstChat ? 1 : 0;
+            var totalChats = chats + hasChat; // Chat-Events + Milestone als Proxy
+            var neutrinoScore = (crafts === 0 && totalChats === 0) ? 1.0
+                : (crafts < 3 && totalChats < 3) ? 0.5
+                : 0.0;
             navigator.sendBeacon(proxy + '/metrics/ingest', JSON.stringify({
                 type: 'session',
                 player_name: localStorage.getItem('insel-spielername') || 'Anonym',
@@ -145,7 +156,7 @@
                 blocks_harvested: data.demolishes || 0,
                 quests_completed: data.quests_done || 0,
                 crafts_total: data.builds || 0,
-                chat_messages: 0,
+                chat_messages: totalChats,
                 unique_materials: data.materials || 0,
                 engagement_score: Math.min(100, Math.round(
                     (data.duration_s > 30 ? 20 : 0) +
@@ -155,6 +166,7 @@
                     (data.easter_eggs > 0 ? 10 : 0) +
                     (data.materials > 3 ? 10 : 0)
                 )),
+                neutrino_score: neutrinoScore,
             }));
         } catch (e) { /* kein Tracking > kaputtes Tracking */ }
     }

--- a/worker.js
+++ b/worker.js
@@ -491,15 +491,24 @@ async function handleMetricsIngest(request, env) {
     const { type } = body;
 
     if (type === 'session') {
+        // neutrino_score: Spalte wird per ALTER TABLE hinzugefügt wenn sie fehlt
+        // SQLite ignoriert doppeltes ALTER TABLE nicht, daher try/catch
+        try {
+            await env.METRICS_DB.prepare(
+                `ALTER TABLE sessions ADD COLUMN neutrino_score REAL DEFAULT NULL`
+            ).run();
+        } catch (e) { /* Spalte existiert bereits — OK */ }
+
         await env.METRICS_DB.prepare(
             `INSERT INTO sessions (player_name, country, duration_s, blocks_placed, blocks_harvested,
-             quests_completed, crafts_total, crafts_llm, chat_messages, unique_materials, engagement_score)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+             quests_completed, crafts_total, crafts_llm, chat_messages, unique_materials, engagement_score, neutrino_score)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
         ).bind(
             body.player_name || 'Anonym', body.country || 'unknown',
             body.duration_s || 0, body.blocks_placed || 0, body.blocks_harvested || 0,
             body.quests_completed || 0, body.crafts_total || 0, body.crafts_llm || 0,
-            body.chat_messages || 0, body.unique_materials || 0, body.engagement_score || 0
+            body.chat_messages || 0, body.unique_materials || 0, body.engagement_score || 0,
+            typeof body.neutrino_score === 'number' ? body.neutrino_score : null
         ).run();
         return json({ ok: true, type: 'session' });
     }


### PR DESCRIPTION
## Summary
- **analytics.js**: Zählt Craft-Events (`craft`, `quick-craft`, `llm-craft`) und Chat-Events. Berechnet `neutrino_score` am Session-Ende: 1.0 (nur gebaut/geschaut), 0.5 (wenig Interaktion), 0.0 (viel interagiert). Sendet den Score mit dem Beacon an `/metrics/ingest`.
- **worker.js**: Nimmt `neutrino_score` als REAL-Spalte in der `sessions`-Tabelle entgegen. ALTER TABLE läuft automatisch beim ersten Request (idempotent per try/catch).

## Test plan
- [ ] `node --check analytics.js` grün
- [ ] `node --check worker.js` grün
- [ ] `tsc --noEmit` grün
- [ ] Session spielen ohne Crafting/Chat → neutrino_score = 1.0 in D1
- [ ] Session mit 1-2 Crafts → neutrino_score = 0.5
- [ ] Session mit 3+ Crafts → neutrino_score = 0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)