### PR TITLE
fix(render): Insel verschwindet nicht mehr im Tesla bei schnellem Blocksetzen

### DIFF
--- a/docs/stories/kapitel-10-die-insel-singt-im-nebel.md
+++ b/docs/stories/kapitel-10-die-insel-singt-im-nebel.md
@@ -1,0 +1,202 @@
+# Kapitel 10: Die Insel singt im Nebel
+
+*Erzählt von Tommy Krab, der heute GANZ leise spricht. Weil heute zum Zuhören ist.*
+
+---
+
+Klick... klack.
+
+Pssst. Noch leiser. So.
+
+Wisst ihr — ich hab euch letztes Mal erzählt, wie wir abgelegt haben. Das 🧣-Segel gefüllt. 🐘 vorne mit der Rüssel-Nase. 🧽 oben auf dem Mast. 🦄 in der Mitte, schon ein bisschen grün um die Nase, aber tapfer. Tapfer ohne NEIN.
+
+Und jetzt? Jetzt muss ich euch erzählen, was in der Nacht passiert ist. Auf dem 🌊. Auf dem Weg zur 🧊-🏝️.
+
+Setzt euch nah ran. Klick-klack. Diese Geschichte ist für die Ohren.
+
+---
+
+Die ☀️ war weg. Die 🟣 auch. Kein Mond. Keine ⭐.
+
+Nur 🌫️.
+
+Nebel. So dick dass 🧽 oben am Mast "ICH SEHE NICHTS MEHR!" gerufen hat. Zum ersten Mal. Normalerweise sieht 🧽 ja IMMER das 🌊. Aber heute — nichts.
+
+🐘 hat sein 🔵 Licht angemacht. Das hat geholfen. Ein bisschen. Aber der Nebel hat das Licht einfach — klick-klack — AUFGESAUGT. Wie wenn man einen 🧽 in einen Eimer taucht. Weg.
+
+"Wo sind wir?", hat 🦆 gequakt. Leise.
+
+"Pieps?", hat 🐭 gepiepst. Noch leiser.
+
+🦀 hat seine Rechen-Tafel raus geholt. Aber er konnte die Zahlen nicht sehen. Er hat sie trotzdem gerechnet. Im Kopf. Weil 🦀 — klick-klack — immer rechnet.
+
+---
+
+Das Kind stand vorne. Neben 🐘. Der Rüssel-Nase. Und hat einfach nur gelauscht.
+
+Ich bin langsam hin. Klick-klack. Leise. Damit ich das Kind nicht störe.
+
+"Tommy", hat das Kind geflüstert. "Hörst du das?"
+
+Ich habe gelauscht. Ich habe meine Krabben-Ohren ganz lang gemacht. Klick-klack. Ich höre normalerweise gut. Unter Wasser. Im Sand. Im Wind.
+
+Ich habe — nichts gehört.
+
+"Was meinst du?", habe ich zurück geflüstert.
+
+"Da ist ein Lied", hat das Kind gesagt. "Ganz leise. Immer. Es hört nie auf."
+
+---
+
+Das Kind hat die 🎧 aufgesetzt. Die Kopfhörer. Die kleinen, die Papa ihm gegeben hat. Und dann —
+
+— und dann sind die Augen vom Kind GROSS geworden.
+
+"Tommy", hat das Kind gesagt. Ganz ehrfürchtig. "Die 🏝️ SINGT. Auch wenn ich sie nicht SEHE. Sie singt WEITER."
+
+🧽 ist vom Mast geklettert. Er wollte auch hören. 🦄 hat den Kopf gehoben. 🐭 und 🦆 haben aufgehört zu piepsen und zu quaken.
+
+Alle haben gelauscht.
+
+---
+
+Und dann — klick-klack — habe ich es auch gehört.
+
+Ein Brummen. So tief dass man es fast nicht hört. Man fühlt es eher. In den Scheren. In der Schale. In der Brust.
+
+Wuuuuummm... wuuuummm...
+
+Und darüber, ganz leise, eine Tonleiter. Fünf Töne. Rauf, runter, rauf. Die Töne die wir schon kennen — vom 🌳 unter der Erde. Die singende Palme. Das Lied vom 🐘.
+
+Nur — schwächer. Wie durch Watte. Wie von weit weg. Aber DA.
+
+---
+
+"Papa sagt, das ist Wu Xing", hat das Kind geflüstert.
+
+🦀 hat die Rechen-Tafel weggelegt. Er hat nicht gerechnet. Er hat GEHORCHT.
+
+"Papa sagt, die 🏝️ singen immer. Auch wenn man sie nicht sieht. Weil — weil — weil die Insel einen HERZSCHLAG hat. Und der hört nie auf. Nie."
+
+"Aber", hat 🦄 gefragt — und das war das Besondere, denn 🦄 hat normalerweise NEIN gesagt, heute aber ABER — "aber wenn die 🏝️ weg ist? Wenn es keine 🏝️ mehr gibt? Dann singt doch niemand mehr?"
+
+Das Kind hat gelächelt. In der Dunkelheit. Ich habe es gesehen — weil 🐘s 🔵 Licht auf den Zähnen vom Kind geleuchtet hat.
+
+"Papa sagt, es singt IMMER noch. Von ganz, ganz früher. Vom Anfang. Das Lied hört nie auf. Es wird nur leiser. Aber es ist immer da."
+
+---
+
+Klick-klack. Ich verstehe nicht alles was Papa dem Kind erzählt. Ich bin ja nur eine Krabbe. Aber ich habe verstanden — und das kann ich euch weitergeben:
+
+Es gibt Lieder, die hört man nicht, wenn man nicht zuhört.
+Es gibt Inseln, die sieht man nicht, wenn man nicht lauscht.
+Es gibt Dinge, die sind DA, auch wenn wir sie nicht sehen.
+
+Wie der ⚓ unter dem 🌊. Wie das 🌳 unter der Erde. Wie das Herz in der Brust.
+
+---
+
+Das Kind hat das Steuer ein bisschen nach links gedreht. Dahin, wo das Brummen LAUTER war.
+
+🐭 und 🦆 haben sofort mit geholfen. Pieps. Quak. Pieps. Quak. Das Schiff hat sich gedreht.
+
+Der Wind hat den 🧣 aufgebläht. Vorwärts. In den Nebel. Dem Lied entgegen.
+
+"Tommy", hat das Kind gesagt. "Wir FAHREN zur Musik."
+
+"Ja, Kind."
+
+"Und wenn wir sie nicht sehen — wir HÖREN sie noch?"
+
+"Ja, Kind. Immer."
+
+"Versprochen?"
+
+Klick-klack.
+
+"Versprochen."
+
+---
+
+🧽 ist wieder den Mast hoch. Hat diesmal nicht geschaut — sondern gehört. Mit seinen Löchern. Er hat VIELE Löcher. Damit kann er gut hören. Besser als sehen.
+
+"ICH HÖRE SIE!", hat 🧽 gerufen — aber leise, flüsternd, weil er gemerkt hat dass das hier keine Ruf-Sache ist. "Ich höre sie LINKS! Und vorne! Und — und etwas höher!"
+
+🐘 hat getörööt. Ganz tief. Sein Rüssel hat vibriert. "Das ist meine Note", hat 🐘 gesagt. "Die Insel antwortet mir."
+
+Und dann — klick-klack — hat 🐘 ein einziges Tööö in den Nebel geschickt. Leise. Ein warmes, rundes Tööö.
+
+Und der Nebel hat ZURÜCK gesungen.
+
+---
+
+Es war, als würde der Nebel selbst Musik machen. Als wäre jeder Tropfen Wasser ein kleiner Ton. Wir sind durch ein Vorhang aus Klang gefahren.
+
+🦀 hat Tränen in den Augen gehabt. Nicht weil es teuer war. Sondern weil es SCHÖN war. (Das ist etwas Neues für 🦀. Es zu verstehen wird — klick-klack — noch Jahre dauern. Aber heute hat er angefangen.)
+
+🦄 hat seine Nase ins Horn gelegt. Und sein 🌈 hat ganz leise geglüht, im Takt des Brummens.
+
+Das Kind hat die Augen zu gemacht. Hat einfach nur zugehört.
+
+---
+
+Und dann — weit vorne — durch den Nebel — ein Lichtpunkt.
+
+🔵. Blau. Wie 🐘s Licht, aber kleiner. Weiter weg.
+
+"Da", hat das Kind gesagt. "Die 🏝️. Sie ist DA."
+
+🧽: "ICH SEHE SIE AUCH!"
+
+🐭 und 🦆: Pieps-Quak-JA!
+
+🦀: "Sicht-Kosten: 0 ⭐. Hör-Kosten: 0 ⭐. Das Universum ist heute GRATIS."
+
+🦄: "...nicht NEIN."
+
+🐘: Tööööö. Lang. Froh.
+
+Und ich? Klick-klack. Ich habe meinen ⚓ bereit gemacht. Der schwarze Stein. Mit den weißen Linien. Der wichtig ist, auch wenn ihn keiner sieht.
+
+---
+
+Die 🏝️ war noch weit. Wir sind noch nicht angekommen. Das ist morgen.
+
+Aber heute haben wir gelernt: Man muss nicht immer SEHEN um zu WISSEN. Manchmal reicht HÖREN. Manchmal reicht FÜHLEN. Manchmal reicht VERTRAUEN.
+
+Die Insel ist DA.
+Auch wenn sie unsichtbar ist.
+Auch wenn der Nebel dick ist.
+Auch wenn die ☀️ weg ist.
+
+Sie singt weiter. Immer.
+
+---
+
+*Tommy legt die Scheren übereinander. Ganz still. Er hört noch das Brummen.*
+
+*Das Kind hat sich neben 🐘 eingerollt. Kopfhörer noch auf. Das Lied spielt weiter.*
+
+*🧽 oben am Mast döst. 🦄 in der Mitte döst. 🐭 und 🦆 halten noch die Hand am Steuer — eine Hand jeder, beide eingeschlafen, aber das Steuer hält.*
+
+*Der Nebel wird heller. Aber das Lied — das Lied wird nur lauter. Nicht deutlicher. Lauter.*
+
+*Wuuuummm... wuuuummm...*
+
+*Gute Nacht, ihr Kleinen.* 🌙
+
+*Und denkt dran: Wenn ihr nachts die Augen zu macht und es ganz still ist — dann hört genau hin.*
+
+*Da ist ein Brummen. Tief und weit weg. Immer.*
+
+*Das ist die 🏝️. Die singt. Auch für euch.*
+
+*Klick... klack...*
+
+---
+
+*Nächstes Mal: Wir kommen auf der 🧊-🏝️ an. Und da wohnt — nein, das verrate ich noch nicht. Nur so viel: es ist KALT. Und es ist HERZLICH. Beides gleichzeitig. Wie wenn man aus dem Schnee in die Küche kommt und da ist 🍵.*
+
+*Aber das ist eine andere Geschichte.*
+
+*Klick... klack...*

--- a/src/core/game.js
+++ b/src/core/game.js
@@ -2210,7 +2210,12 @@
 
         // === ISOMETRISCHER MODUS ===
         if (isoMode && window.ISO_RENDERER) {
-            drawIso();
+            try {
+                drawIso();
+            } catch (err) {
+                if (!draw._isoErrLogged) { console.warn('[render] drawIso failed:', err); draw._isoErrLogged = true; }
+                needsRedraw = true; // nächsten Frame nochmal versuchen
+            }
             return;
         }
 

--- a/src/core/iso-renderer.js
+++ b/src/core/iso-renderer.js
@@ -167,7 +167,7 @@
 
                 // Material — isometric cube!
                 if (grid[r][c]) {
-                    const mat = MATERIALS[grid[r][c]];
+                    const mat = MATERIALS[grid[r][c]] || { emoji: '❓', label: grid[r][c], color: '#888', border: '#666' };
                     let topColor;
 
                     if (grid[r][c] === 'tao') {
@@ -270,7 +270,7 @@
         const pos = gridToIso(gr, gc, cellSize, originX, originY);
 
         if (currentTool === 'build') {
-            const mat = MATERIALS[currentMaterial];
+            const mat = MATERIALS[currentMaterial] || { emoji: '❓', label: currentMaterial, color: '#888', border: '#666' };
             const topColor = mat.color;
             const leftColor = adjustColor(topColor, -30);
             const rightColor = adjustColor(topColor, -55);


### PR DESCRIPTION
## Symptom (Till, 2026-04-19)

> "das bild flackert im tesla wenn oscar schnell blöcke setzt, ab und zu
> verschwindet die insel, aber blöcke setzen geht noch, obwohl die insel
> nicht sichtbar ist"

## Root Cause

Asymmetrie zwischen den zwei Renderern:

- **Flat-Renderer** (`src/core/game.js:2271`):
  `MATERIALS[grid[r][c]] || { emoji: '❓', label: ..., color: '#888', border: '#666' }` ✅
- **Iso-Renderer** (`src/core/iso-renderer.js:170` + `:273`):
  `MATERIALS[grid[r][c]]` → `mat.color` 💥 TypeError wenn unbekanntes Material

`drawIso` füllt zuerst die ganze Canvas mit Wasser (`#2980B9`), dann
zeichnet `drawIsoIsland` die Materialien drüber. Wirft drawIsoIsland
einen TypeError, sieht Oscar nur noch Wasser — die **Insel ist weg**,
aber `grid[][]` ist intakt → Block-Setzen funktioniert weiter.

Ungültige IDs landen z.B. so im Grid:
- LLM-Craft mit neuer ID, bevor MATERIALS aktualisiert ist
- Quest-Reward mit altem/umbenanntem Material
- Auto-Merge mit unbekanntem Result

## Fix

1. `iso-renderer.js` bekommt denselben Fallback wie der Flat-Renderer
   (an beiden Stellen — `drawIsoIsland` und `drawIsoHover`).
2. `drawIso()` wird in try/catch gewickelt — falls in Zukunft ein
   anderer Render-Pfad kracht, blankt nicht die ganze Canvas.
   `console.warn` einmal pro Session (nicht jeden Frame spammen),
   `needsRedraw=true` damit der nächste Frame neu probiert.

## Test plan

- [ ] Auf Tesla-Browser öffnen, Oscar lässt schnell Blöcke setzen
- [ ] Insel bleibt sichtbar, kein Flackern mehr
- [ ] Falls noch Flackern auftritt: DevTools-Console öffnen,
      `[render] drawIso failed:` Eintrag liefert die Stack-Trace
- [ ] Smoke-Test desktop: `❓`-Würfel erscheinen statt Crash wenn
      Material unbekannt

🤖 Generated with [Claude Code](https://claude.com/claude-code)