### PR TITLE
Sprint 54 — Magie & Mysterien: Floriane, Mephisto, Alien, Bug (86→96 Quests)

### DIFF
--- a/ops/MEMORY.md
+++ b/ops/MEMORY.md
@@ -6,6 +6,9 @@ Persistent team log. Append-only. Read by all agents.
 
 ## Learnings
 
+| 2026-04-16 | Sprint 54 (Session 54): Quests Runde 13 — 10 Quests für Floriane (3), Mephisto (3), Alien (2), Bug (2). PR #298. CI-Fix burn-panel.spec.js skip guard mitgeliefert (PR #293 noch nicht auf main). |
+| 2026-04-16 | burn-panel.spec.js CI-Fix: test.describe + test.skip(!!process.env.CI) kapselt externe URL-Tests. Solange PR #293 nicht auf main ist, muss jeder neue Branch diesen Fix mitliefern. |
+
 | 2026-04-06 | Dritte Doppelte Implementierung Sprint 37 | main = Sprint 36, aber remote hat Sprints 37–43 in offenen PRs. Fehlender Pflichtschritt: `list_pull_requests` VOR jedem Sprint Planning. Wenn offene PRs existieren → stopp, kein neues Coding. |
 | 2026-04-05 | NTP-Fetch im `beforeunload`-Handler funktioniert nicht zuverlässig | `beforeunload` gibt kein Promise-Warten — NTP-Fetch muss bei Session-Start passieren, nicht beim Ende. Ende nimmt `Date.now()` als approximativen Endpunkt (Drift <2s akzeptabel). |
 | 2026-04-05 | Token-Schätzung ohne API-Zugang | Client hat keinen Zugriff auf echte Usage-Daten außer wenn der Provider `data.usage` mitschickt. Schätzung via Zeichenlänge ÷ 3.5 ist reproduzierbar und ehrlich markiert ("~"). Requesty liefert `completion_tokens` — wenn vorhanden, für NPC-Budget weiter verwenden. |

--- a/ops/SPRINT.md
+++ b/ops/SPRINT.md
@@ -1,3 +1,61 @@
+# Sprint 54 — "Magie & Mysterien"
+
+**Sprint Goal:** Floriane, Mephisto, Alien und Bug bekommen neue Quests. Oscar taucht heute tiefer in die magische Seite der Insel ein.
+**Start:** 2026-04-16
+
+---
+
+## Sprint Backlog
+
+| # | Item | Owner(s) | Status |
+|---|------|----------|--------|
+| S54-1 | **Quests Runde 13** — 10 neue Quests (86→96): Floriane (3), Mephisto (3), Alien (2), Bug (2) | Artist | ✅ PR #298 |
+| S54-2 | **Carry-Over Merges** — PRs #293, #289, #294, #295, #296 landen auf main wenn Till mergt | Engineer | ⏳ wartet auf Till |
+
+---
+
+## Carry-Over (Human Input blockiert)
+
+| # | Item | Blocker |
+|---|------|---------|
+| S48-1 | Tesla-Nutzertest auswerten | ⏳ Till: Video schicken |
+| S48-2 | Requesty Key rotieren ⚠️ | ⏳ Till: Requesty Dashboard |
+| S48-3 | Stripe Production-Links | ⏳ Till: Stripe Dashboard |
+| S49-itch | itch.io Upload | ⏳ Till: Butler-Deploy mit `docs/ITCH-IO-COPY.md` |
+
+---
+
+## Standup Log
+
+### 2026-04-16 — Sprint Planning (Session 54)
+
+**Smoke Tests:** Sandbox-Proxy 403 — bekannte Einschränkung, kein App-Problem.
+
+**PR-Status:**
+- PR #293: CI-Fix — merge-ready
+- PR #289: S50 — merge-ready nach #293
+- PR #294: S51 Neue Bewohner — merge-ready nach #289
+- PR #295: S52 Programmierer-Insel — merge-ready nach #294
+- PR #296: S53 Programmierer-Insel Tiefer — merge-ready nach #295
+- PR #297: S53 Review/Retro docs — offen
+
+**Sprint 53 abgeschlossen:** Review + Retro in PR #297.
+
+**Sprint 54:** S54-1 (Quests Runde 13 — Floriane/Mephisto/Alien/Bug) wird diese Session implementiert. CI-Fix (burn-panel.spec.js skip guard) mitgeliefert.
+
+**Till: Aktionen:**
+1. **PR #293 mergen** — CI ✅ grün
+2. **PR #289 mergen** — S50 live (nach #293)
+3. **PR #294 mergen** — S51 live (nach #289)
+4. **PR #295 mergen** — S52 live (nach #294)
+5. **PR #296 mergen** — S53 live (nach #295)
+6. **PR #297 mergen** — S53 Docs
+7. **PRs #292, #291, #290, #288 schließen**
+
+---
+
+---
+
 # Sprint 36 — "Oscar baut Brücken"
 
 **Sprint Goal:** #62 abschließen (FR/ES/IT NPC-Gedächtnis) + Weltraum-Quests + Archipel-Abschluss.

--- a/ops/tests/burn-panel.spec.js
+++ b/ops/tests/burn-panel.spec.js
@@ -1,23 +1,27 @@
 const { test, expect } = require('@playwright/test');
 
-test('Burn-Balance wird geladen', async ({ page }) => {
-    await page.goto('https://schatzinsel.app');
-    // Warte auf Balance-Poll (max 5s)
-    await page.waitForFunction(() =>
-        window._mmxBurnBalance !== undefined && window._mmxBurnBalance !== '?',
-        { timeout: 5000 }
-    ).catch(() => {}); // OK wenn Timeout — API kann blocken
+test.describe('Burn Panel (nur lokal)', () => {
+    test.skip(!!process.env.CI, 'Externe URLs in CI nicht erreichbar');
 
-    const bal = await page.evaluate(() => window._mmxBurnBalance);
-    // Balance ist entweder eine Zahl oder '—' (API blockiert)
-    expect(bal).toBeDefined();
-    expect(bal).not.toBe('?');
-});
+    test('Burn-Balance wird geladen', async ({ page }) => {
+        await page.goto('https://schatzinsel.app');
+        // Warte auf Balance-Poll (max 5s)
+        await page.waitForFunction(() =>
+            window._mmxBurnBalance !== undefined && window._mmxBurnBalance !== '?',
+            { timeout: 5000 }
+        ).catch(() => {}); // OK wenn Timeout — API kann blocken
 
-test('Burn-Proxy Worker antwortet', async ({ request }) => {
-    const res = await request.get('https://schatzinsel.hoffmeyer-zlotnik.workers.dev/burn');
-    expect(res.ok()).toBeTruthy();
-    const data = await res.json();
-    expect(data).toHaveProperty('ts');
-    expect(data).toHaveProperty('mmx');
+        const bal = await page.evaluate(() => window._mmxBurnBalance);
+        // Balance ist entweder eine Zahl oder '—' (API blockiert)
+        expect(bal).toBeDefined();
+        expect(bal).not.toBe('?');
+    });
+
+    test('Burn-Proxy Worker antwortet', async ({ request }) => {
+        const res = await request.get('https://schatzinsel.hoffmeyer-zlotnik.workers.dev/burn');
+        expect(res.ok()).toBeTruthy();
+        const data = await res.json();
+        expect(data).toHaveProperty('ts');
+        expect(data).toHaveProperty('mmx');
+    });
 });

--- a/src/world/quests.js
+++ b/src/world/quests.js
@@ -100,4 +100,19 @@ window.INSEL_QUEST_TEMPLATES = [
     { npc: 'alien', title: 'Weltraum-Observatorium', desc: '*bloop* Wir brauchen ein Observatorium — um euren blauen Planeten von hier oben zu beobachten. Mit Glas. Riesig.', needs: { mars: 1, glass: 5, stone: 6, lamp: 3 }, reward: '⭐⭐⭐⭐' },
     { npc: 'alien', title: 'Botschaft der Sterne', desc: 'Interessant... *bloop* ...Ihr seid die ersten die eine Botschaft für uns bauen. Das wird notiert. Überall.', needs: { alien: 1, stone: 6, lamp: 4, door: 2, flag: 2 }, reward: '👽👽👽👽' },
     { npc: 'alien', title: 'Weltraum-Forscher', desc: '...Ihr habt Rakete, Mond, Mars und uns besucht. *bloop* Wir sind beeindruckt. Das kam selten vor. Baut das Museum.', needs: { rocket: 1, moon: 1, mars: 1, alien: 1, glass: 4, stone: 4 }, reward: '🌌🌌🌌🌌🌌' },
+    // === RUNDE 13 — Magie & Mysterien ===
+    // Floriane: tiefere Wünsche
+    { npc: 'floriane', title: 'Traumpalast', desc: '✨ Dieser Palast existiert nur im Traum — bis du ihn baust! Kristall fängt Mondlicht, Sterne geben ihm Namen!', needs: { crystal: 4, moon: 1, star: 2, glass: 4 }, reward: '✨✨✨✨✨✨' },
+    { npc: 'floriane', title: 'Wunschbriefe', desc: '✨ Jeder Brief trägt einen Wunsch! Die Schriftrolle, der Brunnen, die Blumen — alles muss PERFEKT sein. Wünsche sind ernst!', needs: { scroll: 2, fountain: 1, flower: 6, star: 1 }, reward: '✨✨✨✨' },
+    { npc: 'floriane', title: 'Glückssteinpfad', desc: '✨ Jeder Stein auf diesem Weg bringt Glück — aber nur wenn man langsam geht und an Wünsche denkt! Versprochen!', needs: { stone: 6, crystal: 2, rainbow: 1, path: 6 }, reward: '✨✨✨✨✨' },
+    // Mephisto: Post-Pakt
+    { npc: 'mephisto', title: 'Höllenbibliothek', desc: 'Bücher die brennen wenn man lügt... das sind meine Lieblingsbücher. Holz für die Regale. Glas damit man sieht was darin steht. Hehehehe...', needs: { wood: 6, glass: 4, lamp: 3, skull: 1 }, reward: '🎭🎭🎭🎭' },
+    { npc: 'mephisto', title: 'Ewige Flamme', desc: 'Feuer das nie erlischt. Der Phönix kennt das Geheimnis — er stirbt und lebt. Das ist kein Versprechen. Das ist ein Beweis. Hehehehe...', needs: { fire: 4, phoenix: 1, crystal: 2, stone: 6 }, reward: '🎭🎭🎭🎭🎭' },
+    { npc: 'mephisto', title: 'Schuldbuch-Turm', desc: 'Jede Abmachung wird notiert. Turm. Schriftrolle. Licht das nie schläft. Und ein Tor damit ich die RICHTIGEN rein lasse. Deal?', needs: { tower: 1, scroll: 3, lamp: 4, door: 2 }, reward: '🎭🎭🎭🎭🎭🎭' },
+    // Alien: Erstkontakt-Fortsetzung
+    { npc: 'alien', title: 'Erstkontakt-Protokoll', desc: '*bloop* Ihr seid die erste Insel die wir offiziell registriert haben. Ein Protokoll muss sein. Stein. Tafel. Licht. Flagge. Für die Aufzeichnungen.', needs: { stone: 6, lamp: 3, flag: 3, scroll: 1 }, reward: '👽👽👽' },
+    { npc: 'alien', title: 'Sternenkarte', desc: '...Diese Karte zeigt den Weg zu unserer Heimat. *bloop* Glas damit man hindurchschauen kann. Vielleicht besucht ihr uns eines Tages. Wir warten.', needs: { glass: 5, star: 3, moon: 1, stone: 4 }, reward: '🌌🌌🌌' },
+    // Bug: Vorbereitungen auf die Verwandlung
+    { npc: 'bug', title: 'Kokon-Kabinett', desc: '🐛 Eines Tages... EINES TAGES werde ich ein Schmetterling! Noch nicht. Aber das Kabinett ist BEREIT! Mit Glas! Und Blumen! Und Hoffnung!', needs: { glass: 4, flower: 6, plant: 4, tree: 2 }, reward: '🐛🐛🐛🐛' },
+    { npc: 'bug', title: 'Wurm-Wanderweg', desc: '🐛 ENDLICH ein Weg der auch für Raupen gebaut ist! Kein Wurm stolpert mehr! Breite Wege! Viele Pilze zum Snacken! Das ist DESIGN!', needs: { path: 8, mushroom: 4, plant: 3, fence: 2 }, reward: '🐛🐛🐛' },
 ];


### PR DESCRIPTION
## Sprint 54 — "Magie & Mysterien"

**Sprint Goal:** Floriane, Mephisto, Alien und Bug bekommen neue Quests. Oscar taucht tiefer in die magische Seite der Insel ein.

## Quests Runde 13 — 86→96 (+10)

### ✨ Floriane (3 neue Quests — tiefere Wünsche)
- **Traumpalast** — crystal (4) + moon + star (2) + glass (4). Dieser Palast existiert nur im Traum — bis Oscar ihn baut!
- **Wunschbriefe** — scroll (2) + fountain + flower (6) + star. Jeder Brief trägt einen Wunsch — alles muss PERFEKT sein.
- **Glückssteinpfad** — stone (6) + crystal (2) + rainbow + path (6). Jeder Stein bringt Glück wenn man langsam geht.

### 🎭 Mephisto (3 neue Quests — Post-Pakt Arc)
- **Höllenbibliothek** — wood (6) + glass (4) + lamp (3) + skull. Bücher die brennen wenn man lügt. Hehehehe...
- **Ewige Flamme** — fire (4) + phoenix + crystal (2) + stone (6). Der Phönix kennt das Geheimnis. Das ist kein Versprechen — das ist ein Beweis.
- **Schuldbuch-Turm** — tower + scroll (3) + lamp (4) + door (2). Jede Abmachung wird notiert. Deal?

### 👽 Alien (2 neue Quests — Erstkontakt-Fortsetzung)
- **Erstkontakt-Protokoll** — stone (6) + lamp (3) + flag (3) + scroll. Ihr seid die erste Insel die wir offiziell registriert haben.
- **Sternenkarte** — glass (5) + star (3) + moon + stone (4). Diese Karte zeigt den Weg zu unserer Heimat. *bloop*

### 🐛 Bug (2 neue Quests — Vorbereitung auf die Verwandlung)
- **Kokon-Kabinett** — glass (4) + flower (6) + plant (4) + tree (2). Eines Tages... EINES TAGES werde ich ein Schmetterling!
- **Wurm-Wanderweg** — path (8) + mushroom (4) + plant (3) + fence (2). ENDLICH ein Weg der auch für Raupen gebaut ist!

## CI-Fix (mitgeliefert)

`burn-panel.spec.js` bekommt `test.describe` + `test.skip(!!process.env.CI)` — externe URLs in CI nicht erreichbar. Solange PR #293 nicht auf main ist, muss jeder Branch diesen Fix mitliefern.

## Merge-Reihenfolge

1. PR #293 mergen (CI-Fix) — dann
2. PR #289 mergen (Sprint 50) — dann
3. PR #294 mergen (Sprint 51) — dann
4. PR #295 mergen (Sprint 52) — dann
5. PR #296 mergen (Sprint 53) — dann
6. **Diesen PR mergen (Sprint 54)**

Hinweis: Alle Sprints branchen von main (86 Quests). Merge-Konflikte am Array-Ende sind trivial — alle Quest-Blöcke behalten.

## Test plan

- [ ] Oscar öffnet Quests-Tab → sieht neue Quests von Floriane, Mephisto, Alien, Bug
- [ ] Florians Quests klingen magisch und sehnsuchtsvoll
- [ ] Mephistos Quests klingen geheimnisvoll mit "Hehehehe..."
- [ ] `tsc --noEmit` — grün
- [ ] CI Check-Job: grün (burn-panel extern skip)

https://claude.ai/code/session_01QfwercP4sFQcZmy4FJT2Tm