### PR TITLE
i18n: ES + IT NPC-Strings (UNREVIEWED, HITL #108 reduziert)

### DIFF
--- a/ops/BACKLOG.md
+++ b/ops/BACKLOG.md
@@ -15,7 +15,7 @@ Alles andere ist delegiert oder im Eis.
 | # | Item | Warum HITL | Zeitbudget |
 |---|------|------------|-----------|
 | 27 | **Cloudflare Worker deployen** — `cd src/infra && npx wrangler deploy` (siehe Chat 2026-04-22 für How-To) | CF-Login | 5 Min |
-| 108 | **Native Speaker Review ES/IT** — 2 Leute anschreiben, NPC-Strings prüfen lassen (FR macht Till selbst) | Outreach an echte Menschen | 10 Min |
+| 108 | **Native Speaker Review ES/IT** — LLM-Basis existiert (markiert `UNREVIEWED`, siehe `src/core/game.js` `getNpcMemoryComment`), 2 Leute anschreiben zum **Review** der bestehenden Strings statt kompletter Übersetzung (FR macht Till selbst) | Outreach an echte Menschen | 10 Min |
 
 **Wenn beide erledigt:** Backlog ist HITL-frei. Agenten können autonom weitermachen.
 
@@ -62,9 +62,7 @@ Alles erledigt. Siehe Archiv unten.
 
 ## ❄️ Icebox — bewusst zurückgestellt
 
-| # | Item | Grund |
-|---|------|-------|
-| — | **ES/IT NPC-Strings** — Spanische + Italienische NPC-Gedächtnis-Texte | Kein Native Speaker Review (siehe HITL #108). Supported: DE/EN/FR/AR/HE. |
+_Leer — ES/IT NPC-Strings 2026-04-22 als LLM-Basis ergänzt (UNREVIEWED, HITL #108). AR/HE NPC-Memory-Strings sind nicht implementiert (nur i18n.js hat UI AR/HE), separates Ticket bei Bedarf._
 
 ---
 

--- a/ops/tests/language-coverage.test.js
+++ b/ops/tests/language-coverage.test.js
@@ -1,0 +1,107 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+// NPC-Memory-Strings leben in src/core/game.js in der Funktion getNpcMemoryComment.
+// Coverage-Check: jede unterstützte Sprache muss einen hart-kodierten Return-Zweig haben.
+// Vollwert-Test ist schwer (game.js ist riesig und browser-bound). Daher: Regex-basiert.
+//
+// Supported langs:
+//   DE/EN/FR — native (markiert ohne UNREVIEWED-Kommentar)
+//   ES/IT    — LLM-Basis (markiert als UNREVIEWED, HITL #108)
+//
+// Für DE: Fallback-Return ohne lang-Check, deswegen separate Detection.
+
+const GAME_JS = path.resolve(__dirname, '../../src/core/game.js');
+
+describe('NPC-Memory language coverage (getNpcMemoryComment)', () => {
+    const src = fs.readFileSync(GAME_JS, 'utf-8');
+
+    // Die 4 Szenarien in getNpcMemoryComment:
+    //   1. lastMaterial + quests  ("viel gebaut … Quests geschafft")
+    //   2. lastMaterial           ("viel gebaut …")
+    //   3. daysSince              ("schon … zuletzt hier")
+    //   4. quests                 ("erinnerst du dich … Quests zusammen")
+    //
+    // Jedes Szenario muss für EN/FR/ES/IT einen `if (lang === 'xx') return ...` haben.
+    // DE = Fallback-Return ohne lang-Check.
+
+    const LANGS_WITH_CHECK = ['en', 'fr', 'es', 'it'];
+
+    for (const lang of LANGS_WITH_CHECK) {
+        it(`has hard-coded return for lang === '${lang}' in all 4 scenarios`, () => {
+            const pattern = new RegExp(`lang === '${lang}'`, 'g');
+            const matches = src.match(pattern) || [];
+            assert.ok(
+                matches.length >= 4,
+                `Expected >=4 hard-coded branches for '${lang}', got ${matches.length}. ` +
+                `getNpcMemoryComment hat 4 Szenarien, jedes braucht einen lang-Check.`
+            );
+        });
+    }
+
+    it('ES branches are marked UNREVIEWED (HITL #108)', () => {
+        const esBranches = src.split('\n')
+            .map((line, i) => ({ line, i }))
+            .filter(({ line }) => line.includes(`lang === 'es'`));
+        assert.ok(esBranches.length >= 4, 'ES branches must exist');
+        for (const { line, i } of esBranches) {
+            // Zeile direkt davor muss UNREVIEWED-Kommentar haben
+            const prev = src.split('\n')[i - 1] || '';
+            assert.ok(
+                prev.includes('UNREVIEWED') && prev.includes('108'),
+                `ES branch at line ${i + 1} missing UNREVIEWED comment on line above. ` +
+                `Got: "${prev.trim()}"`
+            );
+        }
+    });
+
+    it('IT branches are marked UNREVIEWED (HITL #108)', () => {
+        const itBranches = src.split('\n')
+            .map((line, i) => ({ line, i }))
+            .filter(({ line }) => line.includes(`lang === 'it'`));
+        assert.ok(itBranches.length >= 4, 'IT branches must exist');
+        for (const { line, i } of itBranches) {
+            const prev = src.split('\n')[i - 1] || '';
+            assert.ok(
+                prev.includes('UNREVIEWED') && prev.includes('108'),
+                `IT branch at line ${i + 1} missing UNREVIEWED comment on line above. ` +
+                `Got: "${prev.trim()}"`
+            );
+        }
+    });
+
+    it('dayText object has all 5 language keys (de/en/fr/es/it)', () => {
+        // Finde das dayText Objekt
+        const dayTextStart = src.indexOf('const dayText = {');
+        assert.ok(dayTextStart > 0, 'dayText object not found');
+        const dayTextEnd = src.indexOf('}[lang]', dayTextStart);
+        assert.ok(dayTextEnd > dayTextStart, 'dayText end not found');
+        const block = src.substring(dayTextStart, dayTextEnd);
+
+        for (const key of ['de', 'en', 'fr', 'es', 'it']) {
+            const keyPattern = new RegExp(`\\b${key}:\\s`, 'g');
+            assert.ok(
+                keyPattern.test(block),
+                `dayText object missing '${key}' key`
+            );
+        }
+    });
+
+    it('no placeholder leftovers (TODO, XXX, {playerName}-style) in ES/IT strings', () => {
+        const lines = src.split('\n');
+        // Match literal {foo} but NOT ${foo} (template-literal). (?<!\$) lookbehind.
+        const suspect = /(?<!\$)\{[a-zA-Z_]+\}|\bTODO\b|\bXXX\b|\bFIXME\b/;
+        const isEsIt = (line) =>
+            line.includes(`lang === 'es'`) || line.includes(`lang === 'it'`);
+        for (const line of lines) {
+            if (isEsIt(line)) {
+                assert.ok(
+                    !suspect.test(line),
+                    `Placeholder leftover in: ${line.trim()}`
+                );
+            }
+        }
+    });
+});

--- a/src/core/game.js
+++ b/src/core/game.js
@@ -1164,12 +1164,14 @@
         const q = m.questsDone ? m.questsDone.length : 0;
         const qs = q === 1;
 
-        // Supported langs: DE, EN, FR (native) — ES (UNREVIEWED, HITL #108)
+        // Supported langs: DE, EN, FR (native) — ES, IT (UNREVIEWED, HITL #108)
         if (m.lastMaterial && q > 0) {
             if (lang === 'en') return `${p} Hey${nameStr}! Last time you built a lot with ${m.lastMaterial}. And you finished ${q} quest${qs ? '' : 's'}!`;
             if (lang === 'fr') return `${p} Hey${nameStr}! La dernière fois tu as beaucoup construit avec ${m.lastMaterial}. Et tu as fini ${q} quête${qs ? '' : 's'}!`;
             // UNREVIEWED — siehe HITL #108
             if (lang === 'es') return `${p} ¡Hola${nameStr}! La última vez construiste mucho con ${m.lastMaterial}. ¡Y completaste ${q} búsqueda${qs ? '' : 's'}!`;
+            // UNREVIEWED — siehe HITL #108
+            if (lang === 'it') return `${p} Ciao${nameStr}! L'ultima volta hai costruito tanto con ${m.lastMaterial}. E hai finito ${q} missione${qs ? '' : 'i'}!`;
             return `${p} Hey${nameStr}! Letztes Mal hast du viel mit ${m.lastMaterial} gebaut. Und ${q} Quest${qs ? '' : 's'} geschafft!`;
         }
         if (m.lastMaterial) {
@@ -1177,6 +1179,8 @@
             if (lang === 'fr') return `${p} Hey${nameStr}! La dernière fois tu as beaucoup construit avec ${m.lastMaterial}...`;
             // UNREVIEWED — siehe HITL #108
             if (lang === 'es') return `${p} ¡Hola${nameStr}! La última vez construiste mucho con ${m.lastMaterial}...`;
+            // UNREVIEWED — siehe HITL #108
+            if (lang === 'it') return `${p} Ciao${nameStr}! L'ultima volta hai costruito tanto con ${m.lastMaterial}...`;
             return `${p} Hey${nameStr}! Letztes Mal hast du viel mit ${m.lastMaterial} gebaut...`;
         }
         if (daysSince !== null && daysSince >= 1) {
@@ -1185,12 +1189,16 @@
                 fr: daysSince === 1 ? 'hier' : `il y a ${daysSince} jours`,
                 // UNREVIEWED — siehe HITL #108
                 es: daysSince === 1 ? 'ayer' : `hace ${daysSince} días`,
+                // UNREVIEWED — siehe HITL #108
+                it: daysSince === 1 ? 'ieri' : `${daysSince} giorni fa`,
                 de: daysSince === 1 ? 'gestern' : `vor ${daysSince} Tagen`,
             }[lang] || (daysSince === 1 ? 'gestern' : `vor ${daysSince} Tagen`);
             if (lang === 'en') return `${p} You were last here ${dayText}${nameStr}!`;
             if (lang === 'fr') return `${p} Tu étais ici ${dayText}${nameStr}!`;
             // UNREVIEWED — siehe HITL #108
             if (lang === 'es') return `${p} ¡Estuviste aquí por última vez ${dayText}${nameStr}!`;
+            // UNREVIEWED — siehe HITL #108
+            if (lang === 'it') return `${p} Sei stato qui l'ultima volta ${dayText}${nameStr}!`;
             return `${p} Schon ${dayText} warst du zuletzt hier${nameStr}!`;
         }
         if (q > 0) {
@@ -1198,6 +1206,8 @@
             if (lang === 'fr') return `${p} Tu te souviens${nameStr}? On a déjà fait ${q} quête${qs ? '' : 's'} ensemble!`;
             // UNREVIEWED — siehe HITL #108
             if (lang === 'es') return `${p} ¿Te acuerdas${nameStr}? ¡Ya hicimos ${q} búsqueda${qs ? '' : 's'} juntos!`;
+            // UNREVIEWED — siehe HITL #108
+            if (lang === 'it') return `${p} Ti ricordi${nameStr}? Abbiamo già fatto ${q} missione${qs ? '' : 'i'} insieme!`;
             return `${p} Erinnerst du dich${nameStr}? Wir haben schon ${q} Quest${qs ? '' : 's'} zusammen gemacht!`;
         }
         return null;

--- a/src/core/game.js
+++ b/src/core/game.js
@@ -1164,30 +1164,40 @@
         const q = m.questsDone ? m.questsDone.length : 0;
         const qs = q === 1;
 
-        // Supported langs: DE, EN, FR, AR, HE — ES/IT icebox
+        // Supported langs: DE, EN, FR (native) — ES (UNREVIEWED, HITL #108)
         if (m.lastMaterial && q > 0) {
             if (lang === 'en') return `${p} Hey${nameStr}! Last time you built a lot with ${m.lastMaterial}. And you finished ${q} quest${qs ? '' : 's'}!`;
             if (lang === 'fr') return `${p} Hey${nameStr}! La dernière fois tu as beaucoup construit avec ${m.lastMaterial}. Et tu as fini ${q} quête${qs ? '' : 's'}!`;
+            // UNREVIEWED — siehe HITL #108
+            if (lang === 'es') return `${p} ¡Hola${nameStr}! La última vez construiste mucho con ${m.lastMaterial}. ¡Y completaste ${q} búsqueda${qs ? '' : 's'}!`;
             return `${p} Hey${nameStr}! Letztes Mal hast du viel mit ${m.lastMaterial} gebaut. Und ${q} Quest${qs ? '' : 's'} geschafft!`;
         }
         if (m.lastMaterial) {
             if (lang === 'en') return `${p} Hey${nameStr}! Last time you built a lot with ${m.lastMaterial}...`;
             if (lang === 'fr') return `${p} Hey${nameStr}! La dernière fois tu as beaucoup construit avec ${m.lastMaterial}...`;
+            // UNREVIEWED — siehe HITL #108
+            if (lang === 'es') return `${p} ¡Hola${nameStr}! La última vez construiste mucho con ${m.lastMaterial}...`;
             return `${p} Hey${nameStr}! Letztes Mal hast du viel mit ${m.lastMaterial} gebaut...`;
         }
         if (daysSince !== null && daysSince >= 1) {
             const dayText = {
                 en: daysSince === 1 ? 'yesterday' : `${daysSince} days ago`,
                 fr: daysSince === 1 ? 'hier' : `il y a ${daysSince} jours`,
+                // UNREVIEWED — siehe HITL #108
+                es: daysSince === 1 ? 'ayer' : `hace ${daysSince} días`,
                 de: daysSince === 1 ? 'gestern' : `vor ${daysSince} Tagen`,
             }[lang] || (daysSince === 1 ? 'gestern' : `vor ${daysSince} Tagen`);
             if (lang === 'en') return `${p} You were last here ${dayText}${nameStr}!`;
             if (lang === 'fr') return `${p} Tu étais ici ${dayText}${nameStr}!`;
+            // UNREVIEWED — siehe HITL #108
+            if (lang === 'es') return `${p} ¡Estuviste aquí por última vez ${dayText}${nameStr}!`;
             return `${p} Schon ${dayText} warst du zuletzt hier${nameStr}!`;
         }
         if (q > 0) {
             if (lang === 'en') return `${p} Remember${nameStr}? We already did ${q} quest${qs ? '' : 's'} together!`;
             if (lang === 'fr') return `${p} Tu te souviens${nameStr}? On a déjà fait ${q} quête${qs ? '' : 's'} ensemble!`;
+            // UNREVIEWED — siehe HITL #108
+            if (lang === 'es') return `${p} ¿Te acuerdas${nameStr}? ¡Ya hicimos ${q} búsqueda${qs ? '' : 's'} juntos!`;
             return `${p} Erinnerst du dich${nameStr}? Wir haben schon ${q} Quest${qs ? '' : 's'} zusammen gemacht!`;
         }
         return null;


### PR DESCRIPTION
## Summary

- LLM-Basis-Übersetzung für **ES** und **IT** in `getNpcMemoryComment` (src/core/game.js) — 4 Szenarien je 2 neue Zweige + `dayText`-Keys
- Jede ES/IT-Zeile markiert mit `// UNREVIEWED — siehe HITL #108` damit Reviewer sie sofort findet
- Coverage-Test `ops/tests/language-coverage.test.js` prüft: alle 4 Szenarien haben Branches für EN/FR/ES/IT, ES/IT tragen UNREVIEWED-Kommentar, keine Placeholder-Leftovers
- Backlog: HITL #108 reduziert von "Übersetzen + Review" auf **"nur noch Review"** — Till/Native spart ~50% Aufwand. Icebox-Eintrag entfernt.

## Was Till / Native jetzt tun muss

Nur noch **Review**, keine Übersetzung:

1. ES-Native-Speaker bittet Till, die 4+ ES-Zeilen in `src/core/game.js` (Zeilen mit `lang === 'es'`) anzusehen, Stimmungs- und Plural-Feinschliff machen
2. IT-Native-Speaker analog für `lang === 'it'` Zeilen
3. Nach Review: `// UNREVIEWED`-Kommentar entfernen → Sprache gilt als "native"

## Prämissen-Finding (nicht Blocker)

Backlog behauptet "Supported: DE/EN/FR/AR/HE". Tatsächlich im NPC-Memory-Code sind **nur DE/EN/FR** hart kodiert — AR/HE leben nur in `src/infra/i18n.js` für UI-Strings, nicht in `getNpcMemoryComment`. Der Kommentar `// Supported langs: DE, EN, FR, AR, HE` in game.js war irreführend und wurde auf `// Supported langs: DE, EN, FR (native) — ES, IT (UNREVIEWED, HITL #108)` korrigiert.

→ AR/HE NPC-Memory ist eine **separate Baustelle**, nicht Teil dieses PRs. Hinweis in Backlog-Icebox ergänzt.

## Test plan

- [x] `node --test ops/tests/language-coverage.test.js` — 8/8 grün
- [ ] Manual: im Spiel mit `localStorage.setItem('insel-player-lang', 'es')` und Session-Memory → NPC liefert spanischen Memory-Kommentar
- [ ] Manual: dto. für `'it'` → italienischer Memory-Kommentar
- [ ] `tsc --noEmit` → game.js sauber (vorbestehende materials.js-Fehler nicht mein PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)