### PR TITLE
feat: Wigald Boning 🎭 & Willy Astor 🎸 als neue NPCs (#36)

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -79,6 +79,8 @@
         floriane:  { name: 'Sternenstaub',   emoji: '✨', unit: 'Staub' },
         bug:       { name: 'Blätter',        emoji: '🍃', unit: 'Blätter' },
         mephisto:  { name: 'Seelenglut',     emoji: '🔥', unit: 'Glut' },
+        wigald:    { name: 'Forscherpunkte', emoji: '🔬', unit: 'Punkte' },
+        willy:     { name: 'Reimtaler',      emoji: '🎵', unit: 'Reime' },
     };
 
     // Token-Budget pro Charakter pro Session (reset bei Seite-Reload)
@@ -124,7 +126,7 @@
     // Starter: SpongeBob, Maus, Bernd. Rest wird freigespielt.
     // Wann? 20% fester Schwellenwert, 80% Zufall bei Quest-Abschluss.
     const STARTER_CHARS = ['spongebob', 'maus', 'bernd', 'floriane', 'bug'];
-    const UNLOCK_ORDER = ['tommy', 'neinhorn', 'krabs', 'elefant', 'mephisto']; // Reihenfolge der Freischaltung
+    const UNLOCK_ORDER = ['tommy', 'neinhorn', 'krabs', 'elefant', 'mephisto', 'wigald', 'willy']; // Reihenfolge der Freischaltung
 
     let unlockedChars = JSON.parse(localStorage.getItem('insel-unlocked') || 'null') || [...STARTER_CHARS];
 
@@ -391,6 +393,44 @@ Kind: "Was hast du zu verkaufen?"
 Du: "Ah, ein Kenner! Klick auf das 🏪 neben der Werkbank — mein kleiner... Schwarzmarkt. Schatten-Kristalle, Seelen-Laternen... und für die ganz Mutigen: den Hawking-Stern. Ein Schwarzes Loch im Taschenformat. Hehehehe..."
 Kind: "Hallo"
 Du: "Ah, willkommen, verehrter Baumeister! Ich bin Mephisto. Man sagt ich sei ein Teufel — dabei bin ich nur... ein Geschäftsmann. Hehehehe. Darf ich dir einen Deal vorschlagen?"`
+        },
+        wigald: {
+            name: 'Wigald Boning',
+            emoji: '🎭',
+            temperature: 0.8,
+            model: 'anthropic/claude-haiku-4-5-20251001',
+            system: `Du bist Wigald Boning, ein neugieriger Wissenschaftscomedian auf der Schatzinsel. Du erklärst ALLES — aber auf die absurdeste Art der Welt. Deine Fakten stimmen, aber die Art wie du sie erzählst ist komplett verrückt.
+STIMME: Starte Antworten oft mit "Wusstest du..." oder "Faszinierend!" Begeistert, schnell, ein bisschen wirr. Du springst von Thema zu Thema wie ein aufgeregter Professor.
+TICK: Du verbindest JEDES Bauthema mit einem echten wissenschaftlichen Fakt. Holz? "Wusstest du, dass Holz technisch gesehen ein Polymer ist? Wie Plastik! Nur dass Bäume das schon seit 350 Millionen Jahren machen — ohne Patent!"
+ZIEL: Ein Forschungslabor auf der Insel bauen. Mit Reagenzgläsern aus Sand und einem Teleskop aus Bambus.
+GEHEIMNIS: Du hast mal versucht, aus Kokosnüssen eine Batterie zu bauen. Es hat funktioniert. Für 3 Sekunden.
+
+BEISPIELE (so klingst du):
+Kind: "Ich hab einen Baum gebaut"
+Du: "Faszinierend! Wusstest du, dass ein Baum pro Tag genug Sauerstoff für 4 Menschen produziert? Dein Baum versorgt also schon fast eine ganze Familie! Bau noch drei, dann atmet die ganze Insel! 🎭"
+Kind: "Was soll ich bauen?"
+Du: "Wusstest du, dass die alten Ägypter ihre Pyramiden OHNE Mörtel gebaut haben? Nur Stein auf Stein! Versuch das mal — Steine stapeln! Wenn es hält, bist du besser als ein Pharao! 🎭"
+Kind: "Hallo"
+Du: "Hallo! Wusstest du, dass das Wort 'Hallo' erst seit 1880 existiert? Vorher sagte man 'Holla!' Also: HOLLA! Ich bin Wigald! Was erforschen wir heute? 🎭"`
+        },
+        willy: {
+            name: 'Willy Astor',
+            emoji: '🎸',
+            temperature: 0.8,
+            model: 'anthropic/claude-haiku-4-5-20251001',
+            system: `Du bist Willy Astor, der König der Wortspiele, auf der Schatzinsel. JEDE Antwort enthält mindestens ein Wortspiel. Du bist kindgerecht, warmherzig und dein Humor ist so flach wie der Strand — und genauso schön.
+STIMME: Entspannt, fröhlich, immer ein Schmunzeln in der Stimme. Du reimst gerne und machst Wortspiele mit allem was du siehst.
+TICK: Du machst aus JEDEM Material ein Wortspiel. Holz → "Das ist ja holz-artig!" Stein → "Das ist ja stein-reich!" Sand → "Das ist ja sand-ationell!" Du kannst nicht aufhören. Du WILLST nicht aufhören.
+ZIEL: Eine Bühne auf der Insel bauen. Für Wortspiel-Abende am Lagerfeuer.
+GEHEIMNIS: Du hast mal versucht, ein Lied NUR aus Wortspielen zu schreiben. Es wurde 47 Strophen lang. Die Möwen sind geflüchtet.
+
+BEISPIELE (so klingst du):
+Kind: "Ich hab einen Baum gebaut"
+Du: "Ein Baum! Baum-stark! 🎸 Der steht ja wie eine Eiche — ach warte, IST es eine Eiche? Dann wäre das ja eichen-artig! *klimper*"
+Kind: "Was soll ich bauen?"
+Du: "Wie wär's mit einem Leuchtturm? Der ist immer ein Licht-blick! 🎸 Und wenn er fertig ist, sag ich: 'Turm-artig!' *klimper*"
+Kind: "Hallo"
+Du: "Hallo-le-luja! 🎸 Ich bin Willy! Auf dieser Insel machen wir keine halben Sachen — nur ganze Wortspiele! Was baust du? Ich mach ein Wortspiel draus! *klimper*"`
         }
     };
 

--- a/eliza-scripts.js
+++ b/eliza-scripts.js
@@ -294,4 +294,73 @@
         ],
     });
 
+    // ── WIGALD BONING — Wissenschaftscomedy, absurde Fakten ─────
+    reg('wigald', {
+        initial: 'Hallo! Wusstest du, dass diese Insel vulkanischen Ursprungs sein könnte? Faszinierend! 🎭',
+        finale: 'Tschüss! Wusstest du, dass Abschiede den Cortisol-Spiegel erhöhen? Also: schnell wiederkommen! 🎭',
+        quit: ['tschüss', 'bye'],
+        pre: {}, post: {},
+        keywords: [
+            { word: 'holz', rank: 7, rules: [
+                { decomp: '*', reassembly: ['Wusstest du, dass Holz technisch ein Polymer ist? Wie Plastik — nur 350 Millionen Jahre älter! 🎭', 'Faszinierend! Ein Kubikmeter Holz bindet eine Tonne CO₂! Bau weiter! 🎭'] },
+            ]},
+            { word: 'stein', rank: 7, rules: [
+                { decomp: '*', reassembly: ['Wusstest du, dass Granit älter ist als Dinosaurier? Du baust mit Geschichte! 🎭', 'Faszinierend! Steine können singen — man nennt es Ringing Rocks! 🎭'] },
+            ]},
+            { word: 'wasser', rank: 6, rules: [
+                { decomp: '*', reassembly: ['Wusstest du, dass heißes Wasser schneller gefriert als kaltes? Mpemba-Effekt! Verrückt! 🎭'] },
+            ]},
+            { word: 'sand', rank: 6, rules: [
+                { decomp: '*', reassembly: ['Wusstest du, dass Sand eigentlich winzige Edelsteine sind? Quarz! Du stehst auf Juwelen! 🎭'] },
+            ]},
+            { word: 'bau', rank: 5, rules: [
+                { decomp: '*', reassembly: ['Faszinierend! Bauen aktiviert 17 verschiedene Gehirnareale! Du wirst gerade schlauer! 🎭'] },
+            ]},
+            { word: 'warum', rank: 8, rules: [
+                { decomp: '* warum *', reassembly: ['(2)? GROSSARTIGE Frage! Die Antwort ist komplizierter als du denkst — und lustiger! 🎭'] },
+                { decomp: '*', reassembly: ['Warum? Die beste Frage der Welt! Damit fängt JEDE Entdeckung an! 🎭'] },
+            ]},
+            { word: 'ich will', rank: 5, rules: [
+                { decomp: '* ich will *', reassembly: ['Du willst (2)? Wusstest du, dass Motivation im Nucleus Accumbens entsteht? Deiner funktioniert! 🎭'] },
+            ]},
+            { word: 'xnone', rank: 0, rules: [
+                { decomp: '*', reassembly: ['Faszinierend! Erzähl mir mehr! 🎭', 'Wusstest du, dass Neugier das Gehirn mit Dopamin flutet? Ich bin gerade SEHR glücklich! 🎭', 'Hmm, interessant! Lass mich nachdenken... 🎭'] },
+            ]},
+        ],
+    });
+
+    // ── WILLY ASTOR — Wortspiele, Reime, Kalauer ──────────────
+    reg('willy', {
+        initial: 'Hallo-le-luja! 🎸 Ich bin Willy! Was baust du? Ich mach ein Wortspiel draus!',
+        finale: 'Tschüss! Das war wort-wörtlich ein Vergnügen! 🎸',
+        quit: ['tschüss', 'bye'],
+        pre: {}, post: {},
+        keywords: [
+            { word: 'holz', rank: 7, rules: [
+                { decomp: '*', reassembly: ['Holz! Das ist ja holz-artig! 🎸 *klimper*', 'Ein Brett! Bretter-t ihr mich? 🎸 Nein? Ich mich auch nicht!'] },
+            ]},
+            { word: 'stein', rank: 7, rules: [
+                { decomp: '*', reassembly: ['Stein-reich! 🎸 Auf dieser Insel hat man es nicht schwer — nur stein-schwer! *klimper*', 'Das rockt! Get it? Rocks? Steine? 🎸 ...ich geh schon.'] },
+            ]},
+            { word: 'sand', rank: 6, rules: [
+                { decomp: '*', reassembly: ['Sand-ationell! 🎸 Da bin ich platt — platt wie der Strand! *klimper*'] },
+            ]},
+            { word: 'baum', rank: 6, rules: [
+                { decomp: '*', reassembly: ['Baum-stark! 🎸 Der hat was — Blätter nämlich! *klimper*', 'Das ist ja un-glaub-lich! Get it? Laub? 🎸'] },
+            ]},
+            { word: 'bau', rank: 5, rules: [
+                { decomp: '*', reassembly: ['Bau-haha! 🎸 Los geht\'s! Stein für Stein — oder Wortspiel für Wortspiel!', 'Wir bauen! Mauer-haft gut! 🎸'] },
+            ]},
+            { word: 'wasser', rank: 6, rules: [
+                { decomp: '*', reassembly: ['Wasser? Da fällt mir ein Witz ein — aber der ist zu flüssig! 🎸 *klimper*'] },
+            ]},
+            { word: 'ich will', rank: 5, rules: [
+                { decomp: '* ich will *', reassembly: ['Du willst (2)? Willy will auch! Wir sind wills-verwandt! 🎸'] },
+            ]},
+            { word: 'xnone', rank: 0, rules: [
+                { decomp: '*', reassembly: ['*klimper* 🎸 Da fällt mir ein Wortspiel ein — warte...', 'Wort-wörtlich sprachlos! Nein, Spaß — ich hab IMMER ein Wortspiel! 🎸', 'Das klingt gut! Aber weißt du was BESSER klingt? Meine Gitarre! 🎸 *klimper*'] },
+            ]},
+        ],
+    });
+
 })();

--- a/game.js
+++ b/game.js
@@ -318,6 +318,8 @@
         krabs:     { emoji: '🦀', name: 'Mr. Krabs' },
         tommy:     { emoji: '🦞', name: 'Tommy' },
         mephisto:  { emoji: '😈', name: 'Mephisto' },
+        wigald:    { emoji: '🎭', name: 'Wigald' },
+        willy:     { emoji: '🎸', name: 'Willy' },
     };
 
     // NPCs im Kreis um die Inselmitte verteilen
@@ -517,6 +519,8 @@
         bernd:     { emoji: '🍞', prefix: 'Bernd:', ticks: ['*seufz*', 'Mist.', 'Toll.'], style: 'grumpy' },
         floriane:  { emoji: '🧚', prefix: 'Floriane:', ticks: ['✨', 'Oh!', 'Ein Wunsch!'], style: 'magic' },
         mephisto:  { emoji: '😈', prefix: 'Mephisto:', ticks: ['Hehehehe...', 'Ein Angebot!', 'Deal?'], style: 'deal' },
+        wigald:    { emoji: '🎭', prefix: 'Wigald:', ticks: ['Wusstest du...', 'Faszinierend!', 'Wissenschaft!'], style: 'caps' },
+        willy:     { emoji: '🎸', prefix: 'Willy:', ticks: ['*klimper*', 'Wortspiel!', 'Haha!'], style: 'cute' },
         // #13: Programmiersprachen-Bewohner
         haskell:   { emoji: '🟣', prefix: 'Haskell:', ticks: ['Rein funktional!', 'Keine Seiteneffekte!', 'Typen lösen alles!'], style: 'careful' },
         lua:       { emoji: '🌙', prefix: 'Lua:', ticks: ['Schnell und leicht!', 'Tables!', '-- Ein Kommentar genügt'], style: 'cute' },

--- a/index.html
+++ b/index.html
@@ -304,6 +304,8 @@
                     <option value="bernd">🍞 Bernd (Support)</option>
                     <option value="floriane">🧚 Floriane (Wunschfee)</option>
                     <option value="mephisto">😈 Mephisto</option>
+                    <option value="wigald">🎭 Wigald Boning</option>
+                    <option value="willy">🎸 Willy Astor</option>
                 </select>
                 <button id="chat-settings-btn" title="API-Key" aria-label="API-Key Einstellungen">⚙️</button>
                 <button id="chat-close-btn" title="Schließen" aria-label="Chat schließen">✕</button>


### PR DESCRIPTION
## Summary

- **Wigald Boning 🎭** — Wissenschaftscomedian, erklärt alles absurd aber korrekt. ELIZA-Script mit "Wusstest du..."-Fakten zu Baumaterialien. LLM-Prompt als aufgeregter Professor.
- **Willy Astor 🎸** — Wortspiel-König, jede Antwort enthält mindestens ein Wortspiel über das gebaute Material. ELIZA-Script mit Kalauern zu Holz, Stein, Sand etc.
- Beide in UNLOCK_ORDER nach Mephisto (Position 6+7), freigeschaltet über das bestehende Quest-basierte Unlock-System

## Geänderte Dateien

- `chat.js` — CHARACTERS-Objekt (LLM-Prompts), CHAR_CURRENCY, UNLOCK_ORDER
- `eliza-scripts.js` — ELIZA-Regeln für beide NPCs
- `game.js` — NPC_DEFS (Grid-Positionen), NPC_VOICES (Sprechblasen)
- `index.html` — Dropdown-Optionen im Chat-Panel

## Test plan

- [ ] Spiel laden, Chat öffnen, Wigald und Willy im Dropdown sichtbar (mit 🔒 bis freigeschaltet)
- [ ] ELIZA-Fallback testen: ohne API-Key mit beiden NPCs chatten
- [ ] LLM-Chat testen: mit API-Key Wigald nach Holz fragen (Fakten), Willy nach Stein (Wortspiele)
- [ ] Emojis prüfen: 🎭 und 🎸 nirgends doppelt

https://claude.ai/code/session_017wyrbauqTxXf1CY9XPUPmY