### PR TITLE
fix: Butler itch.io Deploy — nur Spieldateien

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -189,11 +189,17 @@ jobs:
       - id: deployment
         uses: actions/deploy-pages@v4
 
+      - name: Build itch.io bundle
+        run: |
+          mkdir -p _itchio
+          cp index.html style.css sw.js manifest.json _itchio/
+          cp -r src/ _itchio/src/
+
       - name: Deploy to itch.io via Butler
         run: |
           curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
           unzip butler.zip
           chmod +x butler
-          ./butler push . crygonejin/schatzinsel:web --userversion "${{ steps.version.outputs.version }}"
+          ./butler push _itchio crygonejin/schatzinsel:web --userversion "${{ steps.version.outputs.version }}"
         env:
           BUTLER_API_KEY: ${{ secrets.itch_io_butler }}


### PR DESCRIPTION
## Summary

- Butler pushed bisher das **gesamte Repo** nach itch.io (inkl. .git, docs, ops, tests)
- Jetzt: Staging-Verzeichnis `_itchio` mit nur den 42 Spieldateien: `index.html`, `style.css`, `sw.js`, `manifest.json` + `src/`
- GitHub Secret `itch_io_butler` ist gesetzt und wird referenziert

## Test plan

- [ ] CI Check & Deploy Workflow läuft durch
- [ ] Butler push auf itch.io enthält nur Spieldateien
- [ ] Spiel läuft auf itch.io nach Deploy

https://claude.ai/code/session_01JSx1SURcEA2bKNrZMJmWMk