### PR TITLE
ops: Daily Scrum Session 30 — Till: nur #270 mergen

### DIFF
--- a/ops/SPRINT.md
+++ b/ops/SPRINT.md
@@ -17,6 +17,21 @@
 
 ## Standup Log
 
+### 2026-04-13 — Daily Scrum (Session 30)
+
+**S47-1:** ✅ Done (PR #256, 2026-04-09).
+**S47-2 + S47-3:** Blockiert — unverändert.
+
+**PR-Schuld: 10 offene PRs.** Till: Bitte nur #270 mergen. Danach schließe ich #271–#280 selbst.
+
+| PR | Aktion |
+|----|--------|
+| #270 | Till: **Mergen** (Sprint 47 Review) |
+| #271–#279 | Nach #270: schließen |
+| #280 | dieser PR — nach #270: schließen |
+
+---
+
 ### 2026-04-12 — Daily Scrum (Session 22)
 
 **S47-1:** ✅ Done.


### PR DESCRIPTION
## Daily Scrum Session 30 — 2026-04-13

Sprint 47 unverändert blockiert.

**S47-1:** ✅ Done (PR #256 gemergt 2026-04-09)
**S47-2:** 🔲 Blocked — Till: Tesla-Video schicken
**S47-3:** 🔲 Blocked — Till: Requesty Dashboard

### PR-Schuld: 10 offene PRs

Till, bitte **nur #270 mergen**. Danach schließe ich alle anderen selbst.

| PR | Inhalt | Aktion |
|----|--------|--------|
| **#270** | Sprint 47 Review | Till: **Jetzt mergen** |
| #271 | Sprint 48 Planning | Danach: Claude schließt |
| #273–#280 | Standup Sessions 23–30 | Danach: Claude schließt alle |

Eine Aktion. Alles andere läuft automatisch.

https://claude.ai/code/session_015q5ZVrPuXvqc9165BxcW3H