### PR TITLE
Abstand zählt: Emergenz statt Prescription

### DIFF
--- a/src/core/game.js
+++ b/src/core/game.js
@@ -3105,54 +3105,12 @@
     // Spontaner Zerfall: ~5% pro Sekunde → mittlere Wartezeit ~20s
     const TAO_DECAY_CHANCE = 0.05;
 
-    // Abstand zählt: Distanz zum nächsten Tao bestimmt Zerfallsprodukte.
-    // Mappt auf die drei fundamentalen Kräfte und ihre Reichweiten:
-    //   Nah  (1-2): Starke Kraft → schwere Quarks (Charm, Strange)
-    //   Mitte(3-5): Elektroschwach → Leptonen (Elektron, Neutrino)
-    //   Weit (6+):  Elektromagnetisch/Standard → Yin+Yang (leichteste Teilchen)
-    //   Allein:     Reiner Symmetriebruch → Yin+Yang
-
-    // Zerfallsprodukte nach Distanzband
-    const DECAY_NEAR = [
-        // Starke Kraft: schwere Quarks direkt
-        { a: 'charm',   b: 'strange',  weight: 3, msg: '💫🌀 Nahzerfall! Starke Kraft → Charm + Strange!' },
-        { a: 'yin',     b: 'yang',     weight: 2, msg: '☯️ Nahzerfall → Yin + Yang (Grundzustand)' },
-        { a: 'yang',    b: 'yang',     weight: 1, msg: '⚡⚡ Nahzerfall! Zwei Yang — Pauli-Druck!' },
-    ];
-    const DECAY_MID = [
-        // Elektroschwache Kraft: Leptonen + leichte Quarks
-        { a: 'electron', b: 'neutrino', weight: 3, msg: '🔹👻 Elektroschwacher Zerfall → Elektron + Neutrino!' },
-        { a: 'yin',      b: 'yang',     weight: 3, msg: '☯️ Mittlerer Zerfall → Yin + Yang' },
-        { a: 'electron', b: 'yin',      weight: 1, msg: '🔹⚫ Elektron + Yin — Neutrino-Einfang möglich!' },
-    ];
-    const DECAY_FAR = [
-        // EM: unendliche Reichweite, leichteste Teilchen
-        { a: 'yin',  b: 'yang',  weight: 5, msg: '☯️ Fernzerfall → Yin + Yang' },
-        { a: 'qi',   b: 'qi',   weight: 1, msg: '💛💛 Weit entfernt! Qi × Qi — Photon möglich!' },
-    ];
-
-    function findNearestTaoDistance(r, c) {
-        let minDist = Infinity;
-        for (let rr = 0; rr < ROWS; rr++) {
-            for (let cc = 0; cc < COLS; cc++) {
-                if (rr === r && cc === c) continue;
-                if (grid[rr][cc] !== 'tao') continue;
-                const dist = Math.abs(rr - r) + Math.abs(cc - c); // Manhattan
-                if (dist < minDist) minDist = dist;
-            }
-        }
-        return minDist;
-    }
-
-    function pickWeightedDecay(table) {
-        const total = table.reduce((s, e) => s + e.weight, 0);
-        let roll = Math.random() * total;
-        for (const entry of table) {
-            roll -= entry.weight;
-            if (roll <= 0) return entry;
-        }
-        return table[table.length - 1];
-    }
+    // Abstand zählt — aber nicht durch verschiedene Zerfallsprodukte.
+    // Tao zerfällt IMMER zu Yin+Yang. Punkt.
+    // Der Abstand wirkt über die Automerge-Physik:
+    //   Nah  → hohe Dichte → viele Nachbarn → Kettenreaktionen (Quarks, Leptonen, Bosonen)
+    //   Weit → niedrige Dichte → isolierte Paare → bleiben Yin+Yang
+    // Eine Mechanik. Keine zwei. Emergenz statt Prescription.
 
     function tickTaoDecay() {
         let hasTao = false;
@@ -3162,37 +3120,24 @@
                 hasTao = true;
                 if (Math.random() > TAO_DECAY_CHANCE) continue;
 
-                // Abstand zählt: Distanz zum nächsten Tao → Kraftband
-                const dist = findNearestTaoDistance(r, c);
-                let decayTable;
-                let coupling;
-                if (dist <= 2) {
-                    decayTable = DECAY_NEAR;
-                    coupling = 'stark';
-                } else if (dist <= 5) {
-                    decayTable = DECAY_MID;
-                    coupling = 'elektroschwach';
-                } else {
-                    decayTable = DECAY_FAR;
-                    coupling = 'elektromagnetisch';
-                }
-
-                const decay = pickWeightedDecay(decayTable);
-
                 // Freie Nachbarzelle finden
                 const isEdge = Math.random() < 0.5;
                 const free = findFreeNeighbor(r, c, isEdge ? EDGE_DIRS : CORNER_DIRS)
                           || findFreeNeighbor(r, c, isEdge ? CORNER_DIRS : EDGE_DIRS);
                 if (!free) continue; // Kein Platz → kein Zerfall
 
-                // ZERFALL! Symmetriebrechung.
+                // ZERFALL! Symmetriebrechung. Immer Yin+Yang.
+                const coupling = isEdge ? 'stark' : 'schwach';
                 const [yr, yc] = free;
-                grid[r][c] = decay.a;
-                grid[yr][yc] = decay.b;
+                grid[r][c] = 'yin';
+                grid[yr][yc] = 'yang';
 
-                logGenesis({ type: 'decay', from: 'tao', results: [decay.a, decay.b], cells: [[r,c],[yr,yc]], coupling, distance: dist });
+                logGenesis({ type: 'decay', from: 'tao', results: ['yin', 'yang'], cells: [[r,c],[yr,yc]], coupling });
 
-                showToast(decay.msg);
+                const msg = isEdge
+                    ? '☯️ → ⚫⚪ Kante!'
+                    : '☯️ → ⚫⚪ Ecke!';
+                showToast(msg);
                 soundCraft();
                 EFFECTS.addPlaceAnimation(r, c);
                 EFFECTS.addPlaceAnimation(yr, yc);


### PR DESCRIPTION
## Summary\n\n- Tao zerfällt **immer** zu Yin+Yang — keine distanzabhängigen Zerfallstabellen\n- Abstand wirkt durch Automerge-Physik: nah = dicht = Kettenreaktion, weit = isoliert = Stille\n- Eine Mechanik statt zwei. 70 Zeilen gelöscht.\n\n## Warum\n\nErster Versuch hatte DECAY_NEAR/MID/FAR-Tabellen die verschiedene Teilchen je nach Tao-Abstand produzierten. Das war eine zweite Mechanik für ein Problem das Automerge schon löst. Dichte = Reaktionswahrscheinlichkeit — wie im echten Universum.\n\n## Test plan\n- [ ] Zwei Taos nah platzieren → dichter Zerfall → Automerge-Ketten (Qi, Charm, Strange...)\n- [ ] Ein Tao allein platzieren → isoliertes Yin+Yang → keine Kettenreaktion\n- [ ] Mehrere Taos weit auseinander → vereinzelte Paare, wenig Merges\n\nhttps://claude.ai/code/session_012YVvZEXDNro2QjoyGqTT3z