### PR TITLE
ops: Sprint 53 Review + Retro

### DIFF
--- a/ops/MEMORY.md
+++ b/ops/MEMORY.md
@@ -6,6 +6,7 @@ Persistent team log. Append-only. Read by all agents.
 
 ## Learnings
 
+| 2026-04-15 | Sprint 53 Review (Session 54): Sprint Goal ✅ — PR #296 (Quests Runde 12). PR-Queue: 5 PRs (#293→#296) warten auf Till. Kein neues Feature auf main seit Sprint 49. Bottleneck ist Merge, nicht Entwicklung. |
 | 2026-04-15 | Sprint 53 S53 (Session 53): Quests Runde 12 — 10 Quests für Bernd/Haskell/Lua/SQL/Scratch (zweite Runde). PR #296. CI-Fix direkt mitgeliefert. |
 | 2026-04-15 | CI-Patch-Pflicht (S53): Neuer Branch von main = skipBigBang() in critical-path.spec.js prüfen + burn-panel.spec.js CI-Skip-Guard prüfen. Sonst CI rot bei erstem Push. Betrifft jeden Branch bis PR #293 auf main ist. |
 | 2026-04-15 | Sprint 52 S52 (Session 52): Quests Runde 11 (10 Quests für Bernd/Haskell/Lua/SQL/Scratch) implementiert. PR #295. CI initial rot, diese Session gefixt (734e196). |

--- a/ops/SPRINT.md
+++ b/ops/SPRINT.md
@@ -25,6 +25,43 @@
 
 ---
 
+## Sprint Review + Retro (2026-04-15 Session 54)
+
+### Review
+
+**Sprint Goal:** Bernd, Haskell, Lua, SQL und Scratch bekommen ihre zweiten Quests.
+**Ergebnis:** ✅ Sprint Goal erreicht — S53-1 implementiert, PR #296 erstellt.
+
+| Item | Ergebnis |
+|------|----------|
+| S53-1 Quests Runde 12 | ✅ 10 neue Quests: Bernd 2 + Haskell 2 + Lua 2 + SQL 2 + Scratch 2 (PR #296) |
+| S53-2 Carry-Over Merges | ⏳ Blocked — wartet auf Till |
+
+**Sprint Goal erreicht?** Ja — code-seitig 100%. Live-Gang blocked auf Till's Merge-Queue.
+
+**PR-Queue Übersicht (wartet auf Till):**
+- PR #293 → CI-Fix (merge-ready, CI ✅)
+- PR #289 → Sprint 50 (nach #293)
+- PR #294 → Sprint 51 (nach #289)
+- PR #295 → Sprint 52 (nach #294)
+- PR #296 → Sprint 53 (nach #295)
+
+### Retro
+
+**Was lief gut:**
+- Sprint-Rhythmus: Planning → Implementierung → PR in einer Session — funktioniert.
+- Quest-Content-Qualität: zweite Runde Programmierer-Quests hat eigenen Ton (Bernd grumpy, Haskell formal, Lua poetisch).
+
+**Was nicht lief:**
+- PR-Queue wächst. 5 PRs warten auf Till. Quests sind nie live für Oscar.
+- Kein neues spielbares Feature seit Sprint 49 auf main.
+
+**Lerning:**
+- Quest-Content ist fertig. Der Bottleneck ist nicht Entwicklung sondern Merges.
+- Nächster Sprint: kein reines Quest-Sprint wenn die Queue bereits voll ist.
+
+---
+
 ## Standup Log
 
 ### 2026-04-15 — Sprint Planning (Session 53)


### PR DESCRIPTION
## Sprint 53 Review — "Programmierer-Insel Tiefer"

**Sprint Goal:** Bernd, Haskell, Lua, SQL und Scratch bekommen ihre zweiten Quests.
**Ergebnis:** ✅ Sprint Goal erreicht

| Item | Ergebnis |
|------|----------|
| S53-1 Quests Runde 12 | ✅ 10 neue Quests (PR #296) |
| S53-2 Carry-Over Merges | ⏳ Blocked — wartet auf Till |

## Retro

**Bottleneck:** PR-Queue hat 5 PRs (#293→#296) die alle auf Till warten. Kein neues Feature auf main seit Sprint 49.

## Till: Aktionen

Reihenfolge einhalten:
1. **PR #293 mergen** — CI ✅ grün
2. **PR #289 mergen** — S50 live (nach #293)
3. **PR #294 mergen** — S51 live (nach #289)
4. **PR #295 mergen** — S52 live (nach #294)
5. **PR #296 mergen** — S53 live (nach #295)
6. **PRs #292, #291, #290, #288 schließen**

https://claude.ai/code/session_01DS5RgRsmC9iBYXbDV8V7KN