### PR TITLE
Feynman: Discovery/Craft Ratio Metrik

### DIFF
--- a/src/core/game.js
+++ b/src/core/game.js
@@ -409,6 +409,7 @@
         if (!npc) return;
         // Memory: Besuch registrieren
         touchNpcMemory(npcId);
+        trackEvent('discovery', { type: 'npc', npc: npcId });
         const quest = window.questSystem.getAvailable(npcId);
         const active = window.questSystem.getActive().find(q => q.npc === npcId);
         if (active) {
@@ -482,7 +483,7 @@
             if (!_dungeonVisited.includes(key)) {
                 _dungeonVisited.push(key);
                 localStorage.setItem('insel-dungeon-visited', JSON.stringify(_dungeonVisited));
-                if (trackEvent) trackEvent('dungeon_level', { level: key });
+                if (trackEvent) { trackEvent('dungeon_level', { level: key }); trackEvent('discovery', { type: 'dungeon', level: key }); }
             }
         });
 

--- a/src/infra/analytics.js
+++ b/src/infra/analytics.js
@@ -125,6 +125,7 @@
             postcards: events.filter(e => e.e === 'postcard').length,
             // Neutrino-Metrik: Crafting- und Chat-Events zählen
             crafts_count: events.filter(e => e.e === 'craft' || e.e === 'quick-craft' || e.e === 'llm-craft').length,
+            discovery_count: events.filter(e => e.e === 'discovery' || e.e === 'dungeon_level' || e.e === 'easter_egg' || e.e === 'hoerspiel' || e.e === 'code_zauber').length,
             chats_count: events.filter(e => e.e === 'chat' || e.e === 'npc_chat').length,
         };
     }
@@ -167,6 +168,8 @@
                     (data.materials > 3 ? 10 : 0)
                 )),
                 neutrino_score: neutrinoScore,
+                discovery_count: data.discovery_count || 0,
+                discovery_craft_ratio: crafts > 0 ? Math.round((data.discovery_count || 0) / crafts * 10) / 10 : null,
             }));
         } catch (e) { /* kein Tracking > kaputtes Tracking */ }
     }


### PR DESCRIPTION
## Summary

- NPC-Interaktionen als `discovery`-Events tracken
- Neue Metrik: `discovery_craft_ratio` = discovery_count / crafts_count
- Ziel: Ratio >3 (MediaMarkt-Umkehr: 7 Kassen/1 Service → 1 Craft/7 Discoveries)
- Discovery-Events: NPC-Klick, Dungeon-Level, Easter Egg, Hörspiel, Code-Zauber
- Ratio wird bei Session-Ende an D1 gesendet

## Test plan

- [ ] NPC antippen → `discovery`-Event in analytics
- [ ] Session beenden → `discovery_craft_ratio` im Webhook-Payload
- [ ] Ratio null wenn keine Crafts (Division by zero)

https://claude.ai/code/session_01HgzQFocEtqhof8CZ646jov