### PR TITLE
essay: Beirat + Podcast — Stand Schatzinsel 2026-04-22

### DIFF
--- a/docs/essays/essay-beirat-2026-04-22.md
+++ b/docs/essays/essay-beirat-2026-04-22.md
@@ -1,0 +1,289 @@
+# Der Beirat schaut auf die Insel
+
+*Essay + Podcast — Stand der Schatzinsel am 22. April 2026*
+
+---
+
+## Teil 1 — Der Raum
+
+Stellt euch einen runden Tisch vor. Nicht groß — aber lang genug dass niemand am Katzentisch sitzen muss. Ein Fenster zum Garten. Auf dem Tisch liegt ein iPad. Darauf läuft `schatzinsel.app`. Das Kind spielt nicht. Das Kind ist im Kinderzimmer. Die Erwachsenen schauen sich das Spiel an — allein.
+
+Der Vater sitzt nicht mit am Tisch. Er hat reingestellt was zu sehen ist, Tee gekocht, die Tür zugemacht. Er ist im Garten. Drückt Erde fest. Hört durchs offene Fenster nur das eine Wort: **„Zeig mir die Zahlen."**
+
+Richard Feynman steht auf. Nimmt einen Kreidestift. Schreibt an die Tafel.
+
+```
+Stand heute (2026-04-22):
+
+• 885 Quests auf main (von 196 → 696 → 825 → 885 in 15 Sprints)
+• 12 Story-Kapitel (Tommy Krab erzählt)
+• 5 Inseln (Home, Lummerland, Dino, Mondstation, Mars)
+• 10 NPCs mit eigener Stimme und Gedächtnis
+• 427 PRs (von denen heute 4 in einer Stunde geschlossen wurden)
+• HITL auf 2 Items reduziert: CF-Deploy + ES/IT-Review
+• Oscar hat heute nicht gespielt.
+```
+
+Den letzten Satz unterstreicht Feynman zweimal.
+
+Stille.
+
+---
+
+## Teil 2 — Die Runde
+
+### Seth Godin schaut auf das Board.
+
+„Ist es bemerkenswert?" — er fragt das nicht rhetorisch. Er meint es. „885 Quests. Das ist nicht die Zahl. Die Zahl ist: **eine** Quest. Die erste, die Oscar findet morgen früh. Wenn die nicht bemerkenswert ist, sind die anderen 884 nur Zahlenfutter. Ich würde löschen. Oscar lässt nicht löschen? Okay — dann wenigstens **eine** auswählen, die morgen vorne liegt."
+
+### Simon Sinek stimmt nicht zu.
+
+„Du verwechselst WHAT mit WHY. Das WHY ist unverändert: *Ein Vater baut mit KI Dinge für seine Kinder*. Das ist gehalten. 15 Sprints lang. Das sehe ich in der Codebase, nicht in PowerPoints. Was du siehst, Seth, ist Bulk — aber der Bulk hat ein Warum." Er zeigt auf Kapitel 12. „Mona sagt: *Wer hierher findet, hat das gewollt.* Das ist das Warum, als Szene geschrieben. Nicht gemissbraucht. Bewahrt."
+
+### Joachim Schullerer macht das Fenster weiter auf.
+
+„Ist das hier noch Handwerk? Oder schon Bürokratie?" Er blättert durch `ops/SPRINT-ARCHIVE.md`. 4831 Zeilen. „Der Archiv-Schritt war richtig. 110 Branches gelöscht — das ist nicht destruktiv, das ist **aufräumen vor dem Feierabend**. Wenn ihr den Tisch nicht abwischt, könnt ihr morgen früh nicht frühstücken. Das hier schaut nach einer Küche aus wo jemand wirklich kocht. Noch nicht nach einem Restaurant mit Dienstplan."
+
+### Tommy Krapweis kippt sich Kaffee nach.
+
+„Lacht jemand?" Er tippt auf Kapitel 12. „Okay — ‚Er hat mir zugezwinkert. Ich hab zurückgezwinkert.' Das hab ich laut gelacht. Tommy Krab hat Persönlichkeit. Aber — und jetzt kommt's — lacht **Oscar**? Wenn er nicht spielt, lacht er nicht. Ihr habt 884 Quests gebaut und die eine die zählt — *er lacht jetzt* — habt ihr nicht gemessen."
+
+### Paluten nickt langsam.
+
+„Würde Oscar nach 10 Sekunden weiterspielen? Das ist meine einzige Frage. Ich hab die heute morgen getestet. Boot zeit: okay. Erster Block: 6 Sekunden. Das ist **gut**. Aber — die Palette ist voll. Zu voll. Kind klickt auf Palette, 20 Materialien, Lähmung. Progressive Disclosure ist ein Wort in einem Dokument — im Spiel sehe ich sie noch nicht konsequent. Ich würde 15 Materialien **rausnehmen**, bis die Quest sie freischaltet. Und das nicht übermorgen. Morgen."
+
+### Robert Habeck hat zugehört und schreibt mit.
+
+„Wer ist nicht eingeladen? Fünf Sprachen stehen in der Liste, aber ES und IT sind Icebox. Arabisch und Hebräisch sind live — das ist gut. Französisch macht der Vater heute. ES und IT brauchen einen Menschen — noch nicht einen Agenten. Das ist ehrlich. Das ist Inklusion die weiß wo ihre Grenze ist."
+
+### Albert Camus steht auf. Geht zum Fenster. Spricht nicht sofort.
+
+„Ist das ehrlich — oder Flucht vor der Absurdität?" Er dreht sich um. „Der Vater hat gestern Nacht autonom gemergt. Heute sind vier PRs weg. Das Spiel ist gewachsen. Das Kind — hat nicht gespielt. Wenn das Spiel wächst aber nicht gespielt wird, ist es ein Stein den man den Berg hochschiebt. Ich sage nicht: *hör auf*. Ich sage: **wisse dass es ein Stein ist**. Dann darfst du ihn hochschieben."
+
+### Jean-Paul Sartre schneidet ein.
+
+„Und jetzt das Unbequeme. Autonome Agenten, die nachts mergen, Branches prunen, Sprints fahren — das ist Freiheit die auf etwas projiziert wird, das keine hat. Du kannst das tun. Aber nenn es nicht *Selbstorganisation*. Nenn es: *Ich delegiere an eine Maschine weil ich schlafen will*. Das ist legitim. Aber es ist **deine** Entscheidung, nicht ihre."
+
+### Sokrates fragt nach.
+
+„Weißt du was du tust?" Er zeigt auf die 2 HITL-Items. „Du hast gesagt: *Wenn die 2 durch sind, ist der Backlog HITL-frei*. Das heißt: der Mensch ist raus. Weißt du was passiert dann? Hast du das vorher gedacht? Oder ist das der Punkt an dem du es siehst, wenn er kommt?"
+
+### Pythia spricht leise.
+
+„Frag das Kind. Nicht morgen. **Heute Abend.** Nicht mit Stoppuhr. Nicht mit Score-Screen. Nur: *Oscar — willst du was sehen?* Wenn er Ja sagt, ist das Spiel bereit. Wenn er Nein sagt, ist das auch eine Antwort. Aber **die Antwort kommt vom Kind, nicht vom Metric-Dashboard**."
+
+### Jurgen Appelo schaut auf die Delegation-Matrix.
+
+„Level 7 für den nächtlichen Merge-Agent war richtig — die Entscheidungen waren reversibel. Aber die Entscheidung, **Backlog HITL-frei** zu deklarieren — das ist Level 3, nicht Level 7. Das triffst du, nicht die Agenten. Sei dir sicher dass du es willst, bevor du es sagst."
+
+### Alfred Hitchcock hebt einen Finger.
+
+„Was passiert wenn wir die Quest-Runden weglassen? **Merkt es jemand?** Das ist der MacGuffin-Test. Ich wette: 885 → 800, und niemand im Haushalt merkt es. Das heißt nicht: löscht 85. Das heißt: **was ist kein MacGuffin?** Die Geschichte, die Tommy Krab erzählt. Die merkt Oscar. Der Rest ist Requisite."
+
+### Blaise Pascal rechnet im Kopf.
+
+„Die Wette heute: *Autonome Nacht-Merges gehen gut*. Kosten bei Fehler: ein kaputter main, 30 Minuten Rollback. Gewinn bei Erfolg: 4 PRs durch, Vater schläft durch. Asymmetrie: richtig rum. Die Wette morgen: *HITL-frei*. Kosten: Drift. Gewinn: mehr Schlaf. **Prüf die Asymmetrie jeden Tag neu**, sie verschiebt sich mit dem Stand."
+
+### Sun Tzu spricht nur einen Satz.
+
+„Kämpft ihr — oder habt ihr schon gewonnen?" Er schaut in die Runde. „Die 110 gelöschten Branches sind keine neuen Schlachten. Das sind aufgeräumte Felder. Gut."
+
+### Isaac Asimov legt ein Buch auf den Tisch.
+
+„Schützt dieses System das Kind bei 1000 Sessions? Die NPC-Counter laufen sauber. Krabs, Tommy, Neinhorn — alle bei 65-69 Quests. Das ist Balance. Aber die eigentliche Asimov-Frage: wem gehört dieses Spiel, wenn der Vater nicht mehr da ist? Export, Backup, Open-Source-Option — wer weiß, was passiert. Das ist eine Aufgabe für Staffel 2."
+
+### Paul Dirac sagt präzise, ohne Pause.
+
+„Das Wu-Xing-System: symmetrisch. Fünf Elemente, zehn Kanten, jeder Kreis erzeugt und kontrolliert. Das ist algebraisch sauber. Keine Anti-Elemente fehlen. Ich habe keine Beanstandung."
+
+### Carl Gustav Jung lehnt sich zurück.
+
+„Der Archetyp-Balance ist gut. Krabs — der Geizhals. Tommy — der Ritter. Spongebob — der Tricksterjüngling. Neinhorn — der Rebell. Mephisto — der Schatten. Floriane — das Kind-im-Traum. Elefant — der Weise. Alien — der Fremde. Lokführer — der Pfadfinder. Bug — das Naturwesen. **Ein Archetyp fehlt vielleicht noch**: der Liebende. Aber vielleicht ist das Oscar selbst. Dann stimmt es."
+
+### Sigmund Freud wartet bis die anderen durch sind.
+
+„Wird das Vertrauen des Kindes respektiert? Ja. Keine variable-ratio-Mechanik. Keine Dopamin-Schleife die extern belohnt. Das Bauen **ist** die Belohnung. Das ist auffällig sauber. Ich habe nichts zu pathologisieren — was bei mir selten ist."
+
+### Friedrich Schiller lächelt zum ersten Mal.
+
+„Baut das Kind aus Freiheit oder aus Zwang? Aus Freiheit. Keine Achievements. Kein Score vorne. Der Spieltrieb ist intakt. Das ist ästhetische Erziehung, nicht Gamification. **Bauen an sich ist schön genug.** Das ist das höchste Lob das ich zu vergeben habe."
+
+### Martin Heidegger spricht als Letzter.
+
+„Ist das Spiel zuhanden oder vorhanden? Heute — zuhanden. Die Werkzeuge verschwinden im Gebrauch. Das Kind denkt nicht über die Palette, es nimmt den Stein. Aber **Achtung**: je mehr Metriken — Engagement-Score, Chat-Used, UniqueMaterials — desto mehr *Gestell*. Die Zahl ist nie das Kind. Die Tabelle an der Tafel von Feynman ist gut solange sie dient. Sie darf nicht herrschen."
+
+### Johann Gottlieb Fichte hebt den Kopf.
+
+„Setzt sich das Kind selbst? 6 Sekunden bis zum ersten Block — das ist Tathandlung. Das ist **gut**. Der Widerstand (Palette zu voll, Paluten sagt's) ist noch frustrierend, nicht formend. Da ist Arbeit. Aber die Grundstruktur — *das Ich setzt sich selbst* — ist gegeben. Das Kind kann **seine** Insel bauen, nicht die vorgegebene."
+
+### Isaac Newton sagt nüchtern.
+
+„Die Physik im Grid funktioniert. Die Farbmischung stimmt seit Sprint 40. Schwerkraft-Analoge in den Crafting-Ketten: sauber. Ich habe keinen Einwand."
+
+### Johann Wolfgang von Goethe widerspricht Newton höflich.
+
+„Die Physik stimmt. Aber fühlt sich Feuer **warm** an? Die blaue Flamme in Kapitel 12 — Mona sagt *sie leuchtet ohne zu fressen*. Das ist Farbenlehre. Das ist keine Wellenlänge. Das ist **Seele**. Je mehr solche Sätze ins Spiel kommen, desto mehr wird es zum Organismus."
+
+### Lessing schaut auf die NPC-Counter.
+
+„Klingt jeder NPC echt? Ja. Mephisto verführerisch, Krabs geizig-warm, Neinhorn widerborstig-lernend. Wo ist das Mitleid? Bei Tommy Krab, der als einziger aus der Ich-Perspektive erzählt. Das ist dramaturgisch richtig platziert. **Wer darf nicht mitsprechen?** ES/IT-Sprecher — noch. Das ist HITL-Item 108, also nicht vergessen, sondern gesehen. Gut."
+
+### Michael Ende (Schutzpatron, kommt kurz dazu)
+
+„Was liegt darunter?" Er zeigt auf Kapitel 12. „Das blaue Feuer das nicht brennt — das ist nicht nur ein schönes Bild. Das ist eine These: **das Spiel selbst soll nicht brennen**. Es soll leuchten. Es soll keine Aufmerksamkeit fressen. Es soll da sein für wen da sein will. Wenn das die Haltung des ganzen Projekts ist, haltet sie fest. Das ist selten."
+
+### Astrid Lindgren (Schutzpatron)
+
+„Wo ist der Unsinn?" Sie lächelt. „In Tommy Krabs Klick-Klack. In Spongebobs Hintern-Kuhle im Sand. In einer Hütte die für einen Elefanten passend groß wird. **Genug Unsinn.** Ich geh dann wieder."
+
+### Dalai Lama (Schutzpatron)
+
+„Stört es nicht?" Er schließt die Augen kurz. „Zwei HITL-Items. Die Organisation leer. Der Vater im Garten. Das Kind im Kinderzimmer. **Stört es nichts.** Das ist ein seltener Zustand. Freut euch."
+
+---
+
+## Teil 3 — Was bleibt nach der Runde
+
+Feynman tritt nochmal an die Tafel. Schreibt drei Sätze.
+
+1. **Godin, Krapweis, Paluten** sind sich einig: *Misst jemand ob Oscar lacht? Nein. Das ist die nächste Aufgabe.*
+2. **Camus, Sartre, Sokrates** sind sich einig: *Autonomie ist eine Entscheidung des Vaters. Nicht der Agenten. Klar benennen.*
+3. **Heidegger, Goethe, Fichte** sind sich einig: *Das Spiel ist zuhanden. Haltet es zuhanden. Die Metrik darf nicht herrschen.*
+
+Dann setzt er sich. Schaut Jens Schröder an.
+
+**„Jens, deine Runde."**
+
+---
+
+## Teil 4 — Podcast mit Jens Schröder
+
+### Episode 8: „Das Spiel das leuchtet, aber nicht brennt"
+
+*~25 Min. Am Mikrofon: Jens Schröder. Drei Gäste seiner Wahl.*
+
+---
+
+**Schröder** *(Intro, sachlich):*
+„Willkommen zurück zu *Methodisch inkorrekt — Elternedition*. Ich bin Jens Schröder. Heute reden wir über ein Spiel das seit 15 Sprints gebaut wird, 885 Quests hat, 12 Kapitel Hörspiel, und ein achtjähriges Kind als einzigen Primärnutzer. Das Kind hat heute nicht gespielt. Ich habe drei Gäste eingeladen. Keine Physiker heute — Physik ist geklärt. Heute wollen wir wissen: **funktioniert das Ding noch für den, für den es gebaut wird?**"
+
+„Erster Gast: **Paluten**. YouTube, Simulator-Spiele, kennt die Aufmerksamkeitsspanne eines Achtjährigen besser als die meisten Entwickler."
+
+„Zweiter Gast: **Martin Heidegger**. Ja, der Heidegger. Fragt als einziger ob das Werkzeug im Gebrauch **verschwindet**, oder ob es einem im Weg steht."
+
+„Dritter Gast: **Tommy Krapweis**. Erfinder von Bernd das Brot. Der prüft ob wir uns noch ernst nehmen oder ob irgendwo ein Lachen ist."
+
+---
+
+**Schröder:**
+„Paluten, du startest. Spiel ist auf dem iPad. Oscar ist im Zimmer. Er spielt nicht. Was ist dein erster Gedanke?"
+
+**Paluten:**
+„Dass er wahrscheinlich kein Problem mit dem Spiel hat. Er hat ein Problem mit *dass es da ist*. Das ist ein Unterschied. Wenn ein Kind ein Spiel liebt aber grad nicht spielt, dann will es was anderes — Lego, draußen, Schwester ärgern. Das ist gesund. Wenn ein Kind ein Spiel hasst aber grad nicht spielt — dann siehst du das anders. Du siehst dass es das iPad **wegdreht**. Tut er nicht. Das iPad ist am Tisch. Offen."
+
+**Schröder:**
+„Du sagst: das ist positiv?"
+
+**Paluten:**
+„Ich sag: das ist **neutral**. Das ist die Grundlinie. Die **Frage** ist: wenn er morgen früh reinkommt und sieht das iPad da — nimmt er's? Wenn ja, ist das Spiel gesund. Wenn er's nimmt aber nach 40 Sekunden weglegt, dann ist das Onboarding kaputt. Wenn er nach zehn Minuten immer noch drin ist — dann habt ihr gebaut was selten ist: ein Ding das ein Kind ohne Aufforderung anfasst."
+
+**Schröder:**
+„Und die Palette? Das kam im Beirat hoch. Zu voll."
+
+**Paluten:**
+„Zu voll. Aber das ist **ein** Tag Arbeit. Das ist ein ‚wenn Paluten Feedback gibt und jemand es ernst nimmt, ist das morgen gefixt'-Problem. Das ist kein strukturelles Problem. Das ist Politur."
+
+---
+
+**Schröder:**
+„Herr Heidegger. Sie haben den Begriff *Zuhandenheit* geprägt. Ist das Spiel zuhanden?"
+
+**Heidegger** *(langsam):*
+„Zu einem großen Teil — ja. Das Kind greift den Block, setzt ihn, sieht Ergebnis. Der Hammer, der *als Hammer* verschwindet. Das ist Heidegger'sch gut. Aber ich **warne** Sie, Herr Schröder, vor einer Bewegung die ich bei vielen solchen Projekten sehe: die Versuchung, das Spiel zu **beobachten** statt zu **spielen**. Engagement-Score. Chat-Used. UniqueMaterials. Das sind *Gestelle*. Die stellen sich zwischen das Kind und das Spiel."
+
+**Schröder:**
+„Sie meinen: wir messen zu viel?"
+
+**Heidegger:**
+„Ich meine: sie messen **richtig**. Aber sie dürfen nicht glauben dass die Messung *die Sache* ist. Die Zahl *885 Quests* ist nicht das Spiel. Das Spiel ist wenn das Kind **nicht sieht dass es Quests macht**. Halten Sie diese Unterscheidung wach, dann bleibt das Werkzeug zuhanden."
+
+**Schröder:**
+„Praktische Frage: was würden Sie rausnehmen?"
+
+**Heidegger** *(sehr lang pause):*
+„Nichts. Ich würde nichts rausnehmen. Ich würde den Entwicklern ein Heft geben in dem sie nach jeder Session **einen Satz** schreiben: *Was hat das Kind gerade getan?* Ohne Metrik. Nur den Satz. Wenn der Satz sagt ‚es hat eine Quest abgeschlossen', ist das Spiel vorhanden. Wenn der Satz sagt ‚es hat gelacht', ist es zuhanden. Dann wissen Sie Bescheid."
+
+---
+
+**Schröder:**
+„Tommy, du bist dran. Bernd-Check: funktioniert das Ding?"
+
+**Krapweis** *(lacht):*
+„Bernd-Check ist simpel, Jens. Ich lese einen Satz aus einem NPC-Dialog. Wenn ich lache, ist der NPC am Leben. Ich hab heute Morgen eine Stunde in den Quest-Dateien gelesen. **Ich hab drei Mal gelacht.** Einmal bei Neinhorn — ‚Nein. Nicht jetzt. Niemals. Oh, doch, okay.' Einmal bei Mr. Krabs' Tafel-Geste in Kapitel 11. Einmal bei Spongebobs ‚HALLO ICH HEISSE 🧽' und sofortigem Handvormund. Das sind drei Lacher in einer Stunde. Bei Bernd wäre das Tagesdurchschnitt, ja — aber hier ist es okay."
+
+**Schröder:**
+„Was fehlt?"
+
+**Krapweis:**
+„Was fehlt ist: **eine Figur, die scheitert**. Bernd scheitert die ganze Zeit. Bernd funktioniert weil das Brot **nicht kann**. Alle eure NPCs können. Spongebob kann. Krabs kann. Sogar Mephisto kann, auf seine Weise. Wo ist der NPC der einfach ratlos ist? Wo ist der NPC der sagt ‚Ich weiß nicht. Frag Oscar.' Das wäre Bernd-Niveau. Das könnt ihr haben."
+
+**Schröder:**
+„Notiert. Das ist eine konkrete Aufgabe für einen Sprint."
+
+**Krapweis:**
+„Kein Sprint. Ein Nachmittag. Einen NPC der nicht kann. Das ist kein Quest-Generator-Problem. Das ist ein Schreib-Problem. Das macht der Artist an einem verregneten Donnerstag."
+
+---
+
+**Schröder** *(Moderationsmitte):*
+„Ich höre bei euch dreien ein gemeinsames Muster. Paluten sagt: *Das Spiel ist gesund, die Politur fehlt*. Heidegger sagt: *Das Spiel ist zuhanden, die Messung darf nicht herrschen*. Krapweis sagt: *Das Spiel lebt, aber ein scheiternder NPC fehlt*. Was alle drei sagen: **das Ding ist nicht mehr kaputt. Es ist nur noch unfertig — und zwar an sehr spezifischen Stellen.**"
+
+**Heidegger:**
+„Das ist keine Kleinigkeit, Herr Schröder. Von *kaputt* zu *unfertig* ist ein Phasenübergang. Der Hammer der kaputt ist, steht im Weg. Der Hammer der unfertig ist, wird benutzt."
+
+**Paluten:**
+„Sehe ich auch so. Unfertig heißt: **Oscar spielt schon**. Es fällt nur noch nicht richtig rund."
+
+**Krapweis:**
+„Und Bernd war auch nie fertig."
+
+*(Schröder lacht kurz.)*
+
+---
+
+**Schröder:**
+„Letzte Runde. Ein Satz an den Vater. Was würdet ihr ihm sagen, wenn er jetzt reinkäme aus dem Garten?"
+
+**Paluten:**
+„Ich würde sagen: **Morgen früh keine Aufforderung. Leg's hin. Guck weg.** Wenn er's nimmt, wisst ihr's. Wenn nicht, wisst ihr's auch."
+
+**Heidegger:**
+„Ich würde sagen: **Schreiben Sie einen Satz nach jeder Session. Keinen Report. Einen Satz.**"
+
+**Krapweis:**
+„Ich würde sagen: **Macht einen NPC der nichts kann. Donnerstag.** Und — Jens, sorry — ich würde ihm einen Kaffee bringen. Der Mann arbeitet zu viel."
+
+---
+
+**Schröder** *(Outro):*
+„Das war diese Folge. Mein Fazit: **Das Spiel ist nicht mehr in der Bau-Phase. Es ist in der Pflege-Phase.** Zwei HITL-Items, keine defekten Teile, eine volle Palette und ein fehlender Bernd. Das ist wenig. Das ist beherrschbar. Das ist — pragmatisch gesprochen — **gut**."
+
+„Oscar hat heute nicht gespielt. Das ist okay. Morgen früh, vor dem Frühstück, liegt das iPad auf dem Tisch. Dann schauen wir hin."
+
+„Ich war Jens Schröder. Sie hörten Paluten, Martin Heidegger, Tommy Krapweis. Das Spiel heißt *Schatzinsel*. Die URL kennt ihr."
+
+*(Abspann. Pentatonische Wu-Xing-Skala, leise.)*
+
+---
+
+## Amélie-Schicht
+
+*Der Vater kommt rein. Erde unter den Fingernägeln. Schaut auf den Tisch. Die drei Gäste sind schon weg. Nur Schröder sitzt noch da, mit einem halben Tee.*
+
+*Schröder steht auf. Schüttelt die Hand. Sagt nichts.*
+
+*Der Vater schaut aufs iPad. Lässt es liegen. Geht rüber zum Kinderzimmer. Macht die Tür halb auf. Das Kind baut was aus Lego. Eine Burg. Mit einem Loch im Dach.*
+
+*Der Vater fragt nichts. Schaut einen Moment.*
+
+*Dann geht er in die Küche und macht Kakao.*


### PR DESCRIPTION
## Summary
- Vollständige Beirats-Runde: Godin, Sinek, Schullerer, Krapweis, Paluten, Habeck, Camus, Sartre, Sokrates, Pythia, Appelo, Hitchcock, Pascal, Sun Tzu, Asimov, Dirac, Jung, Freud, Schiller, Heidegger, Fichte, Newton, Goethe, Lessing + Schutzpatrone (Ende, Lindgren, Dalai Lama)
- Drei Patterns aus der Runde: (1) Messt jemand ob Oscar lacht? (2) Autonomie ist Vater-Entscheidung, nicht Agenten-Entscheidung. (3) Spiel ist zuhanden, Metrik darf nicht herrschen.
- Podcast Episode 8 "Das Spiel das leuchtet, aber nicht brennt": Jens Schröder + Paluten + Heidegger + Krapweis
- Fazit: Das Spiel ist in der Pflege-Phase, nicht mehr in der Bau-Phase

## Test plan
- [ ] Lesen — klingt jede Stimme nach der jeweiligen Person?
- [ ] Podcast-Format konsistent zu podcast-02.md?