### PR TITLE
feat: NPC-Daten → npc-data.js, game.js 4977→4918 LOC (#11)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -34,6 +34,7 @@ Persistent team log. Append-only. Read by all agents.
 
 | Datum | Was | Warum gut |
 |-------|-----|-----------|
+| 2026-04-03 | S25-3: NPC-Daten → npc-data.js — game.js 4977→4918 LOC | Phantom-Open S25-2 (Dungeon war schon in Commit 4cf2646 implementiert) erkannt. 59 LOC raus aus game.js. Pattern: nur Daten extrahieren (NPC_VOICES, MAT_ADJECTIVES, REACTIONS, TEMPLATES, STREAK_COMMENTS), State (lastMaterial, materialStreak) bleibt in game.js. |
 | 2026-04-03 | Bug-NPC (PR #188): Raupe Nimmersatt als Meta-Bug-Melder | Worktree war auf falschem Branch → Commit landete auf feat/floriane-muscheln statt feat/bug-npc. Fix: `git branch -f` + force push. Lektion: In Worktrees immer `git branch --show-current` prüfen vor Commit. |
 | 2026-04-03 | Floriane-Muscheln: Bestätigungsflow statt Silent-Deduction | Vorheriger Agent hatte Fibonacci-Preise die bei sendToApi() still abzogen — Kind sah nur "X 🐚 für diesen Wunsch" als System-Message. Neuer Flow: Wunsch-Erkennung → Preis anzeigen → Kind bestätigt/ablehnt → erst dann abziehen. Wortanzahl-basierte Preise (3/5/8 🐚) statt Zufall. |
 | 2026-04-02 | Oscar am Telefon: "Ich will mit dir spielen." | Nicht um zu spielen. Um zusammen zu sein. Das ist die Wurzel. Alles andere ist Blattwerk. |

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -10,12 +10,22 @@
 | # | Item | Owner(s) | Status |
 |---|------|----------|--------|
 | S25-1 | **#71 Palette = Instrument** — mouseenter auf Palette-Buttons spielt playMaterialSound(mat). Oscar spielt Melodien durch Hovern. Kein Klick nötig. | Engineer | ✅ Done |
-| S25-2 | **#50 Höhle = Dungeon** — Berg+Wasser=Höhle-Tile. Klick auf Höhle öffnet Dungeon-Schicht (Code-Ebene). Oscar entdeckt neue Welt. | Engineer + Artist | 🔲 Offen |
-| S25-3 | **#11 game.js Zellteilung** — NPC-Kommentardaten (NPC_VOICES, MAT_ADJECTIVES, REACTIONS, TEMPLATES, STREAK_COMMENTS) → npc-data.js. game.js: 4975 → ~4800. | Engineer | 🔲 Offen |
+| S25-2 | **#50 Höhle = Dungeon** — Berg+Wasser=Höhle-Tile. Klick auf Höhle öffnet Dungeon-Schicht (Code-Ebene). Oscar entdeckt neue Welt. | Engineer + Artist | ✅ Done |
+| S25-3 | **#11 game.js Zellteilung** — NPC-Kommentardaten (NPC_VOICES, MAT_ADJECTIVES, REACTIONS, TEMPLATES, STREAK_COMMENTS) → npc-data.js. game.js: 4977 → 4918. | Engineer | ✅ Done |
 
 ---
 
 ## Standup Log
+
+### 2026-04-03 (Daily Scrum)
+
+**Gestern (Planning):** S25-1 ✅ (Palette-Hover-Sound). S25-2 war Phantom-Open — Dungeon bereits implementiert in commit 4cf2646 (Dungeon + Inselgeneratoren, PR #181). Als Done markiert.
+
+**Heute:** S25-3 — NPC_VOICES, MAT_ADJECTIVES, REACTIONS, TEMPLATES, STREAK_COMMENTS → npc-data.js. game.js unter 4920 LOC.
+
+**Blocker:** Keine. Smoke Test weiterhin durch Sandbox-Proxy blockiert (bekannt seit Sprint 21).
+
+---
 
 ### 2026-04-03 (Sprint 25 Planning)
 

--- a/game.js
+++ b/game.js
@@ -723,76 +723,17 @@
     // === GENERATIVE NPC-KOMMENTARE ===
     // Baustein-System: Satzteile werden live gemischt = unendliche Kombinationen
     // Kein API-Call, kein Data-Leak, rein clientseitig.
-    const NPC_VOICES = {
-        spongebob: { emoji: '🧽', prefix: 'SpongeBob:', ticks: ['ICH BIN BEREIT', 'Das ist der BESTE Tag!', 'Hihihi!'], style: 'caps' },
-        maus:      { emoji: '🐭', prefix: 'Maus:', ticks: ['*pieps*', '*quak*'], style: 'cute' },
-        elefant:   { emoji: '🐘', prefix: 'Elefant:', ticks: ['Törööö!', 'Hmm, ich möchte sicherstellen...'], style: 'careful' },
-        neinhorn:  { emoji: '🦄', prefix: 'Neinhorn:', ticks: ['NEIN!', '...ok,', 'Mon Dieu!'], style: 'nein' },
-        krabs:     { emoji: '🦀', prefix: 'Krabs:', ticks: ['💰', 'Taler!', 'Geld!'], style: 'money' },
-        tommy:     { emoji: '🦞', prefix: 'Tommy:', ticks: ['Klick-klack!', 'JA!', 'Noch ein Boot!'], style: 'chaos' },
-        bernd:     { emoji: '🍞', prefix: 'Bernd:', ticks: ['*seufz*', 'Mist.', 'Toll.'], style: 'grumpy' },
-        floriane:  { emoji: '🧚', prefix: 'Floriane:', ticks: ['✨', 'Oh!', 'Ein Wunsch!'], style: 'magic' },
-        mephisto:  { emoji: '😈', prefix: 'Mephisto:', ticks: ['Hehehehe...', 'Ein Angebot!', 'Deal?'], style: 'deal' },
-        bug:       { emoji: '🐛', prefix: 'Bug:', ticks: ['*mampf*', 'Was ist kaputt?', 'Zeig mal!'], style: 'bug' },
-        // #13: Programmiersprachen-Bewohner
-        haskell:   { emoji: '🟣', prefix: 'Haskell:', ticks: ['Rein funktional!', 'Keine Seiteneffekte!', 'Typen lösen alles!'], style: 'careful' },
-        lua:       { emoji: '🌙', prefix: 'Lua:', ticks: ['Schnell und leicht!', 'Tables!', '-- Ein Kommentar genügt'], style: 'cute' },
-        sql:       { emoji: '🗃️', prefix: 'SQL:', ticks: ['SELECT * FROM Insel', 'JOIN!', 'NULL... ist auch ein Wert.'], style: 'grumpy' },
-        scratch:   { emoji: '🐱', prefix: 'Scratch:', ticks: ['Wenn grüne Flagge angeklickt...', '10 Schritte gehen!', 'Katze sagt: Miau!'], style: 'caps' },
-    };
-
-    const MAT_ADJECTIVES = {
-        wood: ['rustikales', 'solides', 'gemütliches', 'warmes', 'klassisches'],
-        stone: ['robuster', 'starker', 'massiver', 'ewiger', 'grauer'],
-        glass: ['durchsichtiges', 'glänzendes', 'funkelndes', 'modernes', 'schickes'],
-        plant: ['grüne', 'lebendige', 'frische', 'wilde', 'wuchernde'],
-        tree: ['großer', 'schattenspendender', 'alter', 'stolzer', 'knorriger'],
-        flower: ['bunte', 'duftende', 'leuchtende', 'zarte', 'wilde'],
-        water: ['blaues', 'plätscherndes', 'kühles', 'tiefes', 'glitzerndes'],
-        fence: ['ordentlicher', 'stabiler', 'gerader', 'praktischer'],
-        boat: ['schnelles', 'kleines', 'mutiges', 'abenteuerlustiges'],
-        fish: ['glitschiger', 'flinker', 'neugieriger', 'bunter'],
-        bridge: ['verbindende', 'elegante', 'starke', 'kühne'],
-        flag: ['wehende', 'stolze', 'bunte', 'mutige'],
-        fountain: ['sprudelnder', 'fröhlicher', 'magischer', 'singender'],
-        mushroom: ['geheimnisvoller', 'leuchtender', 'seltsamer', 'kuscheliger'],
-        door: ['einladende', 'mysteriöse', 'offene', 'knarrende'],
-        roof: ['schützendes', 'rotes', 'stabiles', 'gemütliches'],
-        lamp: ['helle', 'warme', 'leuchtende', 'einladende'],
-        sand: ['goldener', 'weicher', 'warmer', 'endloser'],
-        path: ['verschlungener', 'einladender', 'spannender', 'neuer'],
-        cactus: ['stacheliger', 'zäher', 'trotziger', 'cooler'],
-    };
-
-    const REACTIONS = {
-        caps:    ['Das ist FANTASTISCH!', 'MEHR DAVON!', 'Der beste Block ALLER ZEITEN!', 'SO toll!', 'WOW!'],
-        cute:    ['*freu*', '*hüpf*', '*kicher*', '*staun*', 'Oh!', 'Schööön!'],
-        careful: ['Sehr schön gemacht.', 'Ganz sorgfältig, ja.', 'Das passt gut hierhin.', 'Ich bin zufrieden.'],
-        nein:    ['...ist eigentlich gut.', '...naja. Geht so. OK es ist toll.', '...NEIN! Doch. Ja.', '...pfff. Hübsch.'],
-        money:   ['Das bringt Kunden!', 'Wertsteigerung!', 'Cha-ching!', 'Investment!', 'Rendite!'],
-        chaos:   ['SCHNITT! Nochmal! BESSER!', 'Das wird im Film GEIL!', 'KAMERA LÄUFT!', 'Action!'],
-        grumpy:  ['Na toll.', 'Muss das sein?', 'Kann man machen.', 'Hab ich auch mal probiert. War schlecht.'],
-        deal:    ['Interessant...', 'Das hat seinen Preis.', 'Ein fairer Tausch!', 'Hehehehe...', 'Wir kommen ins Geschäft!'],
-        bug:     ['*mampf mampf*', 'Lecker Bug!', 'Nom nom!', 'Noch einen!', 'Der war knusprig!'],
-    };
-
-    const TEMPLATES = [
-        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${npc.ticks[0]} ${adj} ${mat}! ${react}`,
-        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${react} ${adj} ${mat}!`,
-        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} Oh! ${adj} ${mat}. ${npc.ticks[Math.min(1, npc.ticks.length-1)]}`,
-        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${adj} ${mat}? ${react}`,
-        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${npc.ticks[0]} Noch mehr ${mat}! ${react}`,
-    ];
+    // Daten in npc-data.js (#11 Zellteilung)
+    const NPC_VOICES = window.INSEL_NPC_DATA.NPC_VOICES;
+    const MAT_ADJECTIVES = window.INSEL_NPC_DATA.MAT_ADJECTIVES;
+    const REACTIONS = window.INSEL_NPC_DATA.REACTIONS;
+    const TEMPLATES = window.INSEL_NPC_DATA.TEMPLATES;
 
     // Combo-Tracker: besondere Kommentare bei Serien
     let lastMaterial = null;
     let materialStreak = 0;
 
-    const STREAK_COMMENTS = [
-        (npc, mat, n) => `${npc.emoji} ${npc.prefix} ${n}x ${mat} am Stück? ${npc.ticks[0]}`,
-        (npc, mat, n) => `${npc.emoji} ${npc.prefix} Noch mehr ${mat}?! Das wird ja eine ${mat}-Stadt!`,
-        (npc, mat, n) => `${npc.emoji} ${npc.prefix} ${n} ${mat}! Jemand hat einen Plan!`,
-    ];
+    const STREAK_COMMENTS = window.INSEL_NPC_DATA.STREAK_COMMENTS;
 
     // === NPC-SESSION-GEDÄCHTNIS ===
     // Speichert pro NPC: letztes Lieblingsmaterial, abgeschlossene Quests, letzter Besuch

--- a/index.html
+++ b/index.html
@@ -502,6 +502,7 @@
     <script src="screensaver.js"></script>
     <script src="island-generators.js"></script>
     <script src="stories.js"></script>
+    <script src="npc-data.js"></script>
     <script src="sound.js"></script>
     <script src="analytics.js"></script>
     <script src="healthcheck.js"></script>

--- a/npc-data.js
+++ b/npc-data.js
@@ -1,0 +1,87 @@
+// === NPC-DATEN — Kommentar-System ===
+// Exportiert als window.INSEL_NPC_DATA
+// Extrahiert aus game.js (#11 Zellteilung)
+
+(function () {
+    'use strict';
+
+    /** @type {Object<string, {emoji: string, prefix: string, ticks: string[], style: string}>} */
+    var NPC_VOICES = {
+        spongebob: { emoji: '🧽', prefix: 'SpongeBob:', ticks: ['ICH BIN BEREIT', 'Das ist der BESTE Tag!', 'Hihihi!'], style: 'caps' },
+        maus:      { emoji: '🐭', prefix: 'Maus:', ticks: ['*pieps*', '*quak*'], style: 'cute' },
+        elefant:   { emoji: '🐘', prefix: 'Elefant:', ticks: ['Törööö!', 'Hmm, ich möchte sicherstellen...'], style: 'careful' },
+        neinhorn:  { emoji: '🦄', prefix: 'Neinhorn:', ticks: ['NEIN!', '...ok,', 'Mon Dieu!'], style: 'nein' },
+        krabs:     { emoji: '🦀', prefix: 'Krabs:', ticks: ['💰', 'Taler!', 'Geld!'], style: 'money' },
+        tommy:     { emoji: '🦞', prefix: 'Tommy:', ticks: ['Klick-klack!', 'JA!', 'Noch ein Boot!'], style: 'chaos' },
+        bernd:     { emoji: '🍞', prefix: 'Bernd:', ticks: ['*seufz*', 'Mist.', 'Toll.'], style: 'grumpy' },
+        floriane:  { emoji: '🧚', prefix: 'Floriane:', ticks: ['✨', 'Oh!', 'Ein Wunsch!'], style: 'magic' },
+        mephisto:  { emoji: '😈', prefix: 'Mephisto:', ticks: ['Hehehehe...', 'Ein Angebot!', 'Deal?'], style: 'deal' },
+        bug:       { emoji: '🐛', prefix: 'Bug:', ticks: ['*mampf*', 'Was ist kaputt?', 'Zeig mal!'], style: 'bug' },
+        // #13: Programmiersprachen-Bewohner
+        haskell:   { emoji: '🟣', prefix: 'Haskell:', ticks: ['Rein funktional!', 'Keine Seiteneffekte!', 'Typen lösen alles!'], style: 'careful' },
+        lua:       { emoji: '🌙', prefix: 'Lua:', ticks: ['Schnell und leicht!', 'Tables!', '-- Ein Kommentar genügt'], style: 'cute' },
+        sql:       { emoji: '🗃️', prefix: 'SQL:', ticks: ['SELECT * FROM Insel', 'JOIN!', 'NULL... ist auch ein Wert.'], style: 'grumpy' },
+        scratch:   { emoji: '🐱', prefix: 'Scratch:', ticks: ['Wenn grüne Flagge angeklickt...', '10 Schritte gehen!', 'Katze sagt: Miau!'], style: 'caps' },
+    };
+
+    /** @type {Object<string, string[]>} */
+    var MAT_ADJECTIVES = {
+        wood: ['rustikales', 'solides', 'gemütliches', 'warmes', 'klassisches'],
+        stone: ['robuster', 'starker', 'massiver', 'ewiger', 'grauer'],
+        glass: ['durchsichtiges', 'glänzendes', 'funkelndes', 'modernes', 'schickes'],
+        plant: ['grüne', 'lebendige', 'frische', 'wilde', 'wuchernde'],
+        tree: ['großer', 'schattenspendender', 'alter', 'stolzer', 'knorriger'],
+        flower: ['bunte', 'duftende', 'leuchtende', 'zarte', 'wilde'],
+        water: ['blaues', 'plätscherndes', 'kühles', 'tiefes', 'glitzerndes'],
+        fence: ['ordentlicher', 'stabiler', 'gerader', 'praktischer'],
+        boat: ['schnelles', 'kleines', 'mutiges', 'abenteuerlustiges'],
+        fish: ['glitschiger', 'flinker', 'neugieriger', 'bunter'],
+        bridge: ['verbindende', 'elegante', 'starke', 'kühne'],
+        flag: ['wehende', 'stolze', 'bunte', 'mutige'],
+        fountain: ['sprudelnder', 'fröhlicher', 'magischer', 'singender'],
+        mushroom: ['geheimnisvoller', 'leuchtender', 'seltsamer', 'kuscheliger'],
+        door: ['einladende', 'mysteriöse', 'offene', 'knarrende'],
+        roof: ['schützendes', 'rotes', 'stabiles', 'gemütliches'],
+        lamp: ['helle', 'warme', 'leuchtende', 'einladende'],
+        sand: ['goldener', 'weicher', 'warmer', 'endloser'],
+        path: ['verschlungener', 'einladender', 'spannender', 'neuer'],
+        cactus: ['stacheliger', 'zäher', 'trotziger', 'cooler'],
+    };
+
+    /** @type {Object<string, string[]>} */
+    var REACTIONS = {
+        caps:    ['Das ist FANTASTISCH!', 'MEHR DAVON!', 'Der beste Block ALLER ZEITEN!', 'SO toll!', 'WOW!'],
+        cute:    ['*freu*', '*hüpf*', '*kicher*', '*staun*', 'Oh!', 'Schööön!'],
+        careful: ['Sehr schön gemacht.', 'Ganz sorgfältig, ja.', 'Das passt gut hierhin.', 'Ich bin zufrieden.'],
+        nein:    ['...ist eigentlich gut.', '...naja. Geht so. OK es ist toll.', '...NEIN! Doch. Ja.', '...pfff. Hübsch.'],
+        money:   ['Das bringt Kunden!', 'Wertsteigerung!', 'Cha-ching!', 'Investment!', 'Rendite!'],
+        chaos:   ['SCHNITT! Nochmal! BESSER!', 'Das wird im Film GEIL!', 'KAMERA LÄUFT!', 'Action!'],
+        grumpy:  ['Na toll.', 'Muss das sein?', 'Kann man machen.', 'Hab ich auch mal probiert. War schlecht.'],
+        deal:    ['Interessant...', 'Das hat seinen Preis.', 'Ein fairer Tausch!', 'Hehehehe...', 'Wir kommen ins Geschäft!'],
+        bug:     ['*mampf mampf*', 'Lecker Bug!', 'Nom nom!', 'Noch einen!', 'Der war knusprig!'],
+    };
+
+    /** @type {Array<function>} */
+    var TEMPLATES = [
+        function (npc, adj, mat, react) { return npc.emoji + ' ' + npc.prefix + ' ' + npc.ticks[0] + ' ' + adj + ' ' + mat + '! ' + react; },
+        function (npc, adj, mat, react) { return npc.emoji + ' ' + npc.prefix + ' ' + react + ' ' + adj + ' ' + mat + '!'; },
+        function (npc, adj, mat, react) { return npc.emoji + ' ' + npc.prefix + ' Oh! ' + adj + ' ' + mat + '. ' + npc.ticks[Math.min(1, npc.ticks.length - 1)]; },
+        function (npc, adj, mat, react) { return npc.emoji + ' ' + npc.prefix + ' ' + adj + ' ' + mat + '? ' + react; },
+        function (npc, adj, mat, react) { return npc.emoji + ' ' + npc.prefix + ' ' + npc.ticks[0] + ' Noch mehr ' + mat + '! ' + react; },
+    ];
+
+    /** @type {Array<function>} */
+    var STREAK_COMMENTS = [
+        function (npc, mat, n) { return npc.emoji + ' ' + npc.prefix + ' ' + n + 'x ' + mat + ' am Stück? ' + npc.ticks[0]; },
+        function (npc, mat, n) { return npc.emoji + ' ' + npc.prefix + ' Noch mehr ' + mat + '?! Das wird ja eine ' + mat + '-Stadt!'; },
+        function (npc, mat, n) { return npc.emoji + ' ' + npc.prefix + ' ' + n + ' ' + mat + '! Jemand hat einen Plan!'; },
+    ];
+
+    window.INSEL_NPC_DATA = {
+        NPC_VOICES: NPC_VOICES,
+        MAT_ADJECTIVES: MAT_ADJECTIVES,
+        REACTIONS: REACTIONS,
+        TEMPLATES: TEMPLATES,
+        STREAK_COMMENTS: STREAK_COMMENTS,
+    };
+})();


### PR DESCRIPTION
## Sprint 25 — Zellteilung S25-3

### Was

`NPC_VOICES`, `MAT_ADJECTIVES`, `REACTIONS`, `TEMPLATES`, `STREAK_COMMENTS` aus `game.js` extrahiert → `npc-data.js` (87 LOC) als `window.INSEL_NPC_DATA`.

- game.js: **4977 → 4918 LOC** (59 LOC weniger)
- Muster wie `stories.js`: IIFE, `'use strict'`, `window.INSEL_*`
- State (`lastMaterial`, `materialStreak`) bleibt in game.js
- `tsc --noEmit` grün

### Sprint 25 komplett

| Item | Status |
|------|--------|
| S25-1 Palette = Instrument | ✅ |
| S25-2 Höhle = Dungeon | ✅ (Phantom-Open, war in #181) |
| S25-3 game.js Zellteilung | ✅ |

https://claude.ai/code/session_01CFGyCEFddBqDREbshfh1Es