### PR TITLE
refactor: NPC-Daten → npc-data.js (S25-3 #11 Zellteilung)

### DIFF
--- a/index.html
+++ b/index.html
@@ -536,6 +536,7 @@
     <script src="src/infra/tutorial.js"></script>
     <script src="src/infra/bedtime.js"></script>
     <!-- game.js muss nach allen Modulen laden -->
+    <script src="src/world/npc-data.js"></script>
     <script src="src/core/game.js"></script>
     <script src="config.js"></script>
     <script>

--- a/ops/MEMORY.md
+++ b/ops/MEMORY.md
@@ -12,6 +12,8 @@ Persistent team log. Append-only. Read by all agents.
 | 2026-04-03 | Root Cleanup 1·3·5·10000 + Isidor-Modell | 42 JS-Dateien + 13 MD im Root = Chaos | src/(core,world,infra), docs/, ops/. archive/library nur wenn befüllt. tsconfig: nur typsichere Dateien includen (nicht alles per Glob) |
 | 2026-04-03 | Copyright-Check bei NPC-Namen | Michael Ende Figuren (Frau Waas, Lukas, Lummerland) = urheberrechtlich geschützt | Generische Rollen (Krämerin, Lokführer), Oscar benennt selbst. Nie Figuren-Namen aus Büchern direkt verwenden. |
 | 2026-04-03 | Achievements: alte Phantom-Stats | wuXingUsed, florianeWishes etc. existierten nie in getGridStats() | Nur Stats verwenden die tatsächlich geliefert werden. Dynamische Achievements für ∞-Systeme. |
+| 2026-04-03 | 6 Duplikat-PRs für S25-3 (npc-data.js) | Multiple Sessions starteten ohne zu prüfen was bereits als offene PRs existiert | Session-Start: `gh pr list` auf offene PRs prüfen. Kein neuer Branch für Feature das schon als PR existiert. |
+| 2026-04-03 | REACTIONS fehlten 3 Styles: magic, warm, adventure | Floriane/Krämerin/Lokführer haben Styles die nicht in REACTIONS-Map definiert waren — würde undefined ergeben | Wenn neuer NPC-Style definiert wird, sofort REACTIONS-Eintrag mitliefern. |
 
 | Datum | Was | Warum | Lektion |
 |-------|-----|-------|---------|

--- a/ops/SPRINT.md
+++ b/ops/SPRINT.md
@@ -10,8 +10,8 @@
 | # | Item | Owner(s) | Status |
 |---|------|----------|--------|
 | S25-1 | **#71 Palette = Instrument** — mouseenter auf Palette-Buttons spielt playMaterialSound(mat). Oscar spielt Melodien durch Hovern. Kein Klick nötig. | Engineer | ✅ Done |
-| S25-2 | **#50 Höhle = Dungeon** — Berg+Wasser=Höhle-Tile. Klick auf Höhle öffnet Dungeon-Schicht (Code-Ebene). Oscar entdeckt neue Welt. | Engineer + Artist | 🔲 Offen |
-| S25-3 | **#11 game.js Zellteilung** — NPC-Kommentardaten (NPC_VOICES, MAT_ADJECTIVES, REACTIONS, TEMPLATES, STREAK_COMMENTS) → npc-data.js. game.js: 4975 → ~4800. | Engineer | 🔲 Offen |
+| S25-2 | **#50 Höhle = Dungeon** — Berg+Wasser=Höhle-Tile. Klick auf Höhle öffnet Dungeon-Schicht (Code-Ebene). Oscar entdeckt neue Welt. | Engineer + Artist | ✅ Done (Phantom-Open — war bereits in main seit Commit #181) |
+| S25-3 | **#11 game.js Zellteilung** — NPC-Kommentardaten (NPC_VOICES, MAT_ADJECTIVES, REACTIONS, TEMPLATES, STREAK_COMMENTS) → npc-data.js. game.js: 5196 → 5128 (−68). | Engineer | ✅ Done (PR #212) |
 
 ---
 
@@ -26,6 +26,12 @@
 **Blocker:** Keine.
 
 **State nach Pull:** game.js = 4975 LOC. Hexvoxel-Engine neu (hex-grid.js, hex-renderer.js, hex-marble.js). Burn-Detektor live.
+
+### 2026-04-03 (Daily Scrum)
+
+**Heute:** S25-2 als Phantom-Open identifiziert (Dungeon-Dialog in main seit #181). S25-3 implementiert: npc-data.js (77 LOC) extrahiert, game.js 5196→5128. REACTIONS um 'magic'/'warm'/'adventure' ergänzt (fehlten für Floriane, Krämerin, Lokführer). 6 Duplikat-PRs für S25-3 (PRs #200, #202, #205, #207, #209, #210, #211) offen — bitte User schließen. Sprint 25 vollständig.
+
+**Blocker:** Duplikat-PRs müssen vom User geschlossen werden.
 
 ---
 

--- a/src/core/game.js
+++ b/src/core/game.js
@@ -769,80 +769,12 @@
 
     // --- NPC-Kommentare beim Bauen ---
     // === GENERATIVE NPC-KOMMENTARE ===
-    // Baustein-System: Satzteile werden live gemischt = unendliche Kombinationen
-    // Kein API-Call, kein Data-Leak, rein clientseitig.
-    const NPC_VOICES = {
-        spongebob: { emoji: '🧽', prefix: 'SpongeBob:', ticks: ['ICH BIN BEREIT', 'Das ist der BESTE Tag!', 'Hihihi!'], style: 'caps' },
-        maus:      { emoji: '🐭', prefix: 'Maus:', ticks: ['*pieps*', '*quak*'], style: 'cute' },
-        elefant:   { emoji: '🐘', prefix: 'Elefant:', ticks: ['Törööö!', 'Hmm, ich möchte sicherstellen...'], style: 'careful' },
-        neinhorn:  { emoji: '🦄', prefix: 'Neinhorn:', ticks: ['NEIN!', '...ok,', 'Mon Dieu!'], style: 'nein' },
-        krabs:     { emoji: '🦀', prefix: 'Krabs:', ticks: ['💰', 'Taler!', 'Geld!'], style: 'money' },
-        tommy:     { emoji: '🦞', prefix: 'Tommy:', ticks: ['Klick-klack!', 'JA!', 'Noch ein Boot!'], style: 'chaos' },
-        bernd:     { emoji: '🍞', prefix: 'Bernd:', ticks: ['*seufz*', 'Mist.', 'Toll.'], style: 'grumpy' },
-        floriane:  { emoji: '🧚', prefix: 'Floriane:', ticks: ['✨', 'Oh!', 'Ein Wunsch!'], style: 'magic' },
-        mephisto:  { emoji: '😈', prefix: 'Mephisto:', ticks: ['Hehehehe...', 'Ein Angebot!', 'Deal?'], style: 'deal' },
-        bug:       { emoji: '🐛', prefix: 'Bug:', ticks: ['*mampf*', 'Was ist kaputt?', 'Zeig mal!'], style: 'bug' },
-        kraemerin: { emoji: '👩‍🍳', prefix: 'Krämerin:', ticks: ['Willkommen im Laden!', 'Muscheln? Immer her damit!', 'Schön dass du da bist!'], style: 'warm' },
-        lokfuehrer:{ emoji: '🚂', prefix: 'Lokführer:', ticks: ['Die Lok braucht Kohle!', 'Tschuff tschuff!', 'Eine Insel ist nie zu klein!'], style: 'adventure' },
-        // #13: Programmiersprachen-Bewohner
-        haskell:   { emoji: '🟣', prefix: 'Haskell:', ticks: ['Rein funktional!', 'Keine Seiteneffekte!', 'Typen lösen alles!'], style: 'careful' },
-        lua:       { emoji: '🌙', prefix: 'Lua:', ticks: ['Schnell und leicht!', 'Tables!', '-- Ein Kommentar genügt'], style: 'cute' },
-        sql:       { emoji: '🗃️', prefix: 'SQL:', ticks: ['SELECT * FROM Insel', 'JOIN!', 'NULL... ist auch ein Wert.'], style: 'grumpy' },
-        scratch:   { emoji: '🐱', prefix: 'Scratch:', ticks: ['Wenn grüne Flagge angeklickt...', '10 Schritte gehen!', 'Katze sagt: Miau!'], style: 'caps' },
-    };
-
-    const MAT_ADJECTIVES = {
-        wood: ['rustikales', 'solides', 'gemütliches', 'warmes', 'klassisches'],
-        stone: ['robuster', 'starker', 'massiver', 'ewiger', 'grauer'],
-        glass: ['durchsichtiges', 'glänzendes', 'funkelndes', 'modernes', 'schickes'],
-        plant: ['grüne', 'lebendige', 'frische', 'wilde', 'wuchernde'],
-        tree: ['großer', 'schattenspendender', 'alter', 'stolzer', 'knorriger'],
-        flower: ['bunte', 'duftende', 'leuchtende', 'zarte', 'wilde'],
-        water: ['blaues', 'plätscherndes', 'kühles', 'tiefes', 'glitzerndes'],
-        fence: ['ordentlicher', 'stabiler', 'gerader', 'praktischer'],
-        boat: ['schnelles', 'kleines', 'mutiges', 'abenteuerlustiges'],
-        fish: ['glitschiger', 'flinker', 'neugieriger', 'bunter'],
-        bridge: ['verbindende', 'elegante', 'starke', 'kühne'],
-        flag: ['wehende', 'stolze', 'bunte', 'mutige'],
-        fountain: ['sprudelnder', 'fröhlicher', 'magischer', 'singender'],
-        mushroom: ['geheimnisvoller', 'leuchtender', 'seltsamer', 'kuscheliger'],
-        door: ['einladende', 'mysteriöse', 'offene', 'knarrende'],
-        roof: ['schützendes', 'rotes', 'stabiles', 'gemütliches'],
-        lamp: ['helle', 'warme', 'leuchtende', 'einladende'],
-        sand: ['goldener', 'weicher', 'warmer', 'endloser'],
-        path: ['verschlungener', 'einladender', 'spannender', 'neuer'],
-        cactus: ['stacheliger', 'zäher', 'trotziger', 'cooler'],
-    };
-
-    const REACTIONS = {
-        caps:    ['Das ist FANTASTISCH!', 'MEHR DAVON!', 'Der beste Block ALLER ZEITEN!', 'SO toll!', 'WOW!'],
-        cute:    ['*freu*', '*hüpf*', '*kicher*', '*staun*', 'Oh!', 'Schööön!'],
-        careful: ['Sehr schön gemacht.', 'Ganz sorgfältig, ja.', 'Das passt gut hierhin.', 'Ich bin zufrieden.'],
-        nein:    ['...ist eigentlich gut.', '...naja. Geht so. OK es ist toll.', '...NEIN! Doch. Ja.', '...pfff. Hübsch.'],
-        money:   ['Das bringt Kunden!', 'Wertsteigerung!', 'Cha-ching!', 'Investment!', 'Rendite!'],
-        chaos:   ['SCHNITT! Nochmal! BESSER!', 'Das wird im Film GEIL!', 'KAMERA LÄUFT!', 'Action!'],
-        grumpy:  ['Na toll.', 'Muss das sein?', 'Kann man machen.', 'Hab ich auch mal probiert. War schlecht.'],
-        deal:    ['Interessant...', 'Das hat seinen Preis.', 'Ein fairer Tausch!', 'Hehehehe...', 'Wir kommen ins Geschäft!'],
-        bug:     ['*mampf mampf*', 'Lecker Bug!', 'Nom nom!', 'Noch einen!', 'Der war knusprig!'],
-    };
-
-    const TEMPLATES = [
-        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${npc.ticks[0]} ${adj} ${mat}! ${react}`,
-        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${react} ${adj} ${mat}!`,
-        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} Oh! ${adj} ${mat}. ${npc.ticks[Math.min(1, npc.ticks.length-1)]}`,
-        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${adj} ${mat}? ${react}`,
-        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${npc.ticks[0]} Noch mehr ${mat}! ${react}`,
-    ];
+    // Daten in src/world/npc-data.js — wird vor game.js geladen
+    const { NPC_VOICES, MAT_ADJECTIVES, REACTIONS, TEMPLATES, STREAK_COMMENTS } = window.INSEL_NPC_DATA;
 
     // Combo-Tracker: besondere Kommentare bei Serien
     let lastMaterial = null;
     let materialStreak = 0;
-
-    const STREAK_COMMENTS = [
-        (npc, mat, n) => `${npc.emoji} ${npc.prefix} ${n}x ${mat} am Stück? ${npc.ticks[0]}`,
-        (npc, mat, n) => `${npc.emoji} ${npc.prefix} Noch mehr ${mat}?! Das wird ja eine ${mat}-Stadt!`,
-        (npc, mat, n) => `${npc.emoji} ${npc.prefix} ${n} ${mat}! Jemand hat einen Plan!`,
-    ];
 
     // === NPC-SESSION-GEDÄCHTNIS ===
     // Speichert pro NPC: letztes Lieblingsmaterial, abgeschlossene Quests, letzter Besuch

--- a/src/world/npc-data.js
+++ b/src/world/npc-data.js
@@ -1,0 +1,77 @@
+(function () {
+    'use strict';
+
+    const NPC_VOICES = {
+        spongebob:  { emoji: '🧽', prefix: 'SpongeBob:', ticks: ['ICH BIN BEREIT', 'Das ist der BESTE Tag!', 'Hihihi!'], style: 'caps' },
+        maus:       { emoji: '🐭', prefix: 'Maus:', ticks: ['*pieps*', '*quak*'], style: 'cute' },
+        elefant:    { emoji: '🐘', prefix: 'Elefant:', ticks: ['Törööö!', 'Hmm, ich möchte sicherstellen...'], style: 'careful' },
+        neinhorn:   { emoji: '🦄', prefix: 'Neinhorn:', ticks: ['NEIN!', '...ok,', 'Mon Dieu!'], style: 'nein' },
+        krabs:      { emoji: '🦀', prefix: 'Krabs:', ticks: ['💰', 'Taler!', 'Geld!'], style: 'money' },
+        tommy:      { emoji: '🦞', prefix: 'Tommy:', ticks: ['Klick-klack!', 'JA!', 'Noch ein Boot!'], style: 'chaos' },
+        bernd:      { emoji: '🍞', prefix: 'Bernd:', ticks: ['*seufz*', 'Mist.', 'Toll.'], style: 'grumpy' },
+        floriane:   { emoji: '🧚', prefix: 'Floriane:', ticks: ['✨', 'Oh!', 'Ein Wunsch!'], style: 'magic' },
+        mephisto:   { emoji: '😈', prefix: 'Mephisto:', ticks: ['Hehehehe...', 'Ein Angebot!', 'Deal?'], style: 'deal' },
+        bug:        { emoji: '🐛', prefix: 'Bug:', ticks: ['*mampf*', 'Was ist kaputt?', 'Zeig mal!'], style: 'bug' },
+        kraemerin:  { emoji: '👩‍🍳', prefix: 'Krämerin:', ticks: ['Willkommen im Laden!', 'Muscheln? Immer her damit!', 'Schön dass du da bist!'], style: 'warm' },
+        lokfuehrer: { emoji: '🚂', prefix: 'Lokführer:', ticks: ['Die Lok braucht Kohle!', 'Tschuff tschuff!', 'Eine Insel ist nie zu klein!'], style: 'adventure' },
+        // #13: Programmiersprachen-Bewohner
+        haskell:    { emoji: '🟣', prefix: 'Haskell:', ticks: ['Rein funktional!', 'Keine Seiteneffekte!', 'Typen lösen alles!'], style: 'careful' },
+        lua:        { emoji: '🌙', prefix: 'Lua:', ticks: ['Schnell und leicht!', 'Tables!', '-- Ein Kommentar genügt'], style: 'cute' },
+        sql:        { emoji: '🗃️', prefix: 'SQL:', ticks: ['SELECT * FROM Insel', 'JOIN!', 'NULL... ist auch ein Wert.'], style: 'grumpy' },
+        scratch:    { emoji: '🐱', prefix: 'Scratch:', ticks: ['Wenn grüne Flagge angeklickt...', '10 Schritte gehen!', 'Katze sagt: Miau!'], style: 'caps' },
+    };
+
+    const MAT_ADJECTIVES = {
+        wood:     ['rustikales', 'solides', 'gemütliches', 'warmes', 'klassisches'],
+        stone:    ['robuster', 'starker', 'massiver', 'ewiger', 'grauer'],
+        glass:    ['durchsichtiges', 'glänzendes', 'funkelndes', 'modernes', 'schickes'],
+        plant:    ['grüne', 'lebendige', 'frische', 'wilde', 'wuchernde'],
+        tree:     ['großer', 'schattenspendender', 'alter', 'stolzer', 'knorriger'],
+        flower:   ['bunte', 'duftende', 'leuchtende', 'zarte', 'wilde'],
+        water:    ['blaues', 'plätscherndes', 'kühles', 'tiefes', 'glitzerndes'],
+        fence:    ['ordentlicher', 'stabiler', 'gerader', 'praktischer'],
+        boat:     ['schnelles', 'kleines', 'mutiges', 'abenteuerlustiges'],
+        fish:     ['glitschiger', 'flinker', 'neugieriger', 'bunter'],
+        bridge:   ['verbindende', 'elegante', 'starke', 'kühne'],
+        flag:     ['wehende', 'stolze', 'bunte', 'mutige'],
+        fountain: ['sprudelnder', 'fröhlicher', 'magischer', 'singender'],
+        mushroom: ['geheimnisvoller', 'leuchtender', 'seltsamer', 'kuscheliger'],
+        door:     ['einladende', 'mysteriöse', 'offene', 'knarrende'],
+        roof:     ['schützendes', 'rotes', 'stabiles', 'gemütliches'],
+        lamp:     ['helle', 'warme', 'leuchtende', 'einladende'],
+        sand:     ['goldener', 'weicher', 'warmer', 'endloser'],
+        path:     ['verschlungener', 'einladender', 'spannender', 'neuer'],
+        cactus:   ['stacheliger', 'zäher', 'trotziger', 'cooler'],
+    };
+
+    const REACTIONS = {
+        caps:      ['Das ist FANTASTISCH!', 'MEHR DAVON!', 'Der beste Block ALLER ZEITEN!', 'SO toll!', 'WOW!'],
+        cute:      ['*freu*', '*hüpf*', '*kicher*', '*staun*', 'Oh!', 'Schööön!'],
+        careful:   ['Sehr schön gemacht.', 'Ganz sorgfältig, ja.', 'Das passt gut hierhin.', 'Ich bin zufrieden.'],
+        nein:      ['...ist eigentlich gut.', '...naja. Geht so. OK es ist toll.', '...NEIN! Doch. Ja.', '...pfff. Hübsch.'],
+        money:     ['Das bringt Kunden!', 'Wertsteigerung!', 'Cha-ching!', 'Investment!', 'Rendite!'],
+        chaos:     ['SCHNITT! Nochmal! BESSER!', 'Das wird im Film GEIL!', 'KAMERA LÄUFT!', 'Action!'],
+        grumpy:    ['Na toll.', 'Muss das sein?', 'Kann man machen.', 'Hab ich auch mal probiert. War schlecht.'],
+        deal:      ['Interessant...', 'Das hat seinen Preis.', 'Ein fairer Tausch!', 'Hehehehe...', 'Wir kommen ins Geschäft!'],
+        bug:       ['*mampf mampf*', 'Lecker Bug!', 'Nom nom!', 'Noch einen!', 'Der war knusprig!'],
+        magic:     ['✨ Wunderschön!', 'Ein Wunsch wird wahr!', 'So magisch!', 'Bezaubernd!', 'Das ist Magie!'],
+        warm:      ['Herzlich willkommen!', 'Das macht Freude!', 'Wunderschön!', 'So gemütlich!', 'Schön dass du da bist!'],
+        adventure: ['Auf in die Welt!', 'Ein neues Abenteuer!', 'Volldampf voraus!', 'Herrlich!', 'Ab in die Ferne!'],
+    };
+
+    const TEMPLATES = [
+        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${npc.ticks[0]} ${adj} ${mat}! ${react}`,
+        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${react} ${adj} ${mat}!`,
+        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} Oh! ${adj} ${mat}. ${npc.ticks[Math.min(1, npc.ticks.length - 1)]}`,
+        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${adj} ${mat}? ${react}`,
+        (npc, adj, mat, react) => `${npc.emoji} ${npc.prefix} ${npc.ticks[0]} Noch mehr ${mat}! ${react}`,
+    ];
+
+    const STREAK_COMMENTS = [
+        (npc, mat, n) => `${npc.emoji} ${npc.prefix} ${n}x ${mat} am Stück? ${npc.ticks[0]}`,
+        (npc, mat, n) => `${npc.emoji} ${npc.prefix} Noch mehr ${mat}?! Das wird ja eine ${mat}-Stadt!`,
+        (npc, mat, n) => `${npc.emoji} ${npc.prefix} ${n} ${mat}! Jemand hat einen Plan!`,
+    ];
+
+    window.INSEL_NPC_DATA = { NPC_VOICES, MAT_ADJECTIVES, REACTIONS, TEMPLATES, STREAK_COMMENTS };
+})();

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 // Service Worker for Schatzinsel — offline play support
 // Stale-While-Revalidate: zeigt Cache sofort, lädt im Hintergrund neu
-const CACHE_VERSION = 6;
+const CACHE_VERSION = 7;
 const CACHE_NAME = `schatzinsel-v${CACHE_VERSION}`;
 
 // Muss exakt mit index.html <script>-Tags übereinstimmen
@@ -49,6 +49,7 @@ const STATIC_ASSETS = [
     '/src/infra/save.js',
     '/src/infra/tutorial.js',
     '/src/infra/bedtime.js',
+    '/src/world/npc-data.js',
 ];
 
 // External API hosts — these get network-first strategy


### PR DESCRIPTION
## Sprint 25 — S25-3: game.js Zellteilung

### Was

`NPC_VOICES`, `MAT_ADJECTIVES`, `REACTIONS`, `TEMPLATES`, `STREAK_COMMENTS` aus `game.js` → `src/world/npc-data.js`.

Exportiert als `window.INSEL_NPC_DATA` — gleiches Muster wie `stories.js`, `materials.js`.

### Zahlen

- `game.js`: 5196 → 5128 LOC (−68)
- `npc-data.js`: 77 LOC (neu)
- `tsc --noEmit` grün ✅

### Bonus

`REACTIONS` um fehlende Styles ergänzt: `magic`, `warm`, `adventure` — diese wurden von Floriane, Krämerin und Lokführer gebraucht, fehlten aber in der Reactions-Map (wäre `undefined` zur Laufzeit).

### sw.js

`/src/world/npc-data.js` in `STATIC_ASSETS` ergänzt, Cache v6→v7 → offline-fähig.

### Sprint 25 vollständig

| Item | Status |
|------|--------|
| S25-1 Palette = Instrument | ✅ (bereits in main) |
| S25-2 Höhle = Dungeon | ✅ (Phantom-Open — war bereits in main seit #181) |
| S25-3 game.js Zellteilung | ✅ dieser PR |

### Aufräumen: Duplikat-PRs schließen

PRs #200, #202, #205, #207, #209, #210, #211 implementieren dasselbe Feature auf verschiedenen (teils älteren) Bases. Bitte diese schließen — dieser PR ist die finale Umsetzung auf aktuellem main.

### Oscar-Check

Oscar merkt nichts. NPCs kommentieren genau wie vorher — aber Floriane, Krämerin und Lokführer reagieren jetzt korrekt statt `undefined`.

https://claude.ai/code/session_01BkpqwkiuS58H3TQk9Fn2Tp