### PR TITLE
docs: Sprint-Status 2026-04-09 — STOP-Regel + PR-Merge-Guide

### DIFF
--- a/ops/MEMORY.md
+++ b/ops/MEMORY.md
@@ -6,6 +6,7 @@ Persistent team log. Append-only. Read by all agents.
 
 ## Learnings
 
+| 2026-04-09 | STOP-Regel greift: PR-Chain #251–#257 wartet auf Till, kein neuer Sprint | Sprints 37–43 fertig implementiert. Sprint 44 Retro etablierte STOP-Regel. Heute: Status-Update in SPRINT.md auf main, kein neuer Code. Nächste Session erst wenn Till gemergt hat. |
 | 2026-04-06 | Dritte Doppelte Implementierung Sprint 37 | main = Sprint 36, aber remote hat Sprints 37–43 in offenen PRs. Fehlender Pflichtschritt: `list_pull_requests` VOR jedem Sprint Planning. Wenn offene PRs existieren → stopp, kein neues Coding. |
 | 2026-04-05 | NTP-Fetch im `beforeunload`-Handler funktioniert nicht zuverlässig | `beforeunload` gibt kein Promise-Warten — NTP-Fetch muss bei Session-Start passieren, nicht beim Ende. Ende nimmt `Date.now()` als approximativen Endpunkt (Drift <2s akzeptabel). |
 | 2026-04-05 | Token-Schätzung ohne API-Zugang | Client hat keinen Zugriff auf echte Usage-Daten außer wenn der Provider `data.usage` mitschickt. Schätzung via Zeichenlänge ÷ 3.5 ist reproduzierbar und ehrlich markiert ("~"). Requesty liefert `completion_tokens` — wenn vorhanden, für NPC-Budget weiter verwenden. |

--- a/ops/SPRINT.md
+++ b/ops/SPRINT.md
@@ -1,3 +1,43 @@
+# ⛔ Status 2026-04-09 — STOP (Warten auf Till)
+
+**Letztes Update:** 2026-04-09
+
+## Was implementiert ist (wartet auf Merge)
+
+Sprints 37–43 sind vollständig implementiert. Code existiert in GitHub PRs.
+Kein weiterer autonomer Sprint sinnvoll — Sprint 44 Retro hat STOP-Regel etabliert.
+
+### PR-Chain — Till: Eine Aktion entsperrt alles
+
+| PR | Sprint | Inhalt | Merge-Reihenfolge |
+|----|--------|--------|-------------------|
+| **#257** | Sprint 43 | CI für alle PRs + Backlog auf Stand | → **main zuerst** (unabhängig) |
+| **#251** | Sprint 37 | Onboarding + Long-Press + Palette-Counter | → **main danach** |
+| #252 | Sprint 38 | Weltraum-Töne + Genesis Phase 2 | → feat/sprint-37 |
+| #253 | Sprint 39 | Tetris Easter Egg (Konami-Code) | → feat/sprint-38 |
+| #254 | Sprint 40 | Snake Easter Egg ("snake" tippen) | → feat/sprint-39 |
+| #255 | Sprint 41 | Blocked-Sprint Docs | → feat/sprint-40 |
+| #256 | Sprint 42 | Playwright E2E Tests | → feat/sprint-41 |
+
+**Nach den Merges sieht Oscar:** Neues Onboarding, Weltraum-Töne, Tetris, Snake.
+
+## Was noch fehlt (Human Input — Till)
+
+| # | Item | Was Till tun muss |
+|---|------|-------------------|
+| #78 | Tesla-Nutzertest auswerten | Video schicken |
+| #103 | Stripe Production Links | 5€/10€/25€ in index.html Zeilen 100/106/112 eintragen |
+| #92 | Requesty Key rotieren | Neuen Key bereitstellen |
+| #27 | Cloudflare Worker CORS | Worker.js im Dashboard deployen |
+
+## STOP-Regel (Sprint 44 Retro 2026-04-08)
+
+> Wenn Sprint Review zeigt: alle Items Human Input → kein neuer Sprint.
+> Keine Ceremony ohne neue Information.
+> Nächster Sprint erst wenn Till gemergt hat ODER ein konkretes Item liefert.
+
+---
+
 # Sprint 36 — "Oscar baut Brücken"
 
 **Sprint Goal:** #62 abschließen (FR/ES/IT NPC-Gedächtnis) + Weltraum-Quests + Archipel-Abschluss.


### PR DESCRIPTION
## Was ist das

SPRINT.md auf main war noch auf Sprint-36-Stand. Remote existieren Sprints 37–43 als fertige PRs.

Diese PR bringt main auf Stand: kompakter Status-Block oben in SPRINT.md + STOP-Regel.

## Was Till tun muss

**Reihenfolge:**

1. `#257` → main (unabhängig, sofort)
2. `#251` → main (danach)
3. `#252` → `feat/sprint-37`
4. `#253` → `feat/sprint-38`
5. `#254` → `feat/sprint-39`
6. `#255` → `feat/sprint-40`
7. `#256` → `feat/sprint-41`

**Nach dem Merge sieht Oscar:** Tetris, Snake, Weltraum-Töne, neues Onboarding.

## Human Input nötig

- `#78` Tesla-Video schicken
- `#103` Stripe Production Links in index.html (Zeilen 100/106/112)
- `#92` Requesty Key rotieren
- `#27` Cloudflare Worker deployen