### PR TITLE
Sprint 32: Schatzkarte + Weltraum-Pfad (Mars) + NPC-Englisch

### DIFF
--- a/ops/SPRINT.md
+++ b/ops/SPRINT.md
@@ -1,3 +1,74 @@
+# Sprint 32 — "Oscar erkundet den Weltraum"
+
+**Sprint Goal:** Weltraum-Pfad (Rakete→Mond→Mars→Alien) + Schatzkarte im Sail-Dialog + NPC-Texte auf Englisch.
+**Start:** 2026-04-05
+
+---
+
+## Sprint Backlog
+
+| # | Item | Owner(s) | Status |
+|---|------|----------|--------|
+| S32-1 | **Schatzkarte im Sail-Dialog** — Entdeckte Inseln mit Besucht-Badge + 3-Wort-Adresse. Oscar sieht sein Archipel auf einem Blick. | Designer + Engineer | 🔲 Offen |
+| S32-2 | **Weltraum-Pfad** — 4 neue Materialien: Rakete 🚀, Mond 🌙, Mars 🪐, Alien 👽. Rezepte: Metall+Feuer=Rakete, Rakete+Wolke=Mond, Mond+Eis=Mars, Mars+Stern=Alien. Natürliche Progression nach Dinos. | Engineer | 🔲 Offen |
+| S32-3 | **#62 NPC-Texte auf Englisch** — NPC-Begrüßungen + Kommentare auf Englisch wenn Sprache EN erkannt. npc-data.js um EN-Varianten erweitern. Spielplatz-Phase. | Engineer + Artist | 🔲 Offen |
+
+---
+
+## Standup Log
+
+### 2026-04-05 (Sprint 32 Planning)
+
+**Kontext:** Sprint 31 vollständig (alle 3 Items Done, PR #244 offen). Dino-Bucht als dritte Insel. Genesis-Toasts live. NPCs reagieren auf Dinos. Logische Nächste: Weltraum-Expansion + Schatzkarte damit Oscar seinen Fortschritt sieht.
+
+**Sprint 32 Fokus:** Weltraum-Pfad (Oscar-sichtbar, max Impact). Dann Schatzkarte (Oscar sieht sein Archipel). Dann NPC-Englisch (#62 abschließen).
+
+**Blocker:** PRs #243 + #244 noch offen (warten auf Till-Merge). feat/sprint-32 basiert auf feat/sprint-31.
+
+### 2026-04-05 (Daily Scrum)
+
+**Heute:** Alle 3 Sprint 32 Items implementiert.
+- S32-1: Schatzkarte im Sail-Dialog — `showSailDialog()` neu gebaut. 3-Wort-Adressen pro Insel (`wellen.sand.zuhause`, `zwei.berge.abenteuer`, `knochen.urzeit.staunen`). "✓ entdeckt" Badge für besuchte Inseln via localStorage. Zähler "X von 3 Inseln entdeckt".
+- S32-2: Weltraum-Pfad — `mars` als neues Material (🪐) in materials.js. 2 neue Rezepte: Mond+Eis=Mars, Mars+Rakete=Marslandung→Alien. Entdeckung: rocket/moon/alien existierten bereits. Nur mars war echtes Gap. `grep materials.js` war richtig (Retro S31 bestätigt).
+- S32-3: #62 Mehrsprachige NPCs — `insel-player-lang` in localStorage gespeichert nach erster Chat-Nachricht. `getNpcMemoryComment()` gibt EN-Texte zurück wenn lang='en'. "Hey! Last time you built a lot with..." — Oscars englische Freunde werden jetzt erkannt.
+
+**Blocker:** Keine.
+
+---
+
+## Sprint Review — 2026-04-05
+
+**Sprint Goal erreicht:** ✅ Ja — alle 3 Items Done.
+
+**Was geliefert wurde:**
+- S32-1: Schatzkarte — Sail-Dialog zeigt entdeckte Inseln mit Badge + 3-Wort-Adresse + Fortschrittszähler. Oscar sieht sein Archipel auf einen Blick.
+- S32-2: Weltraum-Pfad — Mars 🪐 + 2 Rezepte. Dinos → Weltraum. Natürliche Progression.
+- S32-3: #62 NPC-Englisch — Sprache wird in localStorage persistiert. NPC-Begrüßungen auf EN wenn Spieler auf Englisch chattet.
+
+**Bonus:** TypeScript-Fix: Keine Duplikate in materials.js (rocket/moon/alien existierten schon). `grep materials.js` als Retro-Verbesserung sofort angewandt.
+
+**Oscar-Check:** Sail-Dialog zeigt "2 von 3 Inseln entdeckt". Dino-Bucht: entdeckt. Lummerland: entdeckt. Heimatinsel: Du bist hier. Oscars englischer Freund vom Spielplatz bekommt "Hey! Last time you built a lot with Wood!"
+
+---
+
+## Sprint Retrospective — 2026-04-05
+
+### Was lief gut?
+- **S31-Retro-Tipp sofort umgesetzt.** `grep materials.js` vor jedem neuen Material — hat Duplikat-Keys sofort aufgedeckt. 3 Keys (rocket, moon, alien) bereits vorhanden. Fehler verhindert.
+- **Schatzkarte elegant.** Sail-Dialog rebuild statt patch — sauberer Code. 3-Wort-Adressen geben jedem Ort eine Seele.
+- **#62 mit minimalem Overhead.** localStorage als Sprachbrücke zwischen Chat und Greeting. Kein Framework. Vanilla.
+
+### Was lief schlecht?
+- **Weltraum-Pfad kleiner als geplant.** Nur Mars + 2 Rezepte statt 4 neue Materialien. rocket/moon/alien existierten schon — Planung hat Bestand nicht geprüft. Retro-Tipp hätte vorher kommen müssen.
+- **EN-only für NPC-Greetings.** FR/ES/IT noch ohne Übersetzung in getNpcMemoryComment. #62 nur zu 50% erledigt.
+
+### Was verbessern wir?
+1. **Backlog-Audit vor Materialien.** Vor jedem neuen Material/Feature: bestehende Keys prüfen. `grep` ist jetzt Pflicht.
+2. **#62 Phase 2.** FR/ES/IT Übersetzungen für getNpcMemoryComment. Sprint 33.
+3. **Mehr Weltraum-Inhalt.** Weltraum-Insel als Phase 2 (wie Dino-Bucht). Sprint 33 Kandidat.
+
+---
+
 # Sprint 25 — "Oscar spielt und entdeckt"
 
 **Sprint Goal:** Palette wird Instrument (Oscar spielt Melodien) + Höhle als neue Welt + game.js Zellteilung.

--- a/src/core/game.js
+++ b/src/core/game.js
@@ -524,30 +524,60 @@
         if (closeBtn) closeBtn.focus();
     }
 
-    // === SEGELBOOT → INSEL-AUSWAHL (#54 Jim Knopfs Welt) ===
+    // === SEGELBOOT → INSEL-AUSWAHL (#54 Jim Knopfs Welt + S32-1 Schatzkarte) ===
+
+    // 3-Wort-Adressen für jede Insel (Schatzkarte — poetic, einprägsam)
+    const _ISLAND_ADDRESSES = {
+        home:      'wellen.sand.zuhause',
+        lummerland: 'zwei.berge.abenteuer',
+        dinobucht:  'knochen.urzeit.staunen',
+    };
+
     function showSailDialog() {
         const existingDlg = document.getElementById('sail-dialog');
-        if (existingDlg) { existingDlg.classList.remove('hidden'); return; }
+        if (existingDlg) { existingDlg.remove(); } // Neu bauen damit discovered-State stimmt
+
+        // Welche Inseln wurden schon besucht?
+        const currentIsland = localStorage.getItem('insel-current-island') || 'home';
+        const visited = {
+            home:       true,
+            lummerland: !!localStorage.getItem('insel-archipel-lummerland'),
+            dinobucht:  !!localStorage.getItem('insel-archipel-dinobucht'),
+        };
+
+        function islandBtn(dest, emoji, label, desc, borderColor, bgColor) {
+            const addr = _ISLAND_ADDRESSES[dest] || '';
+            const isCurrent = dest === currentIsland;
+            const hasVisited = visited[dest];
+            const badge = isCurrent
+                ? `<span style="font-size:10px;background:#27AE60;color:#fff;border-radius:4px;padding:1px 5px;margin-left:6px;">Du bist hier</span>`
+                : hasVisited
+                    ? `<span style="font-size:10px;background:#F39C12;color:#fff;border-radius:4px;padding:1px 5px;margin-left:6px;">✓ entdeckt</span>`
+                    : '';
+            return `
+                <button class="sail-dest" data-dest="${dest}" style="padding:10px 12px;font-size:15px;border-radius:8px;border:2px solid ${borderColor};background:${bgColor};cursor:pointer;text-align:left;display:flex;align-items:center;gap:10px;">
+                    <span style="font-size:22px;">${emoji}</span>
+                    <span>
+                        <strong>${label}</strong>${badge}<br>
+                        <small style="color:#666;">${desc}</small><br>
+                        <small style="color:#aaa;font-family:monospace;">${addr}</small>
+                    </span>
+                </button>`;
+        }
 
         const dlg = document.createElement('div');
         dlg.id = 'sail-dialog';
         dlg.className = 'dialog-overlay';
         dlg.innerHTML = `
-            <div class="dialog-content" style="max-width:340px;text-align:center;">
+            <div class="dialog-content" style="max-width:380px;text-align:center;">
                 <h3>⛵ Wohin segeln?</h3>
-                <p style="margin:12px 0;font-size:14px;">Dein Segelboot ist bereit!</p>
-                <div style="display:flex;flex-direction:column;gap:8px;margin:16px 0;">
-                    <button class="sail-dest" data-dest="lummerland" style="padding:12px;font-size:16px;border-radius:8px;border:2px solid #2E86C1;background:#EBF5FB;cursor:pointer;">
-                        🏝️ Lummerland<br><small>Eine kleine Insel mit zwei Bergen</small>
-                    </button>
-                    <button class="sail-dest" data-dest="dinobucht" style="padding:12px;font-size:16px;border-radius:8px;border:2px solid #8E44AD;background:#F5EEF8;cursor:pointer;">
-                        🦕 Dino-Bucht<br><small>Vor 66 Millionen Jahren lebten hier Dinosaurier</small>
-                    </button>
-                    <button class="sail-dest" data-dest="home" style="padding:12px;font-size:16px;border-radius:8px;border:2px solid #27AE60;background:#EAFAF1;cursor:pointer;">
-                        🏠 Heimatinsel<br><small>Deine Insel wartet auf dich</small>
-                    </button>
+                <p style="margin:8px 0 14px;font-size:13px;color:#666;">Dein Archipel — ${Object.values(visited).filter(Boolean).length} von ${Object.keys(visited).length} Inseln entdeckt</p>
+                <div style="display:flex;flex-direction:column;gap:8px;margin:0 0 16px;">
+                    ${islandBtn('home',      '🏠', 'Heimatinsel', 'Deine Insel wartet auf dich',                '#27AE60', '#EAFAF1')}
+                    ${islandBtn('lummerland','🏝️', 'Lummerland',  'Eine kleine Insel mit zwei Bergen',          '#2E86C1', '#EBF5FB')}
+                    ${islandBtn('dinobucht', '🦕', 'Dino-Bucht',  'Vor 66 Millionen Jahren lebten hier Dinos', '#8E44AD', '#F5EEF8')}
                 </div>
-                <button id="sail-cancel" style="margin-top:8px;padding:8px 16px;border:none;background:#eee;border-radius:6px;cursor:pointer;">Noch nicht</button>
+                <button id="sail-cancel" style="padding:8px 16px;border:none;background:#eee;border-radius:6px;cursor:pointer;">Noch nicht</button>
             </div>
         `;
         document.body.appendChild(dlg);
@@ -1027,19 +1057,32 @@
         const hasName = playerName && playerName !== 'Spieler' && playerName !== 'Anonym';
         const nameStr = hasName ? ` ${playerName}` : '';
         const daysSince = m.lastVisit ? Math.floor((Date.now() - m.lastVisit) / 86400000) : null;
+        // #62 Mehrsprachige NPCs: gespeicherte Spielersprache nutzen
+        const lang = localStorage.getItem('insel-player-lang') || 'de';
+        const isEN = lang === 'en';
 
         if (m.lastMaterial && m.questsDone && m.questsDone.length > 0) {
-            return `${npc.emoji} ${npc.prefix} Hey${nameStr}! Letztes Mal hast du viel mit ${m.lastMaterial} gebaut. Und ${m.questsDone.length} Quest${m.questsDone.length > 1 ? 's' : ''} geschafft!`;
+            return isEN
+                ? `${npc.emoji} ${npc.prefix} Hey${nameStr}! Last time you built a lot with ${m.lastMaterial}. And you finished ${m.questsDone.length} quest${m.questsDone.length > 1 ? 's' : ''}!`
+                : `${npc.emoji} ${npc.prefix} Hey${nameStr}! Letztes Mal hast du viel mit ${m.lastMaterial} gebaut. Und ${m.questsDone.length} Quest${m.questsDone.length > 1 ? 's' : ''} geschafft!`;
         }
         if (m.lastMaterial) {
-            return `${npc.emoji} ${npc.prefix} Hey${nameStr}! Letztes Mal hast du viel mit ${m.lastMaterial} gebaut...`;
+            return isEN
+                ? `${npc.emoji} ${npc.prefix} Hey${nameStr}! Last time you built a lot with ${m.lastMaterial}...`
+                : `${npc.emoji} ${npc.prefix} Hey${nameStr}! Letztes Mal hast du viel mit ${m.lastMaterial} gebaut...`;
         }
         if (daysSince !== null && daysSince >= 1) {
-            const dayText = daysSince === 1 ? 'gestern' : `vor ${daysSince} Tagen`;
-            return `${npc.emoji} ${npc.prefix} Schon ${dayText} warst du zuletzt hier${nameStr}!`;
+            const dayText = isEN
+                ? (daysSince === 1 ? 'yesterday' : `${daysSince} days ago`)
+                : (daysSince === 1 ? 'gestern' : `vor ${daysSince} Tagen`);
+            return isEN
+                ? `${npc.emoji} ${npc.prefix} You were last here ${dayText}${nameStr}!`
+                : `${npc.emoji} ${npc.prefix} Schon ${dayText} warst du zuletzt hier${nameStr}!`;
         }
         if (m.questsDone && m.questsDone.length > 0) {
-            return `${npc.emoji} ${npc.prefix} Erinnerst du dich${nameStr}? Wir haben schon ${m.questsDone.length} Quest${m.questsDone.length > 1 ? 's' : ''} zusammen gemacht!`;
+            return isEN
+                ? `${npc.emoji} ${npc.prefix} Remember${nameStr}? We already did ${m.questsDone.length} quest${m.questsDone.length > 1 ? 's' : ''} together!`
+                : `${npc.emoji} ${npc.prefix} Erinnerst du dich${nameStr}? Wir haben schon ${m.questsDone.length} Quest${m.questsDone.length > 1 ? 's' : ''} zusammen gemacht!`;
         }
         return null;
     }

--- a/src/world/chat.js
+++ b/src/world/chat.js
@@ -820,19 +820,30 @@ Du: "HOLZ! Lok, hörst du das? HOLZ! *tschuff tschuff* Das ist wie Weihnachten u
         const energyPercent = Math.round(((totalBudget - tokenUsage[charId]) / totalBudget) * 100);
         const budgetInfo = `Dein Energie-Level: ${energyPercent}%. ${energyPercent < 30 ? 'Du wirst bald müde — halte dich kurz!' : ''}`;
 
-        // Spracherkennung: NPC antwortet in der Sprache des Kindes (#34)
+        // Spracherkennung: NPC antwortet in der Sprache des Kindes (#34, #62)
         var lastUserMsg = chatHistory.length > 0 ? chatHistory[chatHistory.length - 1].content : '';
+        var detectedLang = 'de';
         var langHint = (function detectLang(msg) {
-            if (/\b(the|is|are|my|you|what|how|can|do|have|this|that|with|for|was|were|would|could|should|will|want|need|like|hello|hi|yes|no|please|thank|thanks|help|where|when|why|who|build|make|create|play)\b/i.test(msg))
+            if (/\b(the|is|are|my|you|what|how|can|do|have|this|that|with|for|was|were|would|could|should|will|want|need|like|hello|hi|yes|no|please|thank|thanks|help|where|when|why|who|build|make|create|play)\b/i.test(msg)) {
+                detectedLang = 'en';
                 return 'The child is writing in English — reply in English.';
-            if (/\b(le|la|les|je|tu|il|elle|nous|vous|ils|elles|est|sont|avec|pour|dans|sur|c'est|qu'est|bonjour|merci|oui|non|comment|quoi|pourquoi)\b/i.test(msg))
+            }
+            if (/\b(le|la|les|je|tu|il|elle|nous|vous|ils|elles|est|sont|avec|pour|dans|sur|c'est|qu'est|bonjour|merci|oui|non|comment|quoi|pourquoi)\b/i.test(msg)) {
+                detectedLang = 'fr';
                 return "L'enfant écrit en français — réponds en français.";
-            if (/\b(el|la|los|las|yo|tú|él|ella|es|son|con|para|en|como|qué|por|hola|gracias|sí|no|dónde|cuándo|jugar|hacer|crear)\b/i.test(msg))
+            }
+            if (/\b(el|la|los|las|yo|tú|él|ella|es|son|con|para|en|como|qué|por|hola|gracias|sí|no|dónde|cuándo|jugar|hacer|crear)\b/i.test(msg)) {
+                detectedLang = 'es';
                 return 'El niño escribe en español — responde en español.';
-            if (/\b(il|la|gli|le|io|tu|lui|lei|è|sono|con|per|in|come|cosa|perché|ciao|grazie|sì|no|dove|quando|giocare|fare|costruire)\b/i.test(msg))
+            }
+            if (/\b(il|la|gli|le|io|tu|lui|lei|è|sono|con|per|in|come|cosa|perché|ciao|grazie|sì|no|dove|quando|giocare|fare|costruire)\b/i.test(msg)) {
+                detectedLang = 'it';
                 return "Il bambino scrive in italiano — rispondi in italiano.";
+            }
             return 'Antworte auf Deutsch.';
         })(lastUserMsg);
+        // Persistieren: NPC-Greeting kann beim nächsten Start die gespeicherte Sprache nutzen (#62)
+        if (lastUserMsg) localStorage.setItem('insel-player-lang', detectedLang);
 
         // System-Prompt: Persönlichkeit FIRST, Regeln kurz
         const safetyRule = charId === 'bernd'

--- a/src/world/materials.js
+++ b/src/world/materials.js
@@ -184,6 +184,9 @@ window.INSEL_MATERIALS = {
     dino:     { emoji: '🦕', label: 'Dinosaurier',   color: '#4CAF50', border: '#388E3C' },
     trex:     { emoji: '🦖', label: 'T-Rex',         color: '#E65100', border: '#BF360C' },
     meteor:   { emoji: '☄️', label: 'Meteorit',      color: '#5D4037', border: '#3E2723' },
+    // === WELTRAUM-PFAD (S32-2 — Oscar erkundet den Weltraum) ===
+    // rocket, moon, alien existieren bereits — nur Mars ist neu
+    mars:     { emoji: '🪐', label: 'Mars',            color: '#FFCCBC', border: '#E64A19' },
 };
 
 // === SCHRIFTROLLEN DER BIBLIOTHEK — Easter Eggs für Neugierige ===

--- a/src/world/recipes.js
+++ b/src/world/recipes.js
@@ -132,4 +132,8 @@ window.INSEL_CRAFTING_RECIPES = [
     { name: 'Dinosaurier',  result: 'dino',    resultCount: 1, ingredients: { fossil: 1, fire: 1 },          desc: 'Fossil + Feuer = Dinosaurier (Jurassic Park lässt grüßen!)' },
     { name: 'T-Rex',        result: 'trex',    resultCount: 1, ingredients: { dino: 1, earth: 1 },           desc: 'Dinosaurier + Erde = T-Rex (König der Urzeit!)' },
     { name: 'Massenaussterben', result: 'fossil', resultCount: 3, ingredients: { trex: 1, meteor: 1 },       desc: 'T-Rex + Meteorit = 3 Fossilien (66 Millionen Jahre her — und doch hier!)' },
+    // === WELTRAUM-PFAD (S32-2 — Oscar erkundet den Weltraum) ===
+    // rocket/moon/alien hatten schon Rezepte — Mars ist das neue Glied im Weltraum-Pfad
+    { name: 'Mars',  result: 'mars', resultCount: 1, ingredients: { moon: 1, ice: 1 }, desc: 'Mond + Eis = Mars (Der rote Planet ist eisig kalt — und der nächste Schritt nach dem Mond!)' },
+    { name: 'Marslandung', result: 'alien', resultCount: 1, ingredients: { mars: 1, rocket: 1 }, desc: 'Mars + Rakete = Alien (Eine Rakete auf dem Mars — und plötzlich: Besuch!)' },
 ];


### PR DESCRIPTION
## Sprint 32 — "Oscar erkundet den Weltraum"

**Sprint Goal:** Weltraum-Pfad (Mars) + Schatzkarte im Sail-Dialog + NPC-Texte auf Englisch.

## Was geliefert wurde

### S32-1: Schatzkarte im Sail-Dialog 🗺️
`showSailDialog()` komplett neu gebaut (rebuild statt patch):
- **3-Wort-Adressen** für jede Insel: `wellen.sand.zuhause` / `zwei.berge.abenteuer` / `knochen.urzeit.staunen`
- **Entdeckt-Badge** (✓ entdeckt / Du bist hier) via localStorage
- **Fortschrittszähler**: "2 von 3 Inseln entdeckt"
- Karten-Layout: Emoji + Name + Beschreibung + Adresse in einer Zeile

Oscar sieht sein Archipel auf einen Blick.

### S32-2: Weltraum-Pfad 🪐
Neues Material: **Mars** (🪐, #FFCCBC) — `rocket`, `moon`, `alien` existierten bereits.

2 neue Rezepte:
```
Mond + Eis       = Mars 🪐       (Der rote Planet ist eisig kalt!)
Mars + Rakete    = Alien 👽      (Eine Rakete auf dem Mars — und plötzlich: Besuch!)
```

Dinos → Weltraum. Natürliche Progression.

### S32-3: #62 NPC-Texte auf Englisch 🇬🇧
- **chat.js**: `detectedLang` wird nach erster Nachricht in `localStorage.setItem('insel-player-lang', lang)` gespeichert
- **game.js** `getNpcMemoryComment()`: Wenn `insel-player-lang === 'en'`, englische Greetings:
  - "Hey! Last time you built a lot with Wood. And you finished 3 quests!"
  - "You were last here yesterday!"
  - "Remember? We already did 2 quests together!"

Oscars englischer Freund vom Spielplatz wird jetzt erkannt.

## Hinweis
Dieser PR basiert auf `feat/sprint-31` (PR #244). Merge-Reihenfolge: #243 → #244 → dieser PR.

## Oscar-Check
Sail-Dialog: "2 von 3 Inseln entdeckt" — Dino-Bucht ✓, Lummerland ✓, Heimatinsel: Du bist hier. Englischer Freund schreibt "hello" → Bernd antwortet auf Englisch + NPC-Greeting auf Englisch.

https://claude.ai/code/session_01B6swcovHb2E4NgdhQxjMYC