### PR TITLE
feat(worker): GET /health — Smoke-Test Ersatz (S92-1)

### DIFF
--- a/src/infra/worker.js
+++ b/src/infra/worker.js
@@ -34,6 +34,9 @@ export default {
 
         // URL-basiertes Routing (vor POST-Guard, da /discoveries auch GET erlaubt)
         const { pathname } = new URL(request.url);
+        if (pathname === '/health') {
+            return json({ status: 'ok', ts: Date.now() });
+        }
         if (pathname === '/discoveries') {
             return handleDiscoveries(env);
         }


### PR DESCRIPTION
## Was

3 Zeilen in `src/infra/worker.js`: `GET /health` gibt `{status:"ok", ts:<epoch>}` ohne D1-Call zurück.

## Warum

Retro-Action R3 aus S91: `curl schatzinsel.app` schlägt in der Sandbox immer mit CF-Bot-403 fehl. Der Worker-Endpunkt `/health` ist curl-bar und gibt ein sauberes JSON-Signal — kein Datenbankaufruf, keine Auth. Sobald Till den Worker deployed (HITL #27), kann der autonome Session-Start diesen Endpunkt prüfen.

## Test

Nach CF-Deploy:
```
curl https://schatzinsel.hoffmeyer-zlotnik.workers.dev/health
# → {"status":"ok","ts":1234567890123}
```