### PR TITLE
ci: automatisches CF-Worker-Deploy (HITL #27 weg)

### DIFF
--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy Cloudflare Worker
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/infra/worker.js'
+      - 'src/infra/wrangler.toml'
+      - '.github/workflows/worker-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: wrangler deploy
+    runs-on: ubuntu-latest
+    env:
+      CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Guard — secrets vorhanden
+        if: ${{ env.CF_API_TOKEN == '' || env.CF_ACCOUNT_ID == '' }}
+        run: |
+          echo "::warning::CLOUDFLARE_API_TOKEN oder CLOUDFLARE_ACCOUNT_ID nicht gesetzt — Worker-Deploy übersprungen"
+          exit 0
+
+      - name: Wrangler deploy
+        if: ${{ env.CF_API_TOKEN != '' && env.CF_ACCOUNT_ID != '' }}
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: src/infra
+          command: deploy


### PR DESCRIPTION
## Summary

Schließt **HITL #27** durch Automation. CF-Worker wird bei Push auf main automatisch deployed.

## Warum manuell bisher

`preview.yml` deployed nur CF-**Pages** (für PR-Previews). Der CF-**Worker** (`src/infra/worker.js` + `wrangler.toml`) hatte keinen CI-Job und musste von Till manuell per `cd src/infra && npx wrangler deploy`.

## Was sich ändert

Push auf main mit Änderungen in `src/infra/worker.js`, `src/infra/wrangler.toml`, oder diesem Workflow → `wrangler deploy` läuft automatisch. Plus `workflow_dispatch` für manuelle Trigger wenn nötig.

## Voraussetzung

Secrets `CLOUDFLARE_API_TOKEN` und `CLOUDFLARE_ACCOUNT_ID` müssen im Repo gesetzt sein — sind sie laut `preview.yml`-Verwendung bereits.

## Test plan
- [ ] Workflow parst als gültiges YAML
- [ ] Nach Merge: Worker wird deployed oder Warning zeigt „Secrets nicht gesetzt"
- [ ] HITL #27 kann aus `ops/BACKLOG.md` raus

🤖 Generated with [Claude Code](https://claude.com/claude-code)