### PR TITLE
S27-3: Donation-Modal [veraltet — ersetzt durch #237]

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,9 +77,39 @@
         <!-- Header -->
         <header>
             <h1>🏝️ Schatzinsel</h1>
-            <a href="https://donate.stripe.com/test_7sY9AMcTD6wQ7e9flD1ZS00" target="_blank" rel="noopener"
-               class="donate-btn" title="Projekt unterstützen" aria-label="Projekt unterstützen — Kaffee spendieren">☕</a>
+            <button class="donate-btn" onclick="document.getElementById('donate-modal').style.display='flex'"
+                    title="Projekt unterstützen" aria-label="Projekt unterstützen">☕</button>
         </header>
+
+        <!-- Donation-Modal (S27-3) -->
+        <!-- TODO S27-2: echte Stripe Payment Links hier eintragen (5€/10€/25€ aus Stripe Dashboard) -->
+        <div id="donate-modal" style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.7); z-index:9500; align-items:center; justify-content:center;" onclick="if(event.target===this)this.style.display='none'" role="dialog" aria-modal="true" aria-label="Projekt unterstützen">
+            <div class="donate-modal-box">
+                <button class="donate-modal-close" onclick="document.getElementById('donate-modal').style.display='none'" aria-label="Schließen">✕</button>
+                <h2 style="margin:0 0 6px; font-size:20px;">Schatzinsel unterstützen</h2>
+                <p style="margin:0 0 20px; opacity:0.7; font-size:13px;">Hilft Oscar und all seinen Freunden.</p>
+                <div class="donate-tiers">
+                    <!-- TODO S27-2: href auf echten Stripe Payment Link (5€) setzen -->
+                    <a href="https://donate.stripe.com/test_7sY9AMcTD6wQ7e9flD1ZS00" target="_blank" rel="noopener" class="donate-tier">
+                        <span class="donate-tier-icon">☕</span>
+                        <span class="donate-tier-amount">5 €</span>
+                        <span class="donate-tier-label">Kaffee</span>
+                    </a>
+                    <!-- TODO S27-2: href auf echten Stripe Payment Link (10€) setzen -->
+                    <a href="https://donate.stripe.com/test_7sY9AMcTD6wQ7e9flD1ZS00" target="_blank" rel="noopener" class="donate-tier donate-tier-highlight">
+                        <span class="donate-tier-icon">🧁</span>
+                        <span class="donate-tier-amount">10 €</span>
+                        <span class="donate-tier-label">Kuchen</span>
+                    </a>
+                    <!-- TODO S27-2: href auf echten Stripe Payment Link (25€) setzen -->
+                    <a href="https://donate.stripe.com/test_7sY9AMcTD6wQ7e9flD1ZS00" target="_blank" rel="noopener" class="donate-tier">
+                        <span class="donate-tier-icon">🏴‍☠️</span>
+                        <span class="donate-tier-amount">25 €</span>
+                        <span class="donate-tier-label">Pirat</span>
+                    </a>
+                </div>
+            </div>
+        </div>
 
         <!-- Toolbar -->
         <div id="toolbar" role="toolbar" aria-label="Werkzeuge und Aktionen">

--- a/ops/MEMORY.md
+++ b/ops/MEMORY.md
@@ -17,6 +17,8 @@ Persistent team log. Append-only. Read by all agents.
 | 2026-04-04 | NPC-Session-Gedächtnis war zu 80% fertig — nur _sessionGreeted Set fehlte | getNpcMemoryComment() existierte, wurde aber nur bei 30% Zufall oder Quest-Annahme gezeigt | Vor Feature-Implementierung immer prüfen was schon da ist. Oft reicht ein kleiner Eingriff. |
 | 2026-04-04 | Wu-Xing NPC-Events waren bereits komplett — nur Limiter fehlte | npc-events.js hatte alle 9 Event-Typen, 15s Cooldown, Reactions. Nur max 3x/Session fehlte. | Backlog-Items gegen Code abgleichen. "Offen" heißt nicht "nicht angefangen". |
 | 2026-04-04 | Heidegger als Zuhandenheit-Auditor im Beirat | "Die Zahl ist nie das Kind" — Messung verwandelt Zuhandenheit in Vorhandenheit | Essay docs/essays/beschreibung-und-messung.md dokumentiert die Epistemologie des Projekts. |
+| 2026-04-04 | S27-1 war Done aber als "In Progress" markiert — smoke.spec.js war seit mind. einer Session in main | Tests existierten schon in ops/tests/, SPRINT.md war nicht synchron | Phantom-Progress: Vor Implementierung immer prüfen ob Feature schon in main ist (grep + Glob statt blind implementieren). |
+| 2026-04-04 | 5 offene PRs (#226–#231) — parallele Sessions haben unabhängig denselben Sprint bearbeitet | Kein Session-Start-Check auf offene PRs | gh pr list --state open als Pflichtschritt vor jeder Implementierung. Nie doppelt bauen. |
 
 | Datum | Was | Warum | Lektion |
 |-------|-----|-------|---------|

--- a/ops/SPRINT.md
+++ b/ops/SPRINT.md
@@ -177,9 +177,9 @@
 
 | # | Item | Owner(s) | Status |
 |---|------|----------|--------|
-| S27-1 | **Playwright Smoke Tests** — 7 Tests: Load, Intro, Start, Play, Palette, Console, SW. Ersetzt Puppeteer. | Engineer | 🔄 In Progress |
+| S27-1 | **Playwright Smoke Tests** — 6 Tests in `ops/tests/smoke.spec.js`. Ersetzt Puppeteer. | Engineer | ✅ Done (in main) |
 | S27-2 | **Stripe Payment Links im Dashboard erstellen** — 3 Stufen: 5€/10€/25€. Produkt existiert (prod_UH8GIdCYDVu1H5). | User (Till) | 🔲 Human Input |
-| S27-3 | **Donation-Button in index.html** — Nach Intro, dezent. Verlinkt auf Stripe Payment Links. | Designer + Engineer | 🔲 Offen |
+| S27-3 | **Donation-Button in index.html** — ☕-Button im Header öffnet 3-Stufen-Modal (5€/10€/25€). Test-URLs drin — echte Links werden nach S27-2 eingetragen. | Designer + Engineer | ✅ Done (PR #233) |
 | S27-4 | **itch.io Upload via Butler** — Zweiter Distributionskanal. Butler Key nötig. | User (Till) | 🔲 Human Input |
 
 ---
@@ -191,6 +191,17 @@
 **Kontext:** Sprint 25+26 done. Einstein-Entscheidung: Live Launch. Stripe Produkt angelegt. Playwright wird aufgesetzt.
 
 **Blocker:** Payment Links brauchen Stripe Dashboard (Till). itch.io Butler Key (Till).
+
+### 2026-04-04 (Daily Scrum — Session 2)
+
+**Heute:**
+- S27-1 als Done erkannt — `ops/tests/smoke.spec.js` + `burn-panel.spec.js` + `playwright.config.js` bereits in main.
+- S27-3 implementiert: ☕-Button öffnet jetzt 3-Stufen-Modal (Kaffee 5€ / Kuchen 10€ / Pirat 25€). Dezent im Header, sichtbar nach Intro. Test-URLs bis S27-2 echte Links liefert.
+- 5 offene PRs (#226, #227, #228, #230, #231) — Duplikate aus parallelen Sessions. Brauchen User-Entscheidung.
+
+**Blocker:**
+- S27-2: Stripe Payment Links (Till: Stripe Dashboard → 3 Payment Links erstellen, dann TODO-Kommentare in index.html ersetzen)
+- S27-4: itch.io Butler Key (Till)
 
 ---
 

--- a/style.css
+++ b/style.css
@@ -499,7 +499,8 @@ header h1 {
     top: 50%;
     transform: translateY(-50%);
     font-size: 20px;
-    text-decoration: none;
+    background: none;
+    border: none;
     opacity: 0.6;
     transition: opacity 0.2s;
     cursor: pointer;
@@ -510,6 +511,61 @@ header h1 {
     justify-content: center;
 }
 .donate-btn:hover { opacity: 1; }
+
+/* Donation Modal */
+.donate-modal-box {
+    background: #1a1a2e;
+    border: 1px solid rgba(255,255,255,0.15);
+    border-radius: 18px;
+    padding: 28px 24px 24px;
+    max-width: 360px;
+    width: 90%;
+    color: #fff;
+    position: relative;
+    text-align: center;
+    font-family: inherit;
+}
+.donate-modal-close {
+    position: absolute;
+    top: 12px;
+    right: 14px;
+    background: none;
+    border: none;
+    color: rgba(255,255,255,0.5);
+    font-size: 20px;
+    cursor: pointer;
+    line-height: 1;
+    padding: 4px;
+}
+.donate-modal-close:hover { color: #fff; }
+.donate-tiers {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+}
+.donate-tier {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    padding: 14px 10px;
+    border-radius: 14px;
+    border: 1px solid rgba(255,255,255,0.2);
+    background: rgba(255,255,255,0.06);
+    text-decoration: none;
+    color: #fff;
+    flex: 1;
+    transition: background 0.15s, border-color 0.15s;
+}
+.donate-tier:hover { background: rgba(255,255,255,0.14); border-color: rgba(255,255,255,0.5); }
+.donate-tier-highlight {
+    border-color: #f0a500;
+    background: rgba(240,165,0,0.12);
+}
+.donate-tier-highlight:hover { background: rgba(240,165,0,0.22); }
+.donate-tier-icon { font-size: 26px; }
+.donate-tier-amount { font-size: 17px; font-weight: 700; }
+.donate-tier-label { font-size: 11px; opacity: 0.6; }
 
 /* === TOOLBAR === */
 #toolbar {


### PR DESCRIPTION
## Was

☕-Button im Header öffnet jetzt ein dezentes 3-Tier-Modal statt eines direkten Stripe-Links.

**Tiers:**
- ☕ **5 €** — Kaffee
- 🧁 **10 €** — Kuchen (hervorgehoben)
- 🏴‍☠️ **25 €** — Pirat

**Aktuell:** Test-URLs (alle 3 Tiers zeigen auf den bestehenden Stripe-Test-Link).  
**Nach S27-2:** Till trägt die echten Stripe Payment Links in die 3 TODO-Kommentare in `index.html` ein.

## Sprint-Status

- S27-1 ✅ Playwright Tests bereits in main (`ops/tests/smoke.spec.js`)
- S27-2 🔲 Human Input — Till erstellt 3 Stripe Payment Links im Dashboard
- S27-3 ✅ Dieses PR
- S27-4 🔲 Human Input — itch.io Butler Key

## Nach dem Merge: S27-2 erledigen

In `index.html` drei Zeilen mit `TODO S27-2` suchen und jeweils `href` auf den echten Stripe Payment Link setzen:
```
☕ 5€  → https://buy.stripe.com/...
🧁 10€ → https://buy.stripe.com/...
🏴‍☠️ 25€ → https://buy.stripe.com/...
```

https://claude.ai/code/session_014cTf5RtskkVRZynr48tZpx