### PR TITLE
S27-3: Backlog-Sync + Distribution-Items

### DIFF
--- a/ops/BACKLOG.md
+++ b/ops/BACKLOG.md
@@ -12,6 +12,7 @@ Alles was nicht in eine dieser Kategorien fällt → `ARCHIVE.md`.
 | # | Item | Owner | Status |
 |---|------|-------|--------|
 | 78 | **Tesla-Nutzertest auswerten** — 1h Video von Oscar im Tesla. Echte Nutzerdaten. Da ist Gold drin. | Scientist + Leader | 🔲 Offen |
+| 104 | **itch.io live schalten** — CI (Butler) ist bereit (commit 3dcd294). User: itch.io Projekt anlegen (HTML5) + GitHub Secret `BUTLER_API_KEY` setzen. Dann läuft Deploy automatisch. | User | 🔲 Human Input |
 | 27 | **Cloudflare Worker CORS** — User muss worker.js im Dashboard deployen | User | 🔲 Human Input |
 | 92 | **Requesty Key rotieren** — Alter Key im Git-Verlauf. Sicherheitsrisiko. | Engineer | 🔲 Human Input |
 
@@ -28,6 +29,7 @@ Alles was nicht in eine dieser Kategorien fällt → `ARCHIVE.md`.
 | 100 | **Energie vs Geld trennen** — NPC-Currencies (Burger, Noten, Glut) visuell von Muscheln trennen. Zwei Orte, zwei Konzepte. (Ricardo) | Designer | 🔲 Offen | Oscar versteht sofort: Burger = Reden, Muschel = Kaufen. |
 | 101 | **Krabbs-Vorrat sichtbar** — Krabbs hat endliches Inventar. Kein Holz → kein Verkauf. Angebot und Nachfrage ohne Erklärung. (Ricardo) | Engineer | 🔲 Offen | Oscar lernt: wenn Krabbs kein Holz hat, muss er warten. |
 | 102 | **MMX = Nerd-Easter-Egg** — Burn-Panel ehrlich labeln. Keine Goldstandard-Behauptung. (Ricardo) | Designer + Engineer | 🔲 Offen | Nerds freuen sich. Oscar merkt nichts. |
+| 105 | **Stripe PWYW Button** — "Zahle was dir das wert ist" auf schatzinsel.app. 3 Vorschläge (5/10/25 EUR), alles geht. Stripe Payment Link reicht für MVP. | Engineer | 🔲 Offen | Papa zahlt. Oscar ist stolz. |
 
 ## 🟢 P2 — Irgendwann, aber mit Oscar-Outcome
 
@@ -44,6 +46,7 @@ Alles was nicht in eine dieser Kategorien fällt → `ARCHIVE.md`.
 | 19 | **Conway→Gameplay** — Lebende Zellen → Blumen, Glider → Wolken | Engineer + Scientist | 🔲 Offen | Die Insel lebt auch wenn Oscar nicht baut. |
 | 32 | **Code-Ebenen per Touch** — Swipe statt Rechtsklick | Engineer | ✅ Done |
 | 103 | **Insel-Archipel** — Heimatinsel bleibt erhalten wenn Oscar segelt. Jede neue Insel ist ein Kapitel. Wissen (Rezepte, NPCs, Materialien) wird mitgenommen. Schatzkarte mit drei Worten = Adresse jeder Insel. Tommy erzählt abends davon. | alle | 🔲 Offen | Oscar entdeckt mit dem Gelernten immer neue Welten — und findet immer den Weg nach Hause. |
+| 106 | **Anchor-Pricing** — Lummerland-Zugang für Über-Ø-Zahler. Erst nach itch.io-Daten (was zahlen Leute tatsächlich?). | Designer + Engineer | 🔲 Offen | Wer mehr zahlt, segelt weiter. |
 
 ---
 

--- a/ops/SPRINT.md
+++ b/ops/SPRINT.md
@@ -179,7 +179,7 @@
 |---|------|----------|--------|
 | S27-1 | **Taschentücher + Ogilvy-Copy** — 5 One-Pager mit 3-Akt-Struktur (Kubrick/Spielberg/Goethe), mehrdimensional (Baby→Greis, Spielegeschichte, Accessibility/Mandela) | Sales + Artist | 🔄 In Arbeit |
 | S27-2 | **Metrik-Audit Feynman×Heidegger** — Jede Metrik prüfen: was messen wir, lügt es, was ist zuhanden vs. vorhanden? | Scientist + Beirat | 🔄 In Arbeit |
-| S27-3 | **Sprint 26 Backlog-Sync** — Erledigte Items (#54, #95, #96) im Backlog als Done markieren. Distribution-Items erfassen. | Leader | 🔲 Offen |
+| S27-3 | **Sprint 26 Backlog-Sync** — Erledigte Items (#54, #95, #96) im Backlog als Done markieren. Distribution-Items erfassen. | Leader | ✅ Done |
 
 ---
 
@@ -190,6 +190,14 @@
 **Kontext:** Sprint 26 vollständig. User-Aufträge: Sales-Material, Metrik-Audit. "Alles in sprints, backlog features on hold."
 
 **Sprint 27 Fokus:** Kein neuer Code. Substanz für Sales + Metriken. Zwei Agenten arbeiten parallel.
+
+**Blocker:** Keine.
+
+### 2026-04-04 (Daily Scrum)
+
+**Heute:** S27-3 abgeschlossen. #54, #95, #96 waren bereits Done auf origin/main. Distribution-Items ergänzt: #104 (itch.io-Setup, P0 Human Input), #105 (Stripe PWYW, P1), #106 (Anchor-Pricing, P2). PR #228 hatte #103-Nummernkonflikt gegen origin/main — sauber neu implementiert. PR #229 (Live Launch Sprint 27) liegt als offene Frage beim User.
+
+**S27-1 + S27-2:** Sales-Material — liegt beim User (kein Agent-Output sichtbar in main).
 
 **Blocker:** Keine.
 


### PR DESCRIPTION
## Sprint 27 — S27-3 abgeschlossen

### Was
- S27-3 in SPRINT.md als ✅ Done markiert
- Daily Scrum 2026-04-04 dokumentiert
- Distribution-Items in BACKLOG.md erfasst:
  - **#104** itch.io live schalten (P0, Human Input) — CI (Butler) ist bereit, User muss itch.io-Projekt anlegen + `BUTLER_API_KEY` setzen
  - **#105** Stripe PWYW Button auf schatzinsel.app (P1)
  - **#106** Anchor-Pricing — Lummerland für Über-Ø-Zahler (P2, erst nach itch.io-Daten)

### Warum neu statt PR #228
PR #228 hatte eine #103-Nummernkollision gegen origin/main (origin hatte #103 bereits als "Insel-Archipel"). Sauber neu gebaut auf aktuellem main (75f59ba).

### Nächster Schritt für User (itch.io, #104)
1. https://itch.io/game/new — Projekt "Schatzinsel" als HTML5 anlegen
2. GitHub Secret `BUTLER_API_KEY` setzen (aus itch.io → API keys)
3. Dieser PR mergen → CI deployt bei jedem main-Push automatisch

https://claude.ai/code/session_0181xtbnr7uJ2KyuRi3Nobqf