### PR TITLE
feat: Schwarzmarkt — Mephisto-Deals + Seelenglut (#99)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -618,6 +618,7 @@ KINDERSICHERHEIT-Block von 40 auf 2 Zeilen. Persönlichkeit stärker UND billige
 ### Erfolge
 | Datum | Was |
 |-------|-----|
+| 2026-04-02 | Schwarzmarkt P2P live: Mephisto-Klick → Shop, Basar (anonym), Seelenglut-Währung, Worker /blackmarket/* Endpoints, DSGVO nur pseudonyme IDs |
 | 2026-03-31 | Mephisto NPC live: 10. Charakter, Deal-Mechanik, Browning-Zitat, Seelenglut-Währung |
 | 2026-03-31 | Gemini Voice Chat: 5 Stimmen, Worker-Abstraktion, kein Vendor-Lock-In |
 | 2026-03-31 | KLONK auf Minecraft-Niveau: 3-Layer Sub-Bass — Oscar hört den Unterschied |

--- a/game.js
+++ b/game.js
@@ -251,6 +251,12 @@
                         showToast(`🎉 Quest geschafft: ${q.title} ${q.reward}`);
                         soundQuestComplete();
                     }
+                    // Mephisto-Quests: Seelenglut als Bonus-Reward
+                    if (q.npc === 'mephisto') {
+                        const glutReward = Math.max(10, blockCount * 5);
+                        addToInventory('soulfire', glutReward);
+                        showToast(`😈 Mephisto: Hehehehe... ${glutReward} 🔥 Seelenglut für dich!`, 3000);
+                    }
                     // Memory: Quest-Abschluss für den NPC vermerken
                     if (q.npc) recordNpcQuestDone(q.npc, q.title);
                     // Hirn-Transplantation: Neuen Charakter freischalten?
@@ -394,6 +400,13 @@
         } else if (npcId === 'krabs') {
             // Krabs: Kein Quest? Dann HANDEL! 🦀💰
             showKrabsShop();
+        } else if (npcId === 'mephisto') {
+            // Mephisto: Kein Quest? Dann SCHWARZMARKT! 😈🔥
+            if (window.INSEL_MARKETPLACE && window.INSEL_MARKETPLACE.openMephisto) {
+                window.INSEL_MARKETPLACE.openMephisto();
+            } else {
+                showToast('😈 Mephisto: Der Schwarzmarkt ist... noch nicht bereit. Hehehehe...', 3000);
+            }
         } else {
             const voice = NPC_VOICES[npcId];
             if (voice) {

--- a/marketplace.js
+++ b/marketplace.js
@@ -1,22 +1,50 @@
-// === INSEL MARKETPLACE — P2P Rare-Item-Handel via MMX/XCH ===
-// Kindertauglich: Kinder sehen Seelenglut, Nerds sehen Crypto.
-// DSGVO: Nur pseudonyme Blockchain-Adressen, kein PII.
-// Deflationäre Arbeitswerttheorie: Tokens → Burn → Arbeit → Hawking-Strahlung.
+// === SCHWARZMARKT — Mephisto's P2P Rare-Item-Handel ===
+// Kindertauglich: Seelenglut 🔥 als In-Game-Währung.
+// DSGVO: Nur pseudonyme IDs (player_id aus localStorage), kein PII.
+// "Ein Reisender bietet..." — keine Spielernamen sichtbar.
 (function () {
     'use strict';
 
     // --- Config ---
     var PROXY = (window.INSEL_CONFIG && window.INSEL_CONFIG.proxy) || 'https://schatzinsel.hoffmeyer-zlotnik.workers.dev';
-    var WALLET_KEY = 'insel-wallet'; // localStorage: { mmx: 'mmx1...', xch: 'xch1...' }
     var PAGE_SIZE = 20;
+    var PLAYER_ID_KEY = 'insel-player-id';
 
-    // --- Wallet (pseudonym, kein Account) ---
-    function getWallet() {
-        try { return JSON.parse(localStorage.getItem(WALLET_KEY) || '{}'); } catch (e) { return {}; }
+    // --- Pseudonyme Spieler-ID (DSGVO: kein Name, kein Account) ---
+    function getPlayerId() {
+        var id = localStorage.getItem(PLAYER_ID_KEY);
+        if (!id) {
+            id = 'p_' + Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+            localStorage.setItem(PLAYER_ID_KEY, id);
+        }
+        return id;
     }
 
-    function setWallet(wallet) {
-        localStorage.setItem(WALLET_KEY, JSON.stringify(wallet));
+    // --- Seelenglut (Inventory-Integration) ---
+    function getSeelenglut() {
+        try {
+            var inv = JSON.parse(localStorage.getItem('insel-inventar') || '{}');
+            return inv.soulfire || 0;
+        } catch (e) { return 0; }
+    }
+
+    function spendSeelenglut(amount) {
+        try {
+            var inv = JSON.parse(localStorage.getItem('insel-inventar') || '{}');
+            if ((inv.soulfire || 0) < amount) return false;
+            inv.soulfire -= amount;
+            if (inv.soulfire <= 0) delete inv.soulfire;
+            localStorage.setItem('insel-inventar', JSON.stringify(inv));
+            return true;
+        } catch (e) { return false; }
+    }
+
+    function earnSeelenglut(amount) {
+        try {
+            var inv = JSON.parse(localStorage.getItem('insel-inventar') || '{}');
+            inv.soulfire = (inv.soulfire || 0) + amount;
+            localStorage.setItem('insel-inventar', JSON.stringify(inv));
+        } catch (e) { /* still */ }
     }
 
     // --- API ---
@@ -32,14 +60,52 @@
         }).then(function (r) { return r.json(); });
     }
 
-    // --- Rare Items: LLM-gecraftete Unikate erkennen ---
-    function isRareItem(materialId) {
-        // LLM-gecraftete Materialien haben keinen Eintrag in MATERIALS
-        var mats = window.INSEL_MATERIALS || {};
-        return materialId && !mats[materialId];
+    // --- Mephisto Kommentare ---
+    var MEPHISTO_COMMENTS = {
+        buy: [
+            'Ein guter Tausch... für mich 😈',
+            'Hehehehe... Deal!',
+            'Du wirst es nicht bereuen. Oder doch. Hehehehe...',
+            'Das Schicksal hat euch zusammengeführt. Und ich.',
+            'Ein Schnäppchen! Für mich jedenfalls...',
+        ],
+        sell: [
+            'Ah, du willst handeln? Ich mag deinen Stil...',
+            'Ein Reisender wird sich freuen. Oder auch nicht.',
+            'Ins Schaufenster damit! Hehehehe...',
+            'Der Basar der Schatten nimmt dein Angebot an.',
+        ],
+        empty: [
+            'Noch leer hier... Aber Geduld ist eine Tugend. Die ich nicht habe.',
+            'Der Markt schläft. Weck ihn auf — biete etwas an!',
+            'Kein Angebot? Dann schaff eins. Hehehehe...',
+        ],
+        greeting: [
+            '😈 Willkommen im Schwarzmarkt, Reisender...',
+            '😈 Ah, du bist zurück. Ich habe auf dich gewartet...',
+            '😈 Der Basar der Schatten ist geöffnet. Was suchst du?',
+        ],
+        broke: [
+            'Kein Seelenglut? Erledige meine Quests. Dann reden wir.',
+            'Arm aber neugierig. Das gefällt mir. Hehehehe...',
+        ],
+    };
+
+    function mephistoSays(category) {
+        var lines = MEPHISTO_COMMENTS[category] || MEPHISTO_COMMENTS.greeting;
+        return lines[Math.floor(Math.random() * lines.length)];
     }
 
-    // --- Marketplace UI ---
+    // --- NPC Rare Shop Items (Mephisto's eigener Laden) ---
+    var MEPHISTO_DEALS = [
+        { id: 'schatten_kristall', name: 'Schatten-Kristall', emoji: '🔮', desc: 'Leuchtet nur bei Nacht. Flüstert Faust-Zitate.', price_glut: 50 },
+        { id: 'seelen_laterne', name: 'Seelen-Laterne', emoji: '🏮', desc: 'Zeigt den Weg den man nicht gehen sollte.', price_glut: 80 },
+        { id: 'mitternachts_rose', name: 'Mitternachts-Rose', emoji: '🥀', desc: 'Blüht nur zwischen 23:00 und 01:00.', price_glut: 120 },
+        { id: 'pakt_siegel', name: 'Pakt-Siegel', emoji: '📜', desc: 'Unterschreibe nicht. Oder doch. Hehehehe...', price_glut: 200 },
+        { id: 'hawking_stern', name: 'Hawking-Stern', emoji: '⭐', desc: 'Strahlt Information. Schwarzes Loch im Taschenformat.', price_glut: 500 },
+    ];
+
+    // --- Schwarzmarkt UI ---
     var marketPanel = null;
     var isOpen = false;
 
@@ -47,28 +113,32 @@
         if (marketPanel) return marketPanel;
 
         var panel = document.createElement('div');
-        panel.id = 'marketplace-panel';
+        panel.id = 'schwarzmarkt-panel';
         panel.style.cssText = 'display:none;position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);' +
-            'width:90vw;max-width:480px;max-height:80vh;background:#1a1a2e;color:#e0e0e0;border:2px solid #FF6B00;' +
-            'border-radius:12px;z-index:10000;overflow-y:auto;font-family:monospace;padding:0;';
+            'width:92vw;max-width:500px;max-height:85vh;background:#0a0a12;color:#e0d0c0;border:2px solid #8B0000;' +
+            'border-radius:12px;z-index:10000;overflow-y:auto;font-family:monospace;padding:0;' +
+            'box-shadow:0 0 30px rgba(139,0,0,0.5),inset 0 0 20px rgba(139,0,0,0.1);';
 
         panel.innerHTML = [
-            '<div style="padding:16px;border-bottom:1px solid #333;">',
+            '<div style="padding:16px;border-bottom:1px solid #2a0a0a;background:linear-gradient(180deg,#1a0505,#0a0a12);">',
             '  <div style="display:flex;justify-content:space-between;align-items:center;">',
-            '    <span style="font-size:16px;font-weight:bold;">🏪 Schwarzmarkt</span>',
-            '    <button id="market-close" style="background:none;border:none;color:#888;font-size:20px;cursor:pointer;">&times;</button>',
+            '    <span style="font-size:18px;font-weight:bold;">😈 Schwarzmarkt</span>',
+            '    <div style="display:flex;align-items:center;gap:12px;">',
+            '      <span id="sm-glut-display" style="font-size:12px;color:#ff4400;">🔥 0</span>',
+            '      <button id="sm-close" style="background:none;border:none;color:#666;font-size:22px;cursor:pointer;line-height:1;">&times;</button>',
+            '    </div>',
             '  </div>',
-            '  <div style="font-size:10px;color:#666;margin-top:4px;">Rare Items tauschen. Pseudonym. Kein Account.</div>',
+            '  <div id="sm-greeting" style="font-size:10px;color:#8B4513;margin-top:6px;font-style:italic;"></div>',
             '</div>',
-            '<div id="market-tabs" style="display:flex;border-bottom:1px solid #333;">',
-            '  <button class="market-tab active" data-tab="browse" style="flex:1;padding:8px;background:none;border:none;color:#FF6B00;font-size:12px;cursor:pointer;border-bottom:2px solid #FF6B00;">Angebote</button>',
-            '  <button class="market-tab" data-tab="sell" style="flex:1;padding:8px;background:none;border:none;color:#666;font-size:12px;cursor:pointer;">Verkaufen</button>',
-            '  <button class="market-tab" data-tab="wallet" style="flex:1;padding:8px;background:none;border:none;color:#666;font-size:12px;cursor:pointer;">Wallet</button>',
+            '<div id="sm-tabs" style="display:flex;border-bottom:1px solid #2a0a0a;">',
+            '  <button class="sm-tab active" data-tab="deals" style="flex:1;padding:8px;background:none;border:none;color:#ff4400;font-size:11px;cursor:pointer;border-bottom:2px solid #ff4400;">Mephisto Deals</button>',
+            '  <button class="sm-tab" data-tab="bazaar" style="flex:1;padding:8px;background:none;border:none;color:#555;font-size:11px;cursor:pointer;border-bottom:2px solid transparent;">Basar</button>',
+            '  <button class="sm-tab" data-tab="sell" style="flex:1;padding:8px;background:none;border:none;color:#555;font-size:11px;cursor:pointer;border-bottom:2px solid transparent;">Anbieten</button>',
             '</div>',
-            '<div id="market-content" style="padding:16px;min-height:200px;">',
-            '  <div id="market-browse"></div>',
-            '  <div id="market-sell" style="display:none;"></div>',
-            '  <div id="market-wallet" style="display:none;"></div>',
+            '<div id="sm-content" style="padding:12px;min-height:200px;">',
+            '  <div id="sm-deals"></div>',
+            '  <div id="sm-bazaar" style="display:none;"></div>',
+            '  <div id="sm-sell" style="display:none;"></div>',
             '</div>',
         ].join('\n');
 
@@ -76,133 +146,254 @@
         marketPanel = panel;
 
         // Close
-        panel.querySelector('#market-close').addEventListener('click', closeMarket);
+        panel.querySelector('#sm-close').addEventListener('click', closeMarket);
 
         // Tabs
-        var tabs = panel.querySelectorAll('.market-tab');
+        var tabs = panel.querySelectorAll('.sm-tab');
+        var tabIds = ['deals', 'bazaar', 'sell'];
         for (var i = 0; i < tabs.length; i++) {
             tabs[i].addEventListener('click', function () {
                 var target = this.getAttribute('data-tab');
                 for (var j = 0; j < tabs.length; j++) {
-                    tabs[j].style.color = '#666';
+                    tabs[j].style.color = '#555';
                     tabs[j].style.borderBottom = '2px solid transparent';
                     tabs[j].classList.remove('active');
                 }
-                this.style.color = '#FF6B00';
-                this.style.borderBottom = '2px solid #FF6B00';
+                this.style.color = '#ff4400';
+                this.style.borderBottom = '2px solid #ff4400';
                 this.classList.add('active');
-                panel.querySelector('#market-browse').style.display = target === 'browse' ? '' : 'none';
-                panel.querySelector('#market-sell').style.display = target === 'sell' ? '' : 'none';
-                panel.querySelector('#market-wallet').style.display = target === 'wallet' ? '' : 'none';
-                if (target === 'browse') loadListings();
+                for (var k = 0; k < tabIds.length; k++) {
+                    var el = panel.querySelector('#sm-' + tabIds[k]);
+                    if (el) el.style.display = tabIds[k] === target ? '' : 'none';
+                }
+                if (target === 'deals') renderMephistoDeals();
+                if (target === 'bazaar') loadBazaarListings();
                 if (target === 'sell') renderSellTab();
-                if (target === 'wallet') renderWalletTab();
             });
         }
 
         return panel;
     }
 
-    function openMarket() {
+    function updateGlutDisplay() {
+        var el = document.getElementById('sm-glut-display');
+        if (el) el.textContent = '🔥 ' + getSeelenglut();
+    }
+
+    function openMephisto() {
         var panel = createMarketPanel();
         panel.style.display = '';
         isOpen = true;
-        loadListings();
+        updateGlutDisplay();
+        // Greeting
+        var greetEl = document.getElementById('sm-greeting');
+        if (greetEl) greetEl.textContent = mephistoSays('greeting');
+        renderMephistoDeals();
+        if (typeof window.showToast === 'function') {
+            window.showToast(mephistoSays('greeting'), 3000);
+        }
     }
+
+    // Legacy: openMarket als Alias
+    function openMarket() { openMephisto(); }
 
     function closeMarket() {
         if (marketPanel) marketPanel.style.display = 'none';
         isOpen = false;
     }
 
-    // --- Browse Tab: Listings laden ---
-    function loadListings() {
-        var container = document.getElementById('market-browse');
+    // --- Tab 1: Mephisto Deals (NPC-Shop, Seelenglut only) ---
+    function renderMephistoDeals() {
+        var container = document.getElementById('sm-deals');
         if (!container) return;
-        container.innerHTML = '<div style="text-align:center;color:#666;padding:20px;">Lade Angebote...</div>';
+        updateGlutDisplay();
 
-        apiGet('/market/items?limit=' + PAGE_SIZE).then(function (data) {
+        var glut = getSeelenglut();
+        var html = '<div style="font-size:10px;color:#8B4513;margin-bottom:10px;">Mephistos persönliche Sammlung. Nur gegen Seelenglut.</div>';
+
+        for (var i = 0; i < MEPHISTO_DEALS.length; i++) {
+            var deal = MEPHISTO_DEALS[i];
+            var canAfford = glut >= deal.price_glut;
+            html += [
+                '<div style="background:#110808;border:1px solid #2a0a0a;border-radius:8px;padding:10px;margin-bottom:8px;',
+                canAfford ? '' : 'opacity:0.6;', '">',
+                '  <div style="display:flex;justify-content:space-between;align-items:center;">',
+                '    <span style="font-size:22px;">' + deal.emoji + '</span>',
+                '    <div style="flex:1;margin-left:10px;">',
+                '      <div style="font-weight:bold;font-size:12px;color:#e0d0c0;">' + escHtml(deal.name) + '</div>',
+                '      <div style="font-size:9px;color:#8B4513;font-style:italic;">' + escHtml(deal.desc) + '</div>',
+                '    </div>',
+                '    <div style="text-align:right;">',
+                '      <div style="font-size:11px;color:#ff4400;">🔥 ' + deal.price_glut + '</div>',
+                '      <button class="sm-deal-btn" data-idx="' + i + '" style="margin-top:4px;background:' + (canAfford ? '#8B0000' : '#333') + ';color:#fff;border:none;border-radius:4px;padding:4px 10px;font-size:10px;cursor:' + (canAfford ? 'pointer' : 'not-allowed') + ';" ' + (canAfford ? '' : 'disabled') + '>Kaufen</button>',
+                '    </div>',
+                '  </div>',
+                '</div>',
+            ].join('');
+        }
+
+        container.innerHTML = html;
+
+        var btns = container.querySelectorAll('.sm-deal-btn');
+        for (var j = 0; j < btns.length; j++) {
+            btns[j].addEventListener('click', function () {
+                var idx = parseInt(this.getAttribute('data-idx'));
+                buyMephistoDeal(idx);
+            });
+        }
+    }
+
+    function buyMephistoDeal(idx) {
+        var deal = MEPHISTO_DEALS[idx];
+        if (!deal) return;
+        if (!spendSeelenglut(deal.price_glut)) {
+            if (typeof window.showToast === 'function') {
+                window.showToast('😈 ' + mephistoSays('broke'), 3000);
+            }
+            return;
+        }
+        // Item ins LLM-Materials Inventar legen (rare item)
+        try {
+            var stored = JSON.parse(localStorage.getItem('insel-llm-materials') || '{}');
+            stored[deal.id] = { name: deal.name, emoji: deal.emoji, description: deal.desc, source: 'mephisto' };
+            localStorage.setItem('insel-llm-materials', JSON.stringify(stored));
+        } catch (e) { /* still */ }
+
+        if (typeof window.showToast === 'function') {
+            window.showToast('😈 ' + mephistoSays('buy') + ' ' + deal.emoji + ' ' + deal.name, 4000);
+        }
+        updateGlutDisplay();
+        renderMephistoDeals();
+    }
+
+    // --- Tab 2: Basar (P2P anonym via Worker) ---
+    function loadBazaarListings() {
+        var container = document.getElementById('sm-bazaar');
+        if (!container) return;
+        updateGlutDisplay();
+        container.innerHTML = '<div style="text-align:center;color:#555;padding:20px;">Lade Angebote...</div>';
+
+        apiGet('/blackmarket/items?limit=' + PAGE_SIZE).then(function (data) {
             if (!data.items || data.items.length === 0) {
-                container.innerHTML = '<div style="text-align:center;color:#666;padding:20px;">Noch keine Angebote. Sei der Erste!</div>';
+                container.innerHTML = '<div style="text-align:center;color:#8B4513;padding:20px;font-style:italic;">' + mephistoSays('empty') + '</div>';
                 return;
             }
-            var html = '';
+            var html = '<div style="font-size:10px;color:#8B4513;margin-bottom:10px;">Anonyme Angebote von Reisenden. Mephisto garantiert... nichts.</div>';
             for (var i = 0; i < data.items.length; i++) {
                 var item = data.items[i];
-                html += renderListingCard(item);
+                html += renderBazaarCard(item);
             }
             container.innerHTML = html;
 
-            // Buy buttons
-            var buyBtns = container.querySelectorAll('.market-buy-btn');
+            var buyBtns = container.querySelectorAll('.sm-buy-btn');
             for (var j = 0; j < buyBtns.length; j++) {
                 buyBtns[j].addEventListener('click', function () {
-                    handleBuy(this.getAttribute('data-id'));
+                    handleBazaarBuy(this.getAttribute('data-id'), parseInt(this.getAttribute('data-price')));
                 });
             }
         }).catch(function () {
-            container.innerHTML = '<div style="text-align:center;color:#c33;padding:20px;">Keine Verbindung zum Schwarzmarkt.</div>';
+            container.innerHTML = '<div style="text-align:center;color:#8B0000;padding:20px;">Keine Verbindung zum Schwarzmarkt. Die Schatten schweigen.</div>';
         });
     }
 
-    function renderListingCard(item) {
+    function renderBazaarCard(item) {
         var emoji = item.emoji || '🎁';
-        var priceStr = '';
-        if (item.price_mmx > 0) priceStr += item.price_mmx + ' MMX ';
-        if (item.price_xch > 0) priceStr += item.price_xch + ' XCH ';
-        if (item.price_glut > 0) priceStr += item.price_glut + ' Seelenglut ';
-        if (!priceStr) priceStr = 'Gratis';
+        var price = item.price_glut || 0;
+        var canAfford = getSeelenglut() >= price;
+        var isMine = item.seller_id === getPlayerId();
 
         return [
-            '<div style="background:#0f0f1a;border:1px solid #333;border-radius:8px;padding:12px;margin-bottom:8px;">',
+            '<div style="background:#110808;border:1px solid #2a0a0a;border-radius:8px;padding:10px;margin-bottom:8px;">',
             '  <div style="display:flex;justify-content:space-between;align-items:center;">',
             '    <span style="font-size:20px;">' + emoji + '</span>',
             '    <div style="flex:1;margin-left:10px;">',
-            '      <div style="font-weight:bold;font-size:12px;">' + escHtml(item.name || item.material_id) + '</div>',
-            '      <div style="font-size:10px;color:#888;">' + escHtml(item.description || '') + '</div>',
+            '      <div style="font-weight:bold;font-size:12px;color:#e0d0c0;">' + escHtml(item.name || item.material_id) + '</div>',
+            '      <div style="font-size:9px;color:#8B4513;">' + escHtml(item.description || '') + '</div>',
             '    </div>',
             '    <div style="text-align:right;">',
-            '      <div style="font-size:11px;color:#FF6B00;">' + escHtml(priceStr) + '</div>',
-            '      <button class="market-buy-btn" data-id="' + item.id + '" style="margin-top:4px;background:#FF6B00;color:#fff;border:none;border-radius:4px;padding:4px 10px;font-size:10px;cursor:pointer;">Kaufen</button>',
+            '      <div style="font-size:11px;color:#ff4400;">🔥 ' + price + '</div>',
+            isMine
+                ? '      <span style="font-size:9px;color:#555;">Dein Angebot</span>'
+                : '      <button class="sm-buy-btn" data-id="' + item.id + '" data-price="' + price + '" style="margin-top:4px;background:' + (canAfford ? '#8B0000' : '#333') + ';color:#fff;border:none;border-radius:4px;padding:4px 10px;font-size:10px;cursor:' + (canAfford ? 'pointer' : 'not-allowed') + ';" ' + (canAfford ? '' : 'disabled') + '>Kaufen</button>',
             '    </div>',
             '  </div>',
-            '  <div style="font-size:9px;color:#555;margin-top:4px;">von ' + (item.seller_addr ? item.seller_addr.slice(0, 10) + '...' : 'Anonym') + '</div>',
+            '  <div style="font-size:9px;color:#442211;margin-top:4px;font-style:italic;">Ein Reisender bietet an...</div>',
             '</div>',
         ].join('');
     }
 
-    // --- Sell Tab: Eigene Rare Items listen ---
-    function renderSellTab() {
-        var container = document.getElementById('market-sell');
-        if (!container) return;
-
-        var wallet = getWallet();
-        if (!wallet.mmx && !wallet.xch) {
-            container.innerHTML = '<div style="text-align:center;color:#888;padding:20px;">Erst Wallet einrichten (Tab: Wallet)</div>';
+    function handleBazaarBuy(listingId, price) {
+        if (!spendSeelenglut(price)) {
+            if (typeof window.showToast === 'function') {
+                window.showToast('😈 ' + mephistoSays('broke'), 3000);
+            }
             return;
         }
 
-        // Rare Items aus dem Inventar finden
+        apiPost('/blackmarket/buy', {
+            listing_id: listingId,
+            buyer_id: getPlayerId(),
+            price_glut: price,
+        }).then(function (res) {
+            if (res.ok) {
+                // Item ins lokale Inventar
+                if (res.item) {
+                    try {
+                        var stored = JSON.parse(localStorage.getItem('insel-llm-materials') || '{}');
+                        stored[res.item.material_id] = {
+                            name: res.item.name,
+                            emoji: res.item.emoji,
+                            description: res.item.description || '',
+                            source: 'schwarzmarkt',
+                        };
+                        localStorage.setItem('insel-llm-materials', JSON.stringify(stored));
+                    } catch (e) { /* still */ }
+                }
+                if (typeof window.showToast === 'function') {
+                    window.showToast('😈 ' + mephistoSays('buy'), 4000);
+                }
+                updateGlutDisplay();
+                loadBazaarListings();
+            } else {
+                // Seelenglut zurückgeben bei Fehler
+                earnSeelenglut(price);
+                if (typeof window.showToast === 'function') {
+                    window.showToast('😈 ' + (res.error || 'Der Deal ist geplatzt...'), 3000);
+                }
+            }
+        }).catch(function () {
+            earnSeelenglut(price);
+            if (typeof window.showToast === 'function') {
+                window.showToast('😈 Keine Verbindung. Die Schatten schweigen.', 3000);
+            }
+        });
+    }
+
+    // --- Tab 3: Anbieten (eigene Rare Items listen) ---
+    function renderSellTab() {
+        var container = document.getElementById('sm-sell');
+        if (!container) return;
+        updateGlutDisplay();
+
         var rareItems = findPlayerRareItems();
         if (rareItems.length === 0) {
-            container.innerHTML = '<div style="text-align:center;color:#888;padding:20px;">Keine Rare Items. Crafte mit dem LLM etwas Einzigartiges!</div>';
+            container.innerHTML = '<div style="text-align:center;color:#8B4513;padding:20px;font-style:italic;">Keine Rare Items. Crafte mit dem LLM etwas Einzigartiges — oder erledige Mephistos Quests!</div>';
             return;
         }
 
-        var html = '<div style="font-size:11px;color:#888;margin-bottom:8px;">Deine seltenen Items:</div>';
+        var html = '<div style="font-size:10px;color:#8B4513;margin-bottom:10px;">Biete deine seltenen Items anonym an. Nur Seelenglut als Preis.</div>';
         for (var i = 0; i < rareItems.length; i++) {
             var item = rareItems[i];
             html += [
-                '<div style="background:#0f0f1a;border:1px solid #333;border-radius:8px;padding:10px;margin-bottom:6px;display:flex;align-items:center;justify-content:space-between;">',
-                '  <span style="font-size:16px;">' + (item.emoji || '✨') + ' ' + escHtml(item.name) + '</span>',
-                '  <button class="market-list-btn" data-material="' + escHtml(item.id) + '" data-name="' + escHtml(item.name) + '" data-emoji="' + escHtml(item.emoji || '✨') + '" style="background:#3AAC59;color:#fff;border:none;border-radius:4px;padding:4px 10px;font-size:10px;cursor:pointer;">Anbieten</button>',
+                '<div style="background:#110808;border:1px solid #2a0a0a;border-radius:8px;padding:10px;margin-bottom:6px;display:flex;align-items:center;justify-content:space-between;">',
+                '  <span style="font-size:16px;">' + (item.emoji || '✨') + ' <span style="font-size:12px;color:#e0d0c0;">' + escHtml(item.name) + '</span></span>',
+                '  <button class="sm-list-btn" data-material="' + escHtml(item.id) + '" data-name="' + escHtml(item.name) + '" data-emoji="' + escHtml(item.emoji || '✨') + '" style="background:#8B0000;color:#fff;border:none;border-radius:4px;padding:4px 10px;font-size:10px;cursor:pointer;">Anbieten</button>',
                 '</div>',
             ].join('');
         }
         container.innerHTML = html;
 
-        // List buttons
-        var listBtns = container.querySelectorAll('.market-list-btn');
+        var listBtns = container.querySelectorAll('.sm-list-btn');
         for (var j = 0; j < listBtns.length; j++) {
             listBtns[j].addEventListener('click', function () {
                 handleList(this.getAttribute('data-material'), this.getAttribute('data-name'), this.getAttribute('data-emoji'));
@@ -211,7 +402,6 @@
     }
 
     function findPlayerRareItems() {
-        // LLM-gecraftete Materialien aus localStorage
         var rares = [];
         try {
             var stored = JSON.parse(localStorage.getItem('insel-llm-materials') || '{}');
@@ -228,113 +418,46 @@
         return rares;
     }
 
-    // --- Wallet Tab ---
-    function renderWalletTab() {
-        var container = document.getElementById('market-wallet');
-        if (!container) return;
-
-        var wallet = getWallet();
-
-        container.innerHTML = [
-            '<div style="font-size:11px;color:#888;margin-bottom:12px;">',
-            '  Pseudonym. Keine Registrierung. Nur Blockchain-Adressen.',
-            '  <br><span style="color:#555;font-size:9px;">DSGVO: Kein PII gespeichert. Adressen = Pseudonyme.</span>',
-            '</div>',
-            '<label style="font-size:10px;color:#FF6B00;">MMX Adresse</label>',
-            '<input id="wallet-mmx" type="text" value="' + escHtml(wallet.mmx || '') + '" placeholder="mmx1..." style="width:100%;background:#0f0f1a;color:#e0e0e0;border:1px solid #333;border-radius:4px;padding:6px;font-size:11px;font-family:monospace;margin:4px 0 12px;box-sizing:border-box;">',
-            '<label style="font-size:10px;color:#3AAC59;">XCH Adresse</label>',
-            '<input id="wallet-xch" type="text" value="' + escHtml(wallet.xch || '') + '" placeholder="xch1..." style="width:100%;background:#0f0f1a;color:#e0e0e0;border:1px solid #333;border-radius:4px;padding:6px;font-size:11px;font-family:monospace;margin:4px 0 12px;box-sizing:border-box;">',
-            '<button id="wallet-save" style="width:100%;background:#FF6B00;color:#fff;border:none;border-radius:6px;padding:8px;font-size:12px;cursor:pointer;">Speichern</button>',
-            '<div style="margin-top:12px;padding:10px;background:#0f0f1a;border:1px solid #222;border-radius:6px;font-size:9px;color:#555;">',
-            '  <b style="color:#888;">Deflation\u00e4re Arbeitswerttheorie</b><br>',
-            '  Jeder Token der hierher flie\u00dft, wird zu Arbeit. Jede Arbeit strahlt<br>',
-            '  als Code, als Quest, als Insel zur\u00fcck in die Welt. Das Schwarze Loch<br>',
-            '  frisst Tokens und strahlt Hawking-Strahlung: Kinderlachen.<br><br>',
-            '  Marx sa\u00df im Lesesaal. Wir sitzen auf der Insel.<br>',
-            '  Der Wert entsteht nicht im Besitz, sondern im Verschwinden.',
-            '</div>',
-        ].join('\n');
-
-        container.querySelector('#wallet-save').addEventListener('click', function () {
-            var mmx = container.querySelector('#wallet-mmx').value.trim();
-            var xch = container.querySelector('#wallet-xch').value.trim();
-
-            // Validierung: Adressen-Prefix
-            if (mmx && !mmx.startsWith('mmx1')) {
-                if (typeof window.showToast === 'function') window.showToast('MMX-Adresse muss mit mmx1 beginnen');
-                return;
-            }
-            if (xch && !xch.startsWith('xch1')) {
-                if (typeof window.showToast === 'function') window.showToast('XCH-Adresse muss mit xch1 beginnen');
-                return;
-            }
-
-            setWallet({ mmx: mmx, xch: xch });
-            if (typeof window.showToast === 'function') window.showToast('Wallet gespeichert');
-        });
-    }
-
-    // --- Handlers ---
-    function handleBuy(listingId) {
-        var wallet = getWallet();
-        if (!wallet.mmx && !wallet.xch) {
-            if (typeof window.showToast === 'function') window.showToast('Erst Wallet einrichten!');
-            return;
-        }
-
-        apiGet('/market/item/' + listingId).then(function (data) {
-            if (!data.item) {
-                if (typeof window.showToast === 'function') window.showToast('Angebot nicht mehr verf\u00fcgbar');
-                return;
-            }
-            var item = data.item;
-
-            // Zeige Zahlungsinfos
-            var payAddr = item.seller_mmx || item.seller_xch || '';
-            var payAmount = item.price_mmx > 0 ? item.price_mmx + ' MMX' : item.price_xch + ' XCH';
-            var msg = item.name + ' kaufen?\n\nSende ' + payAmount + ' an:\n' + payAddr +
-                '\n\nDanach "Zahlung best\u00e4tigen" klicken.';
-
-            if (confirm(msg)) {
-                // Zahlung als pending markieren
-                apiPost('/market/buy', {
-                    listing_id: listingId,
-                    buyer_addr: wallet.mmx || wallet.xch,
-                }).then(function (res) {
-                    if (res.ok) {
-                        if (typeof window.showToast === 'function') window.showToast('Kauf eingeleitet! Verifizierung l\u00e4uft...');
-                        loadListings();
-                    }
-                });
-            }
-        });
-    }
-
     function handleList(materialId, name, emoji) {
-        var wallet = getWallet();
-        var price = prompt('Preis in MMX (z.B. 0.1):');
-        if (!price || isNaN(parseFloat(price))) return;
+        var priceStr = prompt('Preis in Seelenglut 🔥 (z.B. 30):');
+        if (!priceStr || isNaN(parseInt(priceStr))) return;
+        var price = Math.max(1, parseInt(priceStr));
 
-        apiPost('/market/list', {
+        apiPost('/blackmarket/list', {
             material_id: materialId,
             name: name,
             emoji: emoji,
-            price_mmx: parseFloat(price),
-            price_xch: 0,
-            price_glut: 0,
-            seller_addr: wallet.mmx || wallet.xch || 'anonym',
-            seller_mmx: wallet.mmx || '',
-            seller_xch: wallet.xch || '',
+            price_glut: price,
+            seller_id: getPlayerId(),
         }).then(function (res) {
             if (res.ok) {
-                if (typeof window.showToast === 'function') window.showToast('Item gelistet!');
+                // Item aus lokalem Inventar entfernen (es ist jetzt auf dem Markt)
+                try {
+                    var stored = JSON.parse(localStorage.getItem('insel-llm-materials') || '{}');
+                    delete stored[materialId];
+                    localStorage.setItem('insel-llm-materials', JSON.stringify(stored));
+                } catch (e) { /* still */ }
+
+                if (typeof window.showToast === 'function') {
+                    window.showToast('😈 ' + mephistoSays('sell'), 3000);
+                }
                 renderSellTab();
             } else {
-                if (typeof window.showToast === 'function') window.showToast(res.error || 'Fehler beim Listen');
+                if (typeof window.showToast === 'function') {
+                    window.showToast('😈 ' + (res.error || 'Fehler beim Listen'), 3000);
+                }
             }
         }).catch(function () {
-            if (typeof window.showToast === 'function') window.showToast('Keine Verbindung');
+            if (typeof window.showToast === 'function') {
+                window.showToast('😈 Keine Verbindung. Die Schatten schweigen.', 3000);
+            }
         });
+    }
+
+    // --- Rare Item Detection ---
+    function isRareItem(materialId) {
+        var mats = window.INSEL_MATERIALS || {};
+        return materialId && !mats[materialId];
     }
 
     // --- HTML Escaping ---
@@ -344,27 +467,18 @@
         return div.innerHTML;
     }
 
-    // --- NPC Rare Shop (Mephisto) ---
-    var MEPHISTO_DEALS = [
-        { id: 'schatten_kristall', name: 'Schatten-Kristall', emoji: '🔮', desc: 'Leuchtet nur bei Nacht. Fl\u00fcstert Faust-Zitate.', price_glut: 50, price_mmx: 0.01 },
-        { id: 'seelen_laterne', name: 'Seelen-Laterne', emoji: '🏮', desc: 'Zeigt den Weg den man nicht gehen sollte.', price_glut: 80, price_mmx: 0.02 },
-        { id: 'mitternachts_rose', name: 'Mitternachts-Rose', emoji: '🥀', desc: 'Bl\u00fcht nur zwischen 23:00 und 01:00.', price_glut: 120, price_mmx: 0.05 },
-        { id: 'pakt_siegel', name: 'Pakt-Siegel', emoji: '📜', desc: 'Unterschreibe nicht. Oder doch. Hehehehe...', price_glut: 200, price_mmx: 0.1 },
-        { id: 'hawking_stern', name: 'Hawking-Stern', emoji: '⭐', desc: 'Strahlt Information. Schwarzes Loch im Taschenformat.', price_glut: 500, price_mmx: 0.5 },
-    ];
-
-    function getMephistoDeals() { return MEPHISTO_DEALS; }
-
     // --- Exports ---
     var marketplace = {
         open: openMarket,
+        openMephisto: openMephisto,
         close: closeMarket,
         isOpen: function () { return isOpen; },
-        getWallet: getWallet,
-        setWallet: setWallet,
         isRareItem: isRareItem,
-        getMephistoDeals: getMephistoDeals,
+        getMephistoDeals: function () { return MEPHISTO_DEALS; },
         MEPHISTO_DEALS: MEPHISTO_DEALS,
+        getSeelenglut: getSeelenglut,
+        earnSeelenglut: earnSeelenglut,
+        spendSeelenglut: spendSeelenglut,
     };
 
     if (window.INSEL) {

--- a/worker.js
+++ b/worker.js
@@ -63,6 +63,16 @@ export default {
         if (pathname === '/market/buy') {
             return handleMarketBuy(request, env);
         }
+        // Schwarzmarkt (Seelenglut-basiert, anonym)
+        if (pathname === '/blackmarket/items') {
+            return handleBlackmarketItems(request, env);
+        }
+        if (pathname === '/blackmarket/list') {
+            return handleBlackmarketList(request, env);
+        }
+        if (pathname === '/blackmarket/buy') {
+            return handleBlackmarketBuy(request, env);
+        }
 
         // Nur POST
         if (request.method !== 'POST') {
@@ -749,6 +759,138 @@ async function createMarketTable(env) {
     await env.METRICS_DB.prepare(
         'CREATE TABLE IF NOT EXISTS marketplace (id TEXT PRIMARY KEY, material_id TEXT NOT NULL, name TEXT NOT NULL, emoji TEXT DEFAULT \'✨\', description TEXT DEFAULT \'\', price_mmx REAL DEFAULT 0, price_xch REAL DEFAULT 0, price_glut INTEGER DEFAULT 0, seller_addr TEXT DEFAULT \'anonym\', seller_mmx TEXT DEFAULT \'\', seller_xch TEXT DEFAULT \'\', buyer_addr TEXT DEFAULT \'\', status TEXT DEFAULT \'active\', created_at DATETIME DEFAULT CURRENT_TIMESTAMP)'
     ).run();
+}
+
+// --- Schwarzmarkt (Seelenglut, anonym, DSGVO-konform) ---
+
+async function createBlackmarketTable(env) {
+    await env.METRICS_DB.prepare(
+        `CREATE TABLE IF NOT EXISTS blackmarket (
+            id TEXT PRIMARY KEY,
+            material_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            emoji TEXT DEFAULT '✨',
+            description TEXT DEFAULT '',
+            price_glut INTEGER NOT NULL DEFAULT 10,
+            seller_id TEXT NOT NULL,
+            buyer_id TEXT DEFAULT '',
+            status TEXT DEFAULT 'active',
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )`
+    ).run();
+}
+
+async function handleBlackmarketItems(request, env) {
+    if (!env.METRICS_DB) return json({ error: 'D1 nicht konfiguriert' }, 500);
+    const url = new URL(request.url);
+    const limit = Math.min(parseInt(url.searchParams.get('limit') || '20'), 50);
+
+    try {
+        await createBlackmarketTable(env);
+        const rows = await env.METRICS_DB.prepare(
+            `SELECT id, material_id, name, emoji, description, price_glut, seller_id, status, created_at
+             FROM blackmarket WHERE status = 'active' ORDER BY created_at DESC LIMIT ?`
+        ).bind(limit).all();
+        return json({ items: rows.results || [] });
+    } catch (e) {
+        return json({ error: e.message }, 500);
+    }
+}
+
+async function handleBlackmarketList(request, env) {
+    if (!env.METRICS_DB) return json({ error: 'D1 nicht konfiguriert' }, 500);
+    if (request.method !== 'POST') return json({ error: 'POST only' }, 405);
+
+    let body;
+    try { body = await request.json(); } catch (e) {
+        return json({ error: 'Ungültiger Body' }, 400);
+    }
+
+    if (!body.material_id || !body.name) {
+        return json({ error: 'material_id und name benötigt' }, 400);
+    }
+    if (!body.price_glut || body.price_glut < 1) {
+        return json({ error: 'price_glut muss mindestens 1 sein' }, 400);
+    }
+
+    const sellerId = body.seller_id || 'anonym';
+
+    try {
+        await createBlackmarketTable(env);
+
+        // Max 10 aktive Listings pro Seller
+        const count = await env.METRICS_DB.prepare(
+            `SELECT COUNT(*) as cnt FROM blackmarket WHERE seller_id = ? AND status = 'active'`
+        ).bind(sellerId).first();
+        if (count && count.cnt >= 10) {
+            return json({ error: 'Maximal 10 aktive Angebote. Mephisto sagt: Geduld!' }, 429);
+        }
+
+        const id = crypto.randomUUID();
+        await env.METRICS_DB.prepare(
+            `INSERT INTO blackmarket (id, material_id, name, emoji, description, price_glut, seller_id, status)
+             VALUES (?, ?, ?, ?, ?, ?, ?, 'active')`
+        ).bind(
+            id, body.material_id, body.name, body.emoji || '✨',
+            body.description || '', body.price_glut, sellerId
+        ).run();
+
+        return json({ ok: true, id });
+    } catch (e) {
+        return json({ error: e.message }, 500);
+    }
+}
+
+async function handleBlackmarketBuy(request, env) {
+    if (!env.METRICS_DB) return json({ error: 'D1 nicht konfiguriert' }, 500);
+    if (request.method !== 'POST') return json({ error: 'POST only' }, 405);
+
+    let body;
+    try { body = await request.json(); } catch (e) {
+        return json({ error: 'Ungültiger Body' }, 400);
+    }
+
+    if (!body.listing_id) return json({ error: 'listing_id benötigt' }, 400);
+
+    try {
+        await createBlackmarketTable(env);
+
+        // Item lesen um Details zurückzugeben
+        const item = await env.METRICS_DB.prepare(
+            `SELECT * FROM blackmarket WHERE id = ? AND status = 'active'`
+        ).bind(body.listing_id).first();
+
+        if (!item) {
+            return json({ error: 'Angebot nicht verfügbar oder bereits verkauft' }, 404);
+        }
+
+        // Nicht eigenes Item kaufen
+        if (item.seller_id === body.buyer_id) {
+            return json({ error: 'Du kannst dein eigenes Angebot nicht kaufen, Schlauberger.' }, 400);
+        }
+
+        // Status auf sold setzen
+        const result = await env.METRICS_DB.prepare(
+            `UPDATE blackmarket SET status = 'sold', buyer_id = ? WHERE id = ? AND status = 'active'`
+        ).bind(body.buyer_id || 'anonym', body.listing_id).run();
+
+        if (result.meta.changes === 0) {
+            return json({ error: 'Jemand war schneller. Mephisto lacht.' }, 409);
+        }
+
+        return json({
+            ok: true,
+            listing_id: body.listing_id,
+            item: {
+                material_id: item.material_id,
+                name: item.name,
+                emoji: item.emoji,
+                description: item.description,
+            }
+        });
+    } catch (e) {
+        return json({ error: e.message }, 500);
+    }
 }
 
 // --- Helpers ---


### PR DESCRIPTION
## Summary

- **Mephisto als Schwarzmarkt-NPC**: Klick auf 😈 öffnet den Schwarzmarkt (dunkles Rot/Schwarz-Design) statt generischem Quest-Dialog
- **3 Tabs**: Mephisto Deals (NPC-Shop mit 5 Rare Items), Basar (P2P anonym), Anbieten (eigene LLM-Items listen)
- **Seelenglut 🔥** als einzige Schwarzmarkt-Währung — kindertauglich, keine Crypto-Adressen nötig
- **Mephisto-Quests** geben Seelenglut als Bonus-Reward (blockCount * 5, min 10)
- **Worker-Endpoints**: `GET /blackmarket/items`, `POST /blackmarket/list`, `POST /blackmarket/buy` mit eigener D1-Tabelle `blackmarket`
- **DSGVO**: Nur pseudonyme `player_id` (auto-generiert), keine Spielernamen. Anzeige: "Ein Reisender bietet an..."
- **Mephisto kommentiert** jeden Deal mit zufälligen Sprüchen ("Ein guter Tausch... für mich 😈")

## Geänderte Dateien

- `marketplace.js` — Komplett umgebaut: Schwarzmarkt-UI mit Mephisto-Theme
- `game.js` — Mephisto-Klick → `openMephisto()`, Seelenglut-Reward bei Quest-Abschluss
- `worker.js` — 3 neue `/blackmarket/*` Endpoints + `blackmarket` D1-Tabelle
- `MEMORY.md` — Erfolg dokumentiert

## Test plan

- [ ] Mephisto auf Grid anklicken → Schwarzmarkt-Panel öffnet sich
- [ ] Tab "Mephisto Deals" zeigt 5 Items mit Seelenglut-Preisen
- [ ] Seelenglut verdienen: Mephisto-Quest abschließen → Glut im Inventar
- [ ] Deal kaufen: Seelenglut wird abgezogen, Item erscheint in LLM-Materials
- [ ] Tab "Basar": Items von anderen Spielern anonym angezeigt
- [ ] Tab "Anbieten": Eigene Rare Items mit Seelenglut-Preis listen
- [ ] Worker: POST /blackmarket/list erstellt Eintrag in D1
- [ ] Worker: GET /blackmarket/items liefert aktive Angebote
- [ ] Worker: POST /blackmarket/buy setzt Status auf 'sold', gibt Item zurück
- [ ] Eigenes Angebot zeigt "Dein Angebot" statt Kaufen-Button
- [ ] Keine Spielernamen sichtbar — nur "Ein Reisender bietet an..."

https://claude.ai/code/session_017wyrbauqTxXf1CY9XPUPmY