### PR TITLE
feat(palette): Bauklötze größer, Emoji-Font verdoppelt

### DIFF
--- a/style.css
+++ b/style.css
@@ -766,7 +766,7 @@ header h1 {
     cursor: pointer;
     background: rgba(255, 255, 255, 0.85);
     transition: transform 0.15s, border-color 0.15s, box-shadow 0.15s;
-    min-height: 58px;
+    min-height: 84px;
 }
 
 .material-btn:hover {
@@ -830,7 +830,8 @@ header h1 {
 }
 
 .mat-emoji {
-    font-size: 32px;
+    font-size: 64px;
+    line-height: 1;
 }
 
 
@@ -1182,13 +1183,14 @@ body.offline-whisper {
 
     /* Palette: kompakter */
     .material-btn {
-        min-height: 44px;
-        min-width: 44px;
+        min-height: 64px;
+        min-width: 64px;
         padding: 4px;
     }
 
     .mat-emoji {
-        font-size: 24px;
+        font-size: 48px;
+        line-height: 1;
     }
 
     /* Canvas: maximale Fläche */
@@ -1724,11 +1726,12 @@ body.code-view-active #chat-settings-btn {
     }
 
     #palette {
-        width: 160px;
+        width: 180px;
     }
 
     .mat-emoji {
-        font-size: 32px;
+        font-size: 72px;
+        line-height: 1;
     }
 
     #stats {
@@ -2117,10 +2120,10 @@ body.code-view-active #chat-settings-btn {
         border-bottom: 1px solid rgba(255, 255, 255, 0.2);
     }
 
-    /* Palette-Buttons: 52x52px — touch-freundlich */
+    /* Palette-Buttons: 68x68px — touch-freundlich, doppelte Emoji-Größe */
     #palette .material-btn {
-        min-width: 52px;
-        min-height: 52px;
+        min-width: 68px;
+        min-height: 68px;
         flex-shrink: 0;
     }
 


### PR DESCRIPTION
## Summary

Oscars Emojis in der Material-Palette waren zu klein.

- **.mat-emoji**: 32px → 64px (Desktop), 24px → 48px (Mobile), 32px → 72px (4K)
- **.material-btn**: min-height 58px → 84px
- **Mobile Portrait**: Block 52x52 → 68x68 (Touch-freundlich)
- **Mobile Landscape**: Block 44x44 → 64x64
- **4K Palette**: 160 → 180 (Platz für 72px Emoji)
- **line-height: 1** auf Emoji — verhindert vertikales Bleeding

## Kein Overflow / Bleeding

- Desktop-Palette bleibt 120px breit. Blöcke wachsen nach unten, Palette hat `overflow-y: auto`.
- Mobile-Palette hat `overflow-x: auto` — scrollt horizontal statt Canvas zu überlappen.
- Canvas/Stats-Container unverändert.

## Test plan

- [ ] Visual auf Desktop: Emojis doppelt so groß, keine Überlagerung
- [ ] Visual auf iPhone Portrait: Palette scrollt horizontal, Canvas nicht verkleinert
- [ ] Visual auf iPhone Landscape: Touch-Target 64px erreicht

🤖 Generated with [Claude Code](https://claude.com/claude-code)