### PR TITLE
feat: Postkarte erst nach Tutorial freigeschaltet (#39)

### DIFF
--- a/game.js
+++ b/game.js
@@ -3550,9 +3550,14 @@
     });
 
     // --- Postkarte von Java (Godin: "Ein Share-Moment fehlt") ---
+    // Tutorial-Gating (#39): Postkarte erst nach Tutorial freigeschaltet
     const postcardBtn = document.getElementById('postcard-btn');
     if (postcardBtn) {
         postcardBtn.addEventListener('click', () => {
+            if (window.INSEL_TUTORIAL && !window.INSEL_TUTORIAL.isDone()) {
+                showToast('🏝️ Erst die Insel erkunden! Schließe das Tutorial ab.', 3000);
+                return;
+            }
             const stats = getGridStats();
             const name = projectNameInput.value.trim() || 'Meine Insel';
 

--- a/tutorial.js
+++ b/tutorial.js
@@ -391,6 +391,10 @@
         open: openTutorial,
         close: closeTutorial,
         isActive: function () { return tutorialActive; },
+        isDone: function () {
+            loadProgress();
+            return currentLesson >= LESSONS.length;
+        },
         getLessons: function () { return LESSONS; },
         getProgress: function () { return currentLesson; },
         resetProgress: function () {


### PR DESCRIPTION
## Summary
- Postkarten-Button ist jetzt gegatet: Klick vor Tutorial-Abschluss zeigt Toast "Erst die Insel erkunden!"
- `isDone()` Funktion auf `window.INSEL_TUTORIAL` API hinzugefügt (prüft `insel_tutorial_progress >= LESSONS.length`)
- Eigenmotivation: Kinder schließen Tutorial ab weil die Postkarte wartet, nicht weil sie müssen

## Test plan
- [ ] Tutorial NICHT abschließen → Postkarten-Button klicken → Toast "Erst die Insel erkunden!" erscheint
- [ ] Tutorial komplett abschließen → Postkarten-Button klicken → Postkarte wird heruntergeladen
- [ ] `localStorage.removeItem('insel_tutorial_progress')` → Gate greift wieder

https://claude.ai/code/session_017wyrbauqTxXf1CY9XPUPmY