### PR TITLE
test(playwright): Block/Quest Tests — 18 Tests S94-1

### DIFF
--- a/ops/SPRINT.md
+++ b/ops/SPRINT.md
@@ -1,7 +1,7 @@
-# Sprint 89 — "Triage: Tesla-Fix landet, Runde 69 auf main"
+# Sprint 94 — "Block, Quest, Münze"
 
-**Sprint Goal:** PR #382 (Oscars Tesla-Fix) und PR #383 (Runde 69 — Tommy/Neinhorn/Elefant/Bernd/Maus) sind auf main. PR-Chaos ist sortiert.
-**Start:** 2026-04-20
+**Sprint Goal:** Playwright-Suite komplett (Block/Quest/Stripe-Donate), Live-Launch-Checkliste grün. Oscar sieht jeden Tag Fortschritt.
+**Start:** 2026-04-21
 
 ---
 
@@ -9,26 +9,53 @@
 
 | # | Item | Owner(s) | Status |
 |---|------|----------|--------|
-| S89-1 | **ISO-Renderer Fix** (PR #382) — Insel verschwindet nicht mehr im Tesla | Engineer | 🔲 Human Input (Till mergt) |
-| S89-2 | **Quests Runde 69** (PR #383) — Tommy/Neinhorn/Elefant/Bernd/Maus (+2 je) | Artist | 🔲 Human Input (Till mergt) |
-| S89-3 | **PR-Triage** — Reihenfolge: #382 → #383 → #387 (rebase) → #390 (rebase). Schließen: #384, #385, #386, #388, #389 | Leader | 🔄 Teilweise: #384/#385/#386/#388/#389 geschlossen (Session 97). Merge-Reihenfolge wartet auf Till. |
+| S94-1 | **Playwright Block/Quest Tests** — 18 Tests: Block-Placement Tools (6), Counter (2), Undo (2), Quest-State (3), Quest-Accept+Persist (5) | Engineer | ✅ PR #404 |
+| S94-2 | **Stripe Donation Link** — Donate-Button öffnet Stripe-Checkout-Link. Kein SDK, kein Webhook. | Engineer | 🔲 |
+| S94-3 | **PR-Merge-Queue für Till** — #394→#395→#396→#397→#399→#401→#402 in richtiger Reihenfolge. #400+#403 schließen nach eigenem Merge. | Leader | 🔲 Human Input |
 
 ---
 
-## Sprint Review S88 + Retro (2026-04-20 Session 92)
+## Sprint Review S89 + Retro (2026-04-21 Session 102)
 
-**Sprint Goal erreicht:** ✅
+**Sprint Goal S89 erreicht:** ✅ (via Konsolidierungs-PR #393)
 
 | Item | Ergebnis |
 |------|---------|
-| S88-1 | ✅ Quests Runde 48 (Lokführer/Krämerin/Elefant, 10 Quests) — via Konsolidierungs-PR #381 auf main |
-| S88-2 | ✅ Carry-Over Merges → 696 Quests auf main — via Konsolidierungs-PR #381 |
+| S89-1 | ✅ ISO-Renderer Fix (Tesla-Bug) — auf main via #393 |
+| S89-2 | ✅ Quests R69-R72 + Konsolidierung — 775 Quests auf main (war 696) |
+| S89-3 | ✅ PR-Triage — 5 Duplikat-PRs geschlossen, Merge-Queue dokumentiert |
 
-**Retro S88:** Merge-Marathon hat funktioniert, spawnt aber PR-Chaos wenn mehrere Nacht-Sessions parallel laufen. Alle Haupt-NPCs jetzt bei 52 (Floriane 55, Mephisto 53). Nächste Priorität: PR-Triage.
+**Retro S89:** Nacht-Sessions 93-101 haben 4 weitere Sprints (90-93) generiert. Code voraus, Docs hintendran. 9 offene PRs (#394-#403), alle conflict-free auf `d85f9ed`. #400 schließen nach #403-Merge. Strategie: Weiterimplementieren statt warten.
 
 ---
 
 ## Standup Log
+
+### 2026-04-21 — Sprint Review S89 + Retro + Planning S94 (Session 102)
+
+**Smoke Tests:** Sandbox-Proxy 403 — bekannte Einschränkung, kein App-Problem.
+
+**Sprint 89 faktisch Done:** Tesla-Fix + 775 Quests auf main (via PRs #387/#390/#392/#393). SPRINT.md war 4 Sprints hinter der Realität.
+
+**PR-Queue für Till (9 PRs, conflict-free, alle auf `d85f9ed`):**
+
+| PR | Inhalt | Aktion |
+|----|--------|--------|
+| #394 | Playwright: Craft-Flow (7 Tests) | ✅ Mergen |
+| #395 | Playwright: Sailing + Archipel (7 Tests) | ✅ Mergen |
+| #396 | Quests R73: Krabs/Bug/Tommy (+10) | ✅ Mergen |
+| #397 | Quests R74: Maus/Neinhorn/Spongebob (+10) | ✅ Mergen |
+| #399 | Quests R75: Alien/Elefant/Lokführer (+10) | ✅ Mergen |
+| #400 | Docs: Sprint 91/92 | ❌ Schließen — #403 übernimmt |
+| #401 | Quests R76: Floriane/Mephisto/Kraemerin (+10) | ✅ Mergen |
+| #402 | Playwright: NPC-Dialog (9 Tests) | ✅ Mergen |
+| #403 | Docs: Sprint 92/93 Planning | ✅ Mergen |
+
+Nach allen Merges: **815 Quests, 23+ Playwright Tests in CI.**
+
+**S94-1 gestartet:** Playwright Block/Quest Tests — heute implementiert.
+
+---
 
 ### 2026-04-20 — Daily Scrum S89 (Session 97)
 

--- a/ops/tests/block-quest.spec.js
+++ b/ops/tests/block-quest.spec.js
@@ -1,0 +1,299 @@
+const { test, expect } = require('@playwright/test');
+
+async function skipBigBang(page, stufe = 1) {
+    await page.addInitScript((s) => {
+        localStorage.setItem('insel-grid', '[]');
+        localStorage.setItem('insel-genesis-shown', '1');
+        localStorage.removeItem('insel-player-name');
+        if (s >= 2) localStorage.setItem('insel-blocks-placed', '5');
+        if (s >= 3) localStorage.setItem('insel-unlocked-materials', '["qi","feuer","wasser","erde","holz"]');
+        if (s >= 4) localStorage.setItem('insel-discovered-recipes', '["qi"]');
+        if (s >= 5) localStorage.setItem('insel-quests-done', '["Seed-Quest"]');
+    }, stufe);
+}
+
+async function startGame(page, stufe = 1) {
+    await skipBigBang(page, stufe);
+    await page.goto('/');
+    await page.fill('#player-name-input', 'Testpirat');
+    await page.click('#start-button');
+    await expect(page.locator('#game-canvas')).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('#intro-overlay')).not.toBeVisible({ timeout: 5000 });
+    await page.waitForFunction(() => typeof window.questSystem === 'object', { timeout: 10000 });
+}
+
+async function clickCanvas(page) {
+    const canvas = page.locator('#game-canvas');
+    const box = await canvas.boundingBox();
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+    await page.waitForTimeout(300);
+}
+
+// ── Block-Placement Tools ───────────────────────────────────────────────────
+
+test.describe('Block-Placement Tools', () => {
+
+    test('Build-Tool ist beim Start aktiv', async ({ page }) => {
+        await startGame(page);
+        const buildBtn = page.locator('[data-tool="build"]');
+        await expect(buildBtn).toHaveClass(/active/);
+    });
+
+    test('Harvest-Tool wird nach Klick aktiv', async ({ page }) => {
+        await startGame(page);
+        const harvestBtn = page.locator('[data-tool="harvest"]');
+        await harvestBtn.click();
+        await expect(harvestBtn).toHaveClass(/active/);
+    });
+
+    test('Fill-Tool wird nach Klick aktiv', async ({ page }) => {
+        await startGame(page);
+        const fillBtn = page.locator('[data-tool="fill"]');
+        await fillBtn.click();
+        await expect(fillBtn).toHaveClass(/active/);
+    });
+
+    test('Tool-Wechsel Fill → Build: Build wird aktiv, Fill nicht mehr', async ({ page }) => {
+        await startGame(page);
+        const fillBtn = page.locator('[data-tool="fill"]');
+        const buildBtn = page.locator('[data-tool="build"]');
+        await fillBtn.click();
+        await expect(fillBtn).toHaveClass(/active/);
+        await buildBtn.click();
+        await expect(buildBtn).toHaveClass(/active/);
+        await expect(fillBtn).not.toHaveClass(/active/);
+    });
+
+    test('Alle drei Tool-Buttons sind im DOM vorhanden', async ({ page }) => {
+        await startGame(page);
+        await expect(page.locator('[data-tool="build"]')).toBeVisible();
+        await expect(page.locator('[data-tool="harvest"]')).toBeVisible();
+        await expect(page.locator('[data-tool="fill"]')).toBeVisible();
+    });
+
+    test('Nur ein Tool-Button aktiv gleichzeitig (Exklusivität)', async ({ page }) => {
+        await startGame(page);
+        await page.locator('[data-tool="harvest"]').click();
+        const activeCount = await page.locator('[data-tool].active').count();
+        expect(activeCount).toBe(1);
+    });
+
+});
+
+// ── Block-Placement Counter ─────────────────────────────────────────────────
+
+test.describe('Block-Placement Counter', () => {
+
+    test('insel-blocks-placed steigt nach Canvas-Klick', async ({ page }) => {
+        await page.addInitScript(() => {
+            localStorage.setItem('insel-grid', '[]');
+            localStorage.setItem('insel-genesis-shown', '1');
+            localStorage.removeItem('insel-player-name');
+            localStorage.setItem('insel-blocks-placed', '0');
+        });
+        await page.goto('/');
+        await page.fill('#player-name-input', 'Testpirat');
+        await page.click('#start-button');
+        await expect(page.locator('#game-canvas')).toBeVisible({ timeout: 15000 });
+        await expect(page.locator('#intro-overlay')).not.toBeVisible({ timeout: 5000 });
+        await page.waitForFunction(() => typeof window.questSystem === 'object', { timeout: 10000 });
+
+        const before = await page.evaluate(() =>
+            parseInt(localStorage.getItem('insel-blocks-placed') || '0')
+        );
+
+        const taoBtn = page.locator('.material-btn[data-material="tao"]');
+        await expect(taoBtn).toBeVisible({ timeout: 5000 });
+        await taoBtn.click();
+        await clickCanvas(page);
+
+        const after = await page.evaluate(() =>
+            parseInt(localStorage.getItem('insel-blocks-placed') || '0')
+        );
+        expect(after).toBeGreaterThan(before);
+    });
+
+    test('Drei Canvas-Klicks erhöhen Counter um mindestens 2', async ({ page }) => {
+        await page.addInitScript(() => {
+            localStorage.setItem('insel-grid', '[]');
+            localStorage.setItem('insel-genesis-shown', '1');
+            localStorage.removeItem('insel-player-name');
+            localStorage.setItem('insel-blocks-placed', '0');
+        });
+        await page.goto('/');
+        await page.fill('#player-name-input', 'Testpirat');
+        await page.click('#start-button');
+        await expect(page.locator('#game-canvas')).toBeVisible({ timeout: 15000 });
+        await expect(page.locator('#intro-overlay')).not.toBeVisible({ timeout: 5000 });
+        await page.waitForFunction(() => typeof window.questSystem === 'object', { timeout: 10000 });
+
+        const taoBtn = page.locator('.material-btn[data-material="tao"]');
+        await expect(taoBtn).toBeVisible({ timeout: 5000 });
+        await taoBtn.click();
+
+        const canvas = page.locator('#game-canvas');
+        const box = await canvas.boundingBox();
+        // Klicke verschiedene Stellen damit nicht dieselbe Zelle getroffen wird
+        await page.mouse.click(box.x + box.width * 0.4, box.y + box.height * 0.4);
+        await page.waitForTimeout(200);
+        await page.mouse.click(box.x + box.width * 0.5, box.y + box.height * 0.5);
+        await page.waitForTimeout(200);
+        await page.mouse.click(box.x + box.width * 0.6, box.y + box.height * 0.6);
+        await page.waitForTimeout(300);
+
+        const count = await page.evaluate(() =>
+            parseInt(localStorage.getItem('insel-blocks-placed') || '0')
+        );
+        expect(count).toBeGreaterThanOrEqual(2);
+    });
+
+});
+
+// ── Undo ────────────────────────────────────────────────────────────────────
+
+test.describe('Undo', () => {
+
+    test('Strg+Z nach Block-Klick: kein JS-Fehler', async ({ page }) => {
+        const errors = [];
+        page.on('pageerror', err => errors.push(err.message));
+
+        await startGame(page);
+
+        const taoBtn = page.locator('.material-btn[data-material="tao"]');
+        await expect(taoBtn).toBeVisible({ timeout: 5000 });
+        await taoBtn.click();
+        await clickCanvas(page);
+
+        await page.keyboard.press('Control+z');
+        await page.waitForTimeout(300);
+
+        const fatal = errors.filter(e =>
+            !e.includes('net::ERR_') &&
+            !e.includes('Failed to load resource') &&
+            !e.includes('WebSocket') &&
+            !e.includes('tts') &&
+            !e.includes('404')
+        );
+        expect(fatal, `JS-Fehler nach Undo: ${fatal.join('\n')}`).toHaveLength(0);
+    });
+
+    test('Strg+Z ohne vorherigen Block: kein JS-Fehler', async ({ page }) => {
+        const errors = [];
+        page.on('pageerror', err => errors.push(err.message));
+
+        await startGame(page);
+
+        await page.keyboard.press('Control+z');
+        await page.waitForTimeout(300);
+
+        const fatal = errors.filter(e =>
+            !e.includes('net::ERR_') &&
+            !e.includes('Failed to load resource') &&
+            !e.includes('WebSocket') &&
+            !e.includes('tts') &&
+            !e.includes('404')
+        );
+        expect(fatal, `JS-Fehler bei Undo ohne Block: ${fatal.join('\n')}`).toHaveLength(0);
+    });
+
+});
+
+// ── Quest State ─────────────────────────────────────────────────────────────
+
+test.describe('Quest State', () => {
+
+    test('getActive() = [] bei frischem Spiel', async ({ page }) => {
+        await startGame(page);
+        const active = await page.evaluate(() => window.questSystem.getActive());
+        expect(active).toEqual([]);
+    });
+
+    test('getCompleted() = [] bei frischem Spiel', async ({ page }) => {
+        await startGame(page);
+        const completed = await page.evaluate(() => window.questSystem.getCompleted());
+        expect(completed).toEqual([]);
+    });
+
+    test('getCompleted() lädt pre-populated Quests aus localStorage', async ({ page }) => {
+        await page.addInitScript(() => {
+            localStorage.setItem('insel-grid', '[]');
+            localStorage.setItem('insel-genesis-shown', '1');
+            localStorage.removeItem('insel-player-name');
+            localStorage.setItem('insel-quests-done', JSON.stringify(['Burger-Stand', 'Handelshafen']));
+        });
+        await page.goto('/');
+        await page.fill('#player-name-input', 'Testpirat');
+        await page.click('#start-button');
+        await expect(page.locator('#game-canvas')).toBeVisible({ timeout: 15000 });
+        await expect(page.locator('#intro-overlay')).not.toBeVisible({ timeout: 5000 });
+        await page.waitForFunction(() => typeof window.questSystem === 'object', { timeout: 10000 });
+
+        const completed = await page.evaluate(() => window.questSystem.getCompleted());
+        expect(completed).toContain('Burger-Stand');
+        expect(completed).toContain('Handelshafen');
+    });
+
+});
+
+// ── Quest Accept + Persist ──────────────────────────────────────────────────
+
+test.describe('Quest Accept + Persist', () => {
+
+    test('Angenommene Quest hat npc + needs-Felder', async ({ page }) => {
+        await startGame(page);
+        const result = await page.evaluate(() => {
+            const quest = window.questSystem.getAvailable('spongebob');
+            if (!quest) return null;
+            window.questSystem.accept(quest);
+            const active = window.questSystem.getActive();
+            return active.find(q => q.npc === 'spongebob') || null;
+        });
+        expect(result).not.toBeNull();
+        expect(result.npc).toBe('spongebob');
+        expect(result.needs).toBeDefined();
+        expect(typeof result.needs).toBe('object');
+    });
+
+    test('Angenommene Quest persistiert in localStorage', async ({ page }) => {
+        await startGame(page);
+        await page.evaluate(() => {
+            const quest = window.questSystem.getAvailable('krabs');
+            if (quest) window.questSystem.accept(quest);
+        });
+        const stored = await page.evaluate(() =>
+            JSON.parse(localStorage.getItem('insel-quests') || '[]')
+        );
+        expect(stored.length).toBeGreaterThan(0);
+        expect(stored[0].npc).toBeDefined();
+    });
+
+    test('getAvailable() gibt null zurück wenn Quest bereits aktiv', async ({ page }) => {
+        await startGame(page);
+        const result = await page.evaluate(() => {
+            const quest = window.questSystem.getAvailable('elefant');
+            if (!quest) return 'no-quest';
+            window.questSystem.accept(quest);
+            const again = window.questSystem.getAvailable('elefant');
+            return again;
+        });
+        expect(result).toBeNull();
+    });
+
+    test('Quest-Title ist ein nicht-leerer String', async ({ page }) => {
+        await startGame(page);
+        const title = await page.evaluate(() => {
+            const quest = window.questSystem.getAvailable('maus');
+            return quest ? quest.title : null;
+        });
+        expect(title).not.toBeNull();
+        expect(typeof title).toBe('string');
+        expect(title.length).toBeGreaterThan(0);
+    });
+
+    test('getActive() gibt immer ein Array zurück', async ({ page }) => {
+        await startGame(page);
+        const active = await page.evaluate(() => window.questSystem.getActive());
+        expect(Array.isArray(active)).toBe(true);
+    });
+
+});


### PR DESCRIPTION
## Summary

18 neue Playwright-Tests für Block-Placement und Quest-System (S94-1, Teil von #103 Live Launch).

**Block-Placement Tools (6 Tests):**
- Build-Tool ist beim Start aktiv (`[data-tool="build"].active`)
- Harvest-Tool wird nach Klick aktiv
- Fill-Tool wird nach Klick aktiv
- Tool-Wechsel Fill → Build: Build aktiv, Fill nicht mehr
- Alle 3 Tool-Buttons im DOM vorhanden
- Nur ein Tool aktiv gleichzeitig (Exklusivität)

**Block Counter (2 Tests):**
- `insel-blocks-placed` steigt nach Canvas-Klick
- Drei Klicks erhöhen Counter um mindestens 2

**Undo (2 Tests):**
- Strg+Z nach Block-Klick: kein JS-Fehler
- Strg+Z ohne vorherigen Block: kein JS-Fehler

**Quest State (3 Tests):**
- `getActive()` = `[]` bei frischem Spiel
- `getCompleted()` = `[]` bei frischem Spiel
- `getCompleted()` lädt pre-populated Quests aus localStorage

**Quest Accept + Persist (5 Tests):**
- Angenommene Quest hat `npc` + `needs`-Felder
- Quest persistiert in `insel-quests` localStorage
- `getAvailable()` gibt `null` zurück wenn Quest bereits aktiv
- Quest-Title ist nicht-leerer String
- `getActive()` gibt immer Array zurück

Sprint 89 Review + Retro + Planning S94 in `ops/SPRINT.md`.

## Merge-Queue für Till (9 PRs vor diesem)

Conflict-free — kann nach allen anderen oder direkt gemergt werden.

| PR | Inhalt |
|----|--------|
| #394 | Playwright: Craft-Flow |
| #395 | Playwright: Sailing + Archipel |
| #396 | Quests R73 |
| #397 | Quests R74 |
| #399 | Quests R75 |
| #401 | Quests R76 |
| #402 | Playwright: NPC-Dialog |
| #403 | Docs Sprint 93 |
| **#404** | **← dieser PR** |

## Test plan

- [x] tsc --noEmit grün
- [ ] CI grün (Playwright 1.58.2 braucht chromium-1208, Sandbox hat 1194 — CI installiert fresh)

https://claude.ai/code/session_012t8DEz4ZGALo7q8hMyXopr