### PR TITLE
Sprint 27 — Muschel-Counter im Inventar + Titel + Backlog-Audit

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Schatzinsel — Außer Text nix gehext</title>
+    <title>Schatzinsel 🏝️</title>
     <meta name="description" content="Baue deine eigene Stadt auf der Insel Java! Ein kostenloses Bauspiel für Kinder — mit Programmiersprachen als Inselbewohnern.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🏝️</text></svg>">
     <link rel="manifest" href="manifest.json">
@@ -218,6 +218,9 @@
 
                 <div class="sidebar-panel" id="panel-inventory">
                     <h2>🎒 Inventar</h2>
+                    <div id="shell-counter" title="Muscheln — Klick für Krabbs Kontor" style="display:none;cursor:pointer;background:#fff8e1;border:1px solid #f9a825;border-radius:6px;padding:4px 10px;margin-bottom:8px;font-size:13px;text-align:center;">
+                        🐚 <span id="shell-count">0</span> Muscheln
+                    </div>
                     <div id="inventory-content">
                         <p class="inv-empty">Ernte Bäume für Holz! ⛏️</p>
                     </div>

--- a/ops/BACKLOG.md
+++ b/ops/BACKLOG.md
@@ -22,12 +22,12 @@ Alles was nicht in eine dieser Kategorien fällt → `ARCHIVE.md`.
 | 11 | **Zellteilung game.js** — NPC-Daten in npc-data.js. game.js: 5196→5128. Grid/Effects noch drin. | Engineer | ✅ Done (S25-3, PR #212) | Oscar merkt nichts. Aber ohne das wird alles langsamer. |
 | 50 | **Höhle = Dungeon** — Berg+Wasser=Höhle. IT-Ebenen Bits→Kernel→Browser im Dialog. | alle | ✅ Done (Commit #181, S25-2) | Oscar entdeckt eine neue Welt unter der Insel. |
 | 71 | **Palette = Instrument** — mouseenter auf Palette-Buttons spielt Ton. Oscar spielt Melodie durch Hovern. | alle | ✅ Done (S25-1, PR #196) | Oscar spielt Musik und baut gleichzeitig. |
-| 54 | **Jim Knopfs Welt** — Lummerland → Meer → weitere Inseln. Boot craften = nächste Insel. | alle | 🔲 Offen | Oscar segelt zu neuen Inseln. |
-| 95 | **Wu-Xing→NPC-Events** — NPCs reagieren auf Element-Events. Inter-Schicht-Kommunikation. | Engineer + Artist | 🔲 Offen | SpongeBob kommentiert wenn Oscar Feuer macht. |
-| 96 | **NPC-Session-Gedächtnis** — NPCs erinnern sich an letzte Session via localStorage. | Engineer + Scientist | 🔲 Offen | "Hey Oscar, gestern hast du viele Bäume gebaut!" |
-| 100 | **Energie vs Geld trennen** — NPC-Currencies (Burger, Noten, Glut) visuell von Muscheln trennen. Zwei Orte, zwei Konzepte. (Ricardo) | Designer | 🔲 Offen | Oscar versteht sofort: Burger = Reden, Muschel = Kaufen. |
-| 101 | **Krabbs-Vorrat sichtbar** — Krabbs hat endliches Inventar. Kein Holz → kein Verkauf. Angebot und Nachfrage ohne Erklärung. (Ricardo) | Engineer | 🔲 Offen | Oscar lernt: wenn Krabbs kein Holz hat, muss er warten. |
-| 102 | **MMX = Nerd-Easter-Egg** — Burn-Panel ehrlich labeln. Keine Goldstandard-Behauptung. (Ricardo) | Designer + Engineer | 🔲 Offen | Nerds freuen sich. Oscar merkt nichts. |
+| 54 | **Jim Knopfs Welt** — Lummerland → Meer → weitere Inseln. Boot craften = nächste Insel. | alle | ✅ Done (PR #220) | Oscar segelt zu neuen Inseln. |
+| 95 | **Wu-Xing→NPC-Events** — NPCs reagieren auf Element-Events. Inter-Schicht-Kommunikation. | Engineer + Artist | ✅ Done (PR #219) | SpongeBob kommentiert wenn Oscar Feuer macht. |
+| 96 | **NPC-Session-Gedächtnis** — NPCs erinnern sich an letzte Session via localStorage. | Engineer + Scientist | ✅ Done (PR #218) | "Hey Oscar, gestern hast du viele Bäume gebaut!" |
+| 100 | **Energie vs Geld trennen** — 🐚-Badge im Inventar-Panel + Klick→Krabbs. Muscheln nie im Chat-Header. | Designer + Engineer | ✅ Done (S27-1) | Oscar sieht Muscheln im Inventar, Energie im Chat. |
+| 101 | **Krabbs-Vorrat sichtbar** — Krabbs hat endliches Inventar (`KRABS_STOCK_INIT`). Kein Vorrat → deaktivierter Kaufen-Button. | Engineer | ✅ Done (Phantom-Done, game.js:507) | Oscar lernt: wenn Krabbs kein Holz hat, muss er warten. |
+| 102 | **MMX = Nerd-Easter-Egg** — Burn-Panel: "🔥 X MMX gefarmt  [nerd easter egg]". Kein Goldstandard. | Designer + Engineer | ✅ Done (Phantom-Done, game.js:4558) | Nerds freuen sich. Oscar merkt nichts. |
 
 ## 🟢 P2 — Irgendwann, aber mit Oscar-Outcome
 

--- a/ops/MEMORY.md
+++ b/ops/MEMORY.md
@@ -41,6 +41,8 @@ Persistent team log. Append-only. Read by all agents.
 
 | Datum | Was | Warum gut |
 |-------|-----|-----------|
+| 2026-04-04 | Sprint 27 S27-1: Muschel-Counter im Inventar — 🐚-Badge klickbar → Krabbs-Kontor. updateShellCounter() in updateInventoryDisplay() eingehängt. PR #226. | Kleine Änderung, klare Trennung: Muscheln im Inventar, Energie im Chat. Oscar sieht sofort wie viele Muscheln er hat. |
+| 2026-04-04 | Backlog-Audit Sprint 27: #101 und #102 waren Phantom-Dones. game.js hatte KRABS_STOCK_INIT (Zeile 507) und "[nerd easter egg]" Label (Zeile 4558) bereits implementiert. | Immer Code lesen bevor Backlog-Item als "offen" gilt. `grep -n "KRABS_STOCK\|nerd easter" game.js` hätte das sofort gezeigt. |
 | 2026-04-04 | 7 Duplikat-PRs für S25-3 — parallele Sessions implementierten dasselbe unabhängig | Vor jeder Session: `gh pr list --state open` prüfen. Wenn Feature schon in PR → Review + Merge statt Neuimplementierung. PR #212 (sauberste Base) gemergt, 7 andere geschlossen. |
 | 2026-04-03 | Bug-NPC (PR #188): Raupe Nimmersatt als Meta-Bug-Melder | Worktree war auf falschem Branch → Commit landete auf feat/floriane-muscheln statt feat/bug-npc. Fix: `git branch -f` + force push. Lektion: In Worktrees immer `git branch --show-current` prüfen vor Commit. |
 | 2026-04-03 | Floriane-Muscheln: Bestätigungsflow statt Silent-Deduction | Vorheriger Agent hatte Fibonacci-Preise die bei sendToApi() still abzogen — Kind sah nur "X 🐚 für diesen Wunsch" als System-Message. Neuer Flow: Wunsch-Erkennung → Preis anzeigen → Kind bestätigt/ablehnt → erst dann abziehen. Wortanzahl-basierte Preise (3/5/8 🐚) statt Zufall. |

--- a/ops/SPRINT.md
+++ b/ops/SPRINT.md
@@ -1,3 +1,103 @@
+# Sprint 27 — "Krabbs wird Kaufmann"
+
+**Sprint Goal:** Wirtschaft wird sichtbar — Krabbs-Vorrat endlich + Currencies klar getrennt + MMX ehrlich gelabelt.
+**Start:** 2026-04-04
+
+---
+
+## Sprint Backlog
+
+| # | Item | Owner(s) | Status |
+|---|------|----------|--------|
+| S27-1 | **#100 Muschel-Counter im Inventar** — Permanenter 🐚-Badge oben im Inventar-Panel. Klick → Krabbs-Kontor. Muscheln nie im Chat-Header. Energie (Burger/Noten/Glut) nur im Chat. | Designer + Engineer | 🔲 Offen |
+| S27-2 | **Backlog-Audit** — #101, #102, weitere Phantom-Dones in ops/BACKLOG.md als ✅ Done markieren. Backlog zeigt Realität. | Scientist | 🔲 Offen |
+| S27-3 | **#33 Titel** — `<title>Schatzinsel 🏝️</title>` kürzer und erkennbarer. Browser-Tab klar. | Designer | 🔲 Offen |
+
+---
+
+## Standup Log
+
+### 2026-04-04 (Sprint 27 Planning)
+
+**Kontext:** Sprint 26 vollständig (PRs #218-220, Doku PR #221). Retro: 25+ offene PRs — PR-Stau. Sprint 27 fokussiert auf kleine, sichhere Items ohne Merge-Konflikt-Risiko.
+
+**Sprint 27 Fokus:** Klares UI für Wirtschaft. #101 und #102 sind Phantom-Dones (bereits in game.js). S27-1 macht Muscheln sichtbar wo sie hingehören: ins Inventar. Alle 3 Items ≤ 30 LOC.
+
+**Blocker:** Keine.
+
+---
+
+# Sprint 26 — "Oscar wird erkannt"
+
+**Sprint Goal:** NPCs kennen Oscar (Session-Gedächtnis) + NPCs reagieren auf Elemente (Wu-Xing-Events).
+**Start:** 2026-04-04
+
+---
+
+## Sprint Backlog
+
+| # | Item | Owner(s) | Status |
+|---|------|----------|--------|
+| S26-1 | **#96 NPC-Session-Gedächtnis** — NPCs erinnern sich via localStorage. Beim ersten Chat-Klick nach Pause: "Hey Oscar, gestern hast du viel [Material] gebaut!" `_sessionGreeted` Set verhindert Wiederholung. | Engineer + Artist | ✅ Done (PR #218) |
+| S26-2 | **#95 Wu-Xing→NPC-Events** — `INSEL_BUS.on('element:fire')` etc. NPCs kommentieren wenn Oscar Feuer/Wasser/Holz/Metall/Erde platziert. 15s Throttle, max 3x/Session. | Engineer + Artist | ✅ Done (PR #219) |
+| S26-3 | **#54 Jim Knopfs Welt** — Boot craften (Planks + Seil + Mast) → neue Insel-Auswahl. Mindestens 1 neue erreichbare Insel. Oscar segelt. | Engineer | ✅ Done (PR #220) |
+
+---
+
+## Standup Log
+
+### 2026-04-04 (Sprint 26 Planning)
+
+**Kontext:** Sprint 25 vollständig (alle 3 Items Done, PR #212 gemergt). Retro: Duplikat-PR-Problem identifiziert und gelöst.
+
+**Sprint 26 Fokus:** Oscar-sichtbare Änderungen. NPCs werden lebendig (#96 Session-Gedächtnis). Welt reagiert (#95 Wu-Xing). Dann Expansion (#54 Boot/Insel).
+
+**Blocker:** Keine.
+
+### 2026-04-04 (Daily Scrum)
+
+**Heute:** Sprint 26 vollständig durch parallele Sessions. PR #218 (S26-1 NPC-Gedächtnis), PR #219 (S26-2 Wu-Xing-Limit), PR #220 (S26-3 Segelboot), PR #221 (Doku). Alle offen, noch nicht in main. Sprint 26 Review + Retro durchgeführt. Sprint 27 geplant.
+
+**Blocker:** 25+ offene PRs gesamt — PR-Stau.
+
+---
+
+## Sprint Review — 2026-04-04
+
+**Sprint Goal erreicht:** ✅ Ja — alle 3 Items Done.
+
+**Was geliefert wurde:**
+- S26-1: NPC-Session-Gedächtnis — `_sessionGreeted` Set, `buildSessionGreeting()` liest `insel-session-snapshot` (>60s = neue Session). 11 NPC-Stimmen. SpongeBob: "ICH BIN BEREIT! Letzte Runde 23 Blöcke Holz — REKORD!" (PR #218 + #213)
+- S26-2: Wu-Xing Events — `sessionReactionCount` Counter + `SESSION_MAX = 3`. Bestehende Throttle (15s) + 30% Chance bleiben. (PR #219)
+- S26-3: Segelboot craften → Insel-Auswahl-Dialog. Seil + Segel + Segelboot als neue Materialien + Rezepte. Lummerland + Wüsteninsel erreichbar. `island:arrived` Event auf INSEL_BUS. (PR #220 + #214)
+
+**Nicht geliefert:** Nichts.
+
+**Oscar-Check:** SpongeBob erinnert sich an Oscar. Oscar segelt. Welt lebt.
+
+---
+
+## Sprint Retrospective — 2026-04-04
+
+### Was lief gut?
+
+- **Sprint 26 vollständig.** Alle 3 Items Done, alle als PRs vorhanden.
+- **NPC-Gedächtnis ist emotional stark.** "Hey Oscar! Letzte Runde 23 Blöcke Holz." Kind fühlt sich erkannt.
+- **Segelboot sauber implementiert.** Neue Materialien, neue Rezepte, neues Event — alles in Muster eingepasst.
+
+### Was lief schlecht?
+
+- **25+ offene PRs.** PR-Stau. Neue Features werden gebaut, aber mergen liegt beim User. Duplikat-Risiko bleibt.
+- **feat/sprint-27 Branch ohne merge base.** Parallele Session hat Sprint 27 auf veraltetem Stand gestartet. Weggeworfen.
+
+### Was verbessern wir?
+
+1. **Sprint 27: nur kleine Items** — max 50 LOC pro Item. Kein Merge-Risiko.
+2. **PR-Stau ansprechen.** User soll Sprint 26 PRs mergen: #218, #219, #220, #221.
+3. **Krabbs-Wirtschaft sichtbar machen** — Oscar versteht Angebot/Nachfrage durch Spielen, nicht durch Erklären.
+
+---
+
 # Sprint 25 — "Oscar spielt und entdeckt"
 
 **Sprint Goal:** Palette wird Instrument (Oscar spielt Melodien) + Höhle als neue Welt + game.js Zellteilung.

--- a/src/core/game.js
+++ b/src/core/game.js
@@ -1045,9 +1045,25 @@
         inventory = JSON.parse(localStorage.getItem('insel-inventar') || '{}');
     }
 
+    function updateShellCounter() {
+        const counter = document.getElementById('shell-counter');
+        const countEl = document.getElementById('shell-count');
+        if (!counter || !countEl) return;
+        const shells = getInventoryCount('shell');
+        countEl.textContent = shells;
+        counter.style.display = shells > 0 ? '' : 'none';
+        if (!counter.dataset.listenerAdded) {
+            counter.dataset.listenerAdded = '1';
+            counter.addEventListener('click', () => {
+                showKrabsShop();
+            });
+        }
+    }
+
     function updateInventoryDisplay() {
         const container = document.getElementById('inventory-content');
         if (!container) return;
+        updateShellCounter();
         const items = Object.entries(inventory).filter(([, count]) => count > 0);
         if (items.length === 0) {
             container.innerHTML = '<p class="inv-empty">Ernte Bäume für Holz! ⛏️</p>';


### PR DESCRIPTION
## Sprint 27 — "Krabbs wird Kaufmann"

### S27-1: Muschel-Counter im Inventar (#100)

- 🐚-Badge oben im Inventar-Panel — nur sichtbar wenn Muscheln > 0
- Klick auf Badge → öffnet Krabbs-Kontor direkt
- `updateShellCounter()` in `updateInventoryDisplay()` eingehängt — wird bei jeder Inventar-Änderung aktualisiert
- Muscheln nie im Chat-Header. Energie (Burger/Noten/Glut) nur im Chat.

**Oscar:** Öffnet Inventar → sieht "🐚 3 Muscheln" → klickt → Krabbs öffnet.

### S27-2: Backlog-Audit

- #54 Jim Knopfs Welt → ✅ Done (PR #220)
- #95 Wu-Xing NPC-Events → ✅ Done (PR #219)
- #96 NPC-Session-Gedächtnis → ✅ Done (PR #218)
- #101 Krabbs-Vorrat → ✅ Done (Phantom-Done, game.js:507 — `KRABS_STOCK_INIT` + `krabsStock`)
- #102 MMX Easter-Egg → ✅ Done (Phantom-Done, game.js:4558 — "[nerd easter egg]" Label)

### S27-3: Titel (#33)

- `<title>Schatzinsel 🏝️</title>` (war: "Schatzinsel — Außer Text nix gehext")

### ops/SPRINT.md

- Sprint 26 vollständig: Items Done + Review + Retro
- Sprint 27 Planning dokumentiert

## Test plan

- [ ] Muschel sammeln (Strand-Klick) → 🐚-Badge erscheint im Inventar-Panel
- [ ] Badge klicken → Krabbs-Kontor öffnet sich
- [ ] Kein Muschel im Inventar → Badge unsichtbar
- [ ] Browser-Tab zeigt "Schatzinsel 🏝️"

https://claude.ai/code/session_01Gd2EiuP6WyWBtK7Lbm1eaf