### PR TITLE
fix: CI check-Job läuft jetzt bei jedem PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,6 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
   check:
     name: Check
@@ -52,6 +48,9 @@ jobs:
     needs: check
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Problem

`check`-Job in `deploy.yml` tauchte bei PRs nicht in den GitHub Check-Runs auf.

**Ursache:** `concurrency: group: pages` war auf **Workflow-Ebene** gesetzt. Das bedeutet: jeder PR-Workflow-Run und jeder Push-auf-main-Workflow-Run lagen in derselben Concurrency-Gruppe. Mit `cancel-in-progress: false` wartete der PR-Run — und wurde nie als Check-Run sichtbar, solange ein Deploy lief oder in der Queue war.

## Fix

`concurrency:` von Workflow-Ebene auf **Job-Ebene** (`deploy`) verschoben.

- `check`-Job: läuft jetzt sofort bei jedem PR-Event, ohne Concurrency-Block
- `deploy`-Job: hat weiterhin `group: pages` + `cancel-in-progress: false` (GitHub Pages braucht das)
- `deploy-itch`-Job: unverändert

## Test plan

- [ ] PR öffnen → `check`-Job erscheint in Check-Runs
- [ ] Deploy auf main → `check` + `deploy` laufen, `deploy` wartet in `pages`-Gruppe

https://claude.ai/code/session_01HbkmVqN3jFBgja5UrcmCfn