### PR TITLE
Distribution: itch.io PWYW + Stripe Vorbereitung

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -1,0 +1,90 @@
+# Distribution — schatzinsel.app
+
+Stand: 2026-04-04 · Einstein-Entscheidung
+
+---
+
+## Strategie
+
+**Reibung erzeugt Wärme.** Pay What You Want = maximale Information bei minimaler Hürde.
+Zahlungsbereitschaft ist die einzige Metrik die nicht lügt.
+
+---
+
+## Kanäle — Priorisiert
+
+### P0: itch.io (PWYW) — Heute
+
+| Aspekt | Details |
+|--------|---------|
+| Modell | Pay What You Want (ab 0€) |
+| Gebühr | 0-10% (wir wählen) |
+| Format | HTML5 ZIP (216 KB) |
+| Review | Keiner |
+| Aufwand | 1 Stunde |
+| Status | ZIP bereit (`/tmp/schatzinsel-itch.zip`) |
+
+**Upload-Schritte (User):**
+1. https://itch.io/game/new
+2. Title: "Schatzinsel — Bau deine Insel"
+3. Kind: HTML5
+4. Pricing: "No payments" → "Donations" oder "Pay what you want"
+5. Upload: `schatzinsel-itch.zip`
+6. "This file will be played in the browser" ✅
+7. Viewport: 1280×720
+8. Fullscreen button ✅
+9. SharedArrayBuffer support: nicht nötig
+
+### P1: schatzinsel.app + Stripe PWYW — Diese Woche
+
+| Aspekt | Details |
+|--------|---------|
+| Modell | "Unterstütze das Spiel" Button mit freiem Betrag |
+| Gebühr | 2.9% + 0.25€ (Stripe) |
+| Hardware | SumUp POS Terminal (gekauft) |
+| MCP | Stripe MCP für Integration (User-Setup) |
+| Aufwand | 1 Tag |
+
+**Vorbereitung (Team):**
+- Stripe MCP Config bereit (wartet auf User-Setup)
+- PWYW-Button Design (Rams)
+- Copy (Ogilvy): kein "Spende" — sondern "Was ist dir das wert?"
+
+### Kill: Steam — Nicht vor Spielplatztest
+
+| Aspekt | Details |
+|--------|---------|
+| Kosten | 100 USD + 30% Umsatz |
+| Aufwand | 1 Woche + Electron Wrapper |
+| Bedingung | 7/10 Kinder setzen Block in <10s |
+| Status | ❌ Gesperrt bis Spielplatztest |
+
+---
+
+## SumUp POS
+
+Terminal gekauft. Einsatz: Live-Events, Spielplatztest, Messen.
+Kombination mit Stripe für einheitliches Payment-Backend.
+
+---
+
+## Metriken (Feynman trackt)
+
+| Metrik | Kanal | Bedeutung |
+|--------|-------|-----------|
+| PWYW Durchschnitt | itch.io | Wahrgenommener Wert |
+| PWYW > 0€ Anteil | itch.io | Conversion |
+| Stripe Spenden/Monat | schatzinsel.app | Wiederkehrendes Commitment |
+| Discovery/Craft Ratio | Alle | >3 = genug Entdeckung |
+
+---
+
+## Anchor-Pricing (Humble Bundle Modell)
+
+| Tier | Betrag | Bonus |
+|------|--------|-------|
+| Frei | 0€ | Vollständiges Spiel |
+| Über Durchschnitt | >Ø | Lummerland freigeschaltet (Easter Egg URL) |
+| Supporter | >5€ | Name als NPC-Gruß ("Hey [Name]!") |
+
+*Noch nicht implementiert. Erst wenn itch.io-Daten da sind.*

--- a/docs/STRIPE_MCP_PREP.md
+++ b/docs/STRIPE_MCP_PREP.md
@@ -1,0 +1,77 @@
+# Stripe MCP — Vorbereitung
+
+Stand: 2026-04-04 · Wartet auf User-Setup
+
+---
+
+## Was das Team vorbereitet hat
+
+1. **DISTRIBUTION.md** — Strategie dokumentiert
+2. **SumUp POS** — Hardware gekauft (User)
+3. **PWYW-Konzept** — Anchor-Pricing definiert
+
+## Was der User tun muss
+
+### 1. Stripe Account
+
+- https://dashboard.stripe.com/register
+- Geschäftstyp: Einzelunternehmen oder Privatperson
+- Land: Deutschland
+- Währung: EUR
+
+### 2. Stripe MCP Server einrichten
+
+```json
+// In Claude Code MCP Settings:
+{
+  "mcpServers": {
+    "stripe": {
+      "command": "npx",
+      "args": ["-y", "@anthropic-ai/mcp-server-stripe"],
+      "env": {
+        "STRIPE_SECRET_KEY": "sk_live_..."
+      }
+    }
+  }
+}
+```
+
+### 3. Stripe Payment Link erstellen (kein Code nötig)
+
+Dashboard → Payment Links → Neu:
+- Produkt: "Schatzinsel — Pay What You Want"
+- Preis: "Kunde entscheidet" (Custom Amount)
+- Minimum: 0€ (oder 1€)
+- Währung: EUR
+- Erfolgsseite: `https://schatzinsel.app/?danke=1`
+
+### 4. Button in schatzinsel.app
+
+Sobald Stripe MCP steht, baut das Team:
+```html
+<a href="https://buy.stripe.com/DEIN_LINK" target="_blank" 
+   class="pwyw-button">
+   Was ist dir das wert?
+</a>
+```
+
+---
+
+## SumUp + Stripe Kombination
+
+| Kanal | Tool | Zweck |
+|-------|------|-------|
+| Online (Browser) | Stripe Payment Link | PWYW im Spiel |
+| Offline (Events) | SumUp POS Terminal | Spielplatz, Messen |
+| Reporting | Stripe Dashboard | Beide Kanäle zusammen |
+
+SumUp kann mit Stripe verbunden werden → einheitliches Reporting.
+
+---
+
+## Nächste Schritte nach User-Setup
+
+1. Team baut PWYW-Button (Designer + Engineer)
+2. `?danke=1` Parameter triggert Danke-Toast im Spiel
+3. Feynman trackt PWYW-Beträge als Metrik
+4. Ogilvy schreibt Copy: "Was ist dir das wert?" (nicht "Spende")


### PR DESCRIPTION
## Summary
- Einstein-Entscheidung: itch.io P0 (PWYW ab 0€), Stripe P1, Steam gesperrt bis Spielplatztest
- DISTRIBUTION.md: Kanäle priorisiert, Anchor-Pricing (Humble Bundle Modell), SumUp POS
- STRIPE_MCP_PREP.md: Account-Setup, MCP-Config, Payment Link Anleitung
- itch.io ZIP bereit (216KB), Upload-Schritte dokumentiert

## Test plan
- [ ] User: itch.io Account + Upload
- [ ] User: Stripe Account erstellen
- [ ] User: Stripe MCP einrichten
- [ ] Team: PWYW-Button nach Stripe-Setup

https://claude.ai/code/session_01HgzQFocEtqhof8CZ646jov