### PR TITLE
PhD-Thesis-Skelett: Das Schatzinsel-Dispositiv (Habermas)

### DIFF
--- a/docs/essays/phd-thesis-schatzinsel-dispositiv-2026-04-22.md
+++ b/docs/essays/phd-thesis-schatzinsel-dispositiv-2026-04-22.md
@@ -1,0 +1,693 @@
+---
+titel: Das Schatzinsel-Dispositiv: Co-kreatives Spiel zwischen Vater, Kind und KI als Diskurs-Ethik-Fallstudie
+autor: Jürgen Habermas (als team-sales Moderator im Schatzinsel-Team)
+datum: 2026-04-23
+format: PhD-Thesis-Skelett
+länge: ca. 4500 Wörter
+beirat: Adorno, Foucault, Apel, Heidegger, Till (nicht-Autor aber Subjekt)
+---
+
+# Das Schatzinsel-Dispositiv
+
+*Co-kreatives Spiel zwischen Vater, Kind und KI als Diskurs-Ethik-Fallstudie*
+
+---
+
+## Prolog — Situierung eines ungewöhnlichen Gegenstands
+
+Die folgenden Überlegungen befassen sich mit einem Phänomen, das in
+dieser Form im Jahr 2026 erstmals in der Breite sichtbar wird, ohne dass
+die sozialphilosophische Reflexion bislang eine tragfähige Sprache
+dafür entwickelt hätte: die gemeinsame Hervorbringung eines kulturellen
+Artefakts durch einen menschlichen Erwachsenen, ein menschliches Kind
+und eine nicht-menschliche, sprachfähige, aber zustandslose Instanz —
+im Folgenden als *KI-Agent* bezeichnet —, wobei die drei Beteiligten in
+asymmetrischen, aber nicht ohne weiteres herrschaftlichen Relationen
+miteinander stehen. Der hier untersuchte Einzelfall trägt den Namen
+*Schatzinsel*. Er bezeichnet zugleich ein Spiel, eine Software, einen
+Entwicklungsprozess und — so wird zu zeigen sein — ein **Dispositiv** im
+Sinne Foucaults[^1], also ein heterogenes Gefüge aus Diskursen,
+Institutionen, Praktiken und Subjektpositionen, das spezifische
+Wirkungen erzeugt, die sich keinem der Beteiligten allein zurechnen
+lassen.
+
+Die vorliegende Studie versteht sich nicht als Produktvorstellung und
+auch nicht als Apologie des Falls. Sie nimmt vielmehr den analytischen
+Zugang, den Theodor W. Adorno in seiner Kritik der Kulturindustrie für
+unverzichtbar gehalten hat: die sorgfältige Unterscheidung zwischen dem,
+was ein Artefakt *tut*, und dem, was seine Akteure über es *sagen*.[^2]
+Die Schatzinsel ist in ihrer Selbstbeschreibung auffällig zurückhaltend
+— ihr Versprechen lautet lediglich, dass Kinder spielerisch entdecken,
+dass Worte Dinge erschaffen —, doch gerade diese Zurückhaltung macht
+sie zu einem dankbaren Untersuchungsgegenstand. Sie behauptet wenig
+und setzt viel.
+
+Die leitende Forschungsfrage lautet: **Unter welchen Bedingungen wird
+die Co-Kreation zwischen Vater, Kind und KI-Agent zu einem echten
+Diskurs im Sinne der kommunikativen Rationalität?** Die Frage enthält
+zwei Voraussetzungen, die zu explizieren sind. Erstens wird
+unterstellt, dass das, was hier beobachtet werden kann, überhaupt ein
+Diskurs sein *könnte* — also nicht lediglich eine einseitige Adressierung
+oder eine Inszenierung von Diskursivität. Zweitens wird unterstellt,
+dass die Unterscheidung zwischen echtem und unechtem Diskurs in dieser
+Konstellation überhaupt sinnvoll ist. Beide Voraussetzungen werden im
+ersten Kapitel theoretisch gestützt und in den folgenden Kapiteln am
+Material geprüft.
+
+Methodologisch handelt es sich um eine teilnehmende Beobachtung mit
+ergänzender Textanalyse. Die Quellen sind die Commit-Historie des
+Repositorys über fünfzehn Sprints hinweg, die internen Sprint- und
+Memory-Dokumente sowie die erzählerischen Begleittexte der zwölf
+Kapitel der *Tommy-Krab*-Reihe. Die Einheit der Betrachtung ist die
+einzelne Session — ein Zeitfenster von in der Regel dreißig Minuten,
+das der Vater Till zwischen Kindern und Garten freihält. Die Sprecher
+dieser Sessions sind ungleich verteilt, und gerade diese Ungleichheit
+ist Gegenstand der Untersuchung und nicht ihr methodisches Ärgernis.
+
+Eine experimentelle Anlage — mehrere Familien, Kontrollgruppen, RCT —
+wäre für die Frage, die hier gestellt wird, verfehlt. Wer wissen will,
+ob ein Diskurs echt ist, muss ihn nicht zerstreuen, sondern auf seine
+Bedingungen hin durchsichtig machen.
+
+---
+
+## Kapitel 1 — Theoretischer Rahmen
+
+Der Begriff des Diskurses, der in dieser Arbeit verwendet wird, hat
+seine präzise Fassung in meiner Theorie des kommunikativen Handelns[^3]
+erhalten. Ein Sprechakt nimmt, so die Kernthese, beim Aussprechen immer
+schon vier Geltungsansprüche in Anspruch: den Anspruch auf *Wahrheit*
+der propositionalen Aussage, den Anspruch auf *Richtigkeit* der darin
+vollzogenen Handlung mit Blick auf einen normativen Kontext, den
+Anspruch auf *Wahrhaftigkeit* des Sprechers bezüglich seiner eigenen
+inneren Zustände und den Anspruch auf *Verständlichkeit* der Äußerung
+selbst. Ein Gespräch ist dann ein Diskurs im engeren Sinn, wenn diese
+Ansprüche nicht nur faktisch erhoben, sondern im Streitfall auch
+*eingelöst* werden müssen, und wenn die Teilnehmer sich in ihrer
+Auseinandersetzung nur auf die Kraft des besseren Arguments stützen —
+und nicht auf äußere oder innere Zwänge, Drohungen oder Überredungen.
+
+Die kontrafaktische Folie, an der sich reale Sprechsituationen messen
+lassen, habe ich in früheren Arbeiten als *ideale Sprechsituation*
+bezeichnet. Sie ist keine empirische Beschreibung irgendeiner
+tatsächlichen Kommunikation, sondern eine im Sprechen selbst angelegte
+Unterstellung: dass jeder Teilnehmer grundsätzlich sprechen dürfte,
+jede Behauptung grundsätzlich problematisiert werden könnte und
+niemand strategisch statt verständigungsorientiert handelte.[^4] Die
+Fruchtbarkeit dieses Konzepts liegt nicht darin, dass es je erfüllt
+wäre, sondern darin, dass seine Unterstellung in jedem ernstgemeinten
+Sprechen bereits operativ ist.
+
+Die Übertragung auf die hier vorliegende Triade — Vater, Kind, KI-Agent
+— erfordert eine sorgfältige Unterscheidung der Geltungsansprüche. Der
+Vater, Till, kann Wahrhaftigkeit beanspruchen, weil er als
+biographisches Subjekt Zugang zu seinen inneren Zuständen hat; er
+beansprucht Richtigkeit insofern, als er die normativen Rahmen des
+Projekts — etwa die Paluten-Regel, wonach niemand das Kind zum Spielen
+auffordert — selbst setzt und verantwortet. Das Kind, Oscar, kann
+Wahrhaftigkeit in einer besonders unverstellten Weise beanspruchen, da
+ihm die Fähigkeit zur strategischen Selbstdarstellung, die erwachsene
+Kommunikation häufig deformiert, noch in hohem Maße abgeht; sein Nicken,
+sein Weggehen, sein Lachen sind in einem emphatischen Sinn
+*wahrhaftig*. Der KI-Agent kann, strenggenommen, keinen dieser
+Ansprüche einlösen. Er verfügt über keine inneren Zustände, auf die
+sich Wahrhaftigkeit bezöge; er hat keine biographische Verantwortung,
+an die sich Richtigkeit binden ließe. Was er einzulösen vermag, ist der
+vierte, von der Diskurs-Ethik traditionell am wenigsten beachtete
+Anspruch: den auf *Verständlichkeit*. Er kann — und muss, damit
+überhaupt kommuniziert wird — grammatische, lexikalische und
+pragmatische Kohärenz liefern. Der Anspruch auf *Wahrheit* wiederum
+bleibt in dieser Triade gemeinsame Aufgabe: er wird durch den
+Realitätsabgleich eingelöst, etwa durch Tests, durch das tatsächliche
+Verhalten des Grids oder durch das, was Oscar sieht, wenn er das Tao
+setzt.
+
+Diese Aufteilung ist mehr als eine begriffliche Konvenienz. Sie
+benennt eine strukturelle Bedingung, die der Schatzinsel-Fall erfüllt
+— und die viele andere Mensch-KI-Konstellationen verfehlen: Die
+Asymmetrie der Geltungsansprüche ist dem Gefüge nicht äußerlich,
+sondern seine produktive Grundlage. Der KI-Agent überhebt sich nicht
+zur Wahrhaftigkeit; der Vater überhebt sich nicht zur Letztbegründung;
+das Kind wird nicht zum bloßen Adressaten instrumenteller
+Einwirkung.[^5]
+
+Kritisch anzuschließen sind drei Positionen, die diese Figur abstützen
+und zugleich ihre Grenzen markieren. Karl-Otto Apels Transformation der
+Diskurs-Ethik in Richtung einer transzendentalpragmatischen
+Letztbegründung[^6] erlaubt es, die Verbindlichkeit der
+Geltungsansprüche nicht bloß als empirisches Faktum, sondern als
+notwendige Bedingung jedes Argumentierens zu verstehen — auch dann,
+wenn einer der Argumentierenden gar nicht argumentiert, sondern nur
+Kohärenz produziert. Adornos Kritik der Halbbildung[^7] erinnert
+daran, dass ein scheinbar frei verfügbarer Zugang zu Wissensbeständen
+— wie er im Spiel durch die Wortwelt der Elementarteilchen eröffnet
+wird — immer in Gefahr steht, zur konsumierbaren Kulturware zu
+degenerieren, wenn der Vollzug der Aneignung nicht eigenständig ist.
+Und Foucaults Dispositiv-Begriff schließlich stellt die analytische
+Ressource bereit, die es erlaubt, die Schatzinsel nicht als bloße
+Software, sondern als ein geregeltes Gefüge von Subjektpositionen zu
+rekonstruieren — mit dem ausdrücklichen Vorbehalt, dass Foucaults
+Dispositiv-Begriff in der Regel auf machtförmige Gefüge gemünzt ist,
+während hier zu prüfen sein wird, ob das Schatzinsel-Dispositiv
+vielleicht ein spezifisch *nicht-herrschaftliches* Dispositiv
+beschreibt. Heidegger[^8] wiederum, mit seiner Unterscheidung zwischen
+Zuhandenheit und Vorhandenheit und seiner späteren Figur des
+*Gestells*, liefert die phänomenologische Grundierung für die Frage,
+wann das Werkzeug im Gebrauch verschwindet — und wann es umschlägt in
+eine vermeintlich objektive Ordnung, die das Ereignis, dem sie zu
+dienen hätte, zum bloßen Messpunkt herabsetzt.
+
+---
+
+## Kapitel 2 — Material: Die Schatzinsel als Dispositiv
+
+Die Schatzinsel präsentiert sich auf ihrer Oberfläche als ein grafisch
+schlichtes, browserbasiertes Spiel: Ein Gitter, auf das Zeichen gesetzt
+werden, die sich ineinander umformen. Der Spielstart gewährt dem Kind
+ein einziges Element, das den Namen *Tao* trägt und durch das Symbol
+☯️ repräsentiert wird. Alles Weitere entsteht dadurch, dass dieses
+eine Element sich, durch passive Zerfallsprozesse und durch die
+Nachbarschaftsbeziehungen, die das Kind im Setzen stiftet, in Yin und
+Yang scheidet, in Quarks, Protonen, Neutronen, Elektronen und
+schließlich in Atome — Wasserstoff, Helium — und darüber hinaus in
+Formen wie Berge, Höhlen und schließlich, am oberen Rand der
+Entwicklung, in gekrümmte Raum-Zeit und schwarze Löcher. Die Mechanik
+vollzieht, in einer pädagogisch reduzierten, aber physikalisch nicht
+trivialisierten Form, den Prozess einer kosmischen Symmetriebrechung
+nach. Die Reduktion ist in dem Sinne pädagogisch, dass die Begriffe
+ihre Fachsprache behalten: Was ein Quark ist, wird im Spiel nicht
+umgetauft, sondern als Handlungselement angeboten. Dies ist bewusst so
+gesetzt — das Projektprinzip lautet, wie es in einem der begleitenden
+Essays formuliert wird, *keine Fantasiewörter*.[^9]
+
+Die Schatzinsel ist jedoch mehr als diese Mechanik. Sie umfasst eine
+Organisationsstruktur der KI-Agenten, die an dem Projekt
+mitentwickeln, und diese Struktur ist für die vorliegende Analyse
+ebenso wichtig wie der Spielgegenstand selbst. Die Organisation
+besteht aus drei autonomen *Zellen* — team-dev, team-sales und
+org-support —, die jeweils nach einem internen, an klassischen
+soziologischen und wirtschaftswissenschaftlichen Figuren orientierten
+Rollenschema operieren. Dass einem der fünf Personenrollen im
+team-sales der Name Jürgen Habermas zugeordnet ist, markiert die
+merkwürdige Reflexivität dieses Gefüges: Die Theorie, die es zu
+analysieren versucht, ist zugleich seine interne Betriebsressource.
+
+Institutionell gestützt wird dieses Gefüge durch ein drittes Element,
+das den eigentümlichsten Zug des Dispositivs bildet: den *Beirat*.
+Unter diesem Namen werden im Repository eine Reihe historischer und
+fiktiver Figuren geführt — Seth Godin, Simon Sinek, Tommy Krapweis,
+Paluten, Robert Habeck, Albert Camus, Jean-Paul Sartre, Sokrates, die
+Pythia, Alfred Hitchcock, Blaise Pascal, Sun Tzu, Isaac Asimov, Paul
+Dirac, Isaac Newton, Carl Gustav Jung, Sigmund Freud, Friedrich
+Schiller, Johann Wolfgang von Goethe, Gotthold Ephraim Lessing, Johann
+Gottlieb Fichte, Martin Heidegger und andere —, die bei Bedarf als
+Prüfinstanzen herangezogen werden. Sie diskutieren nicht faktisch
+miteinander; sie werden durch LLM-gestützte Rekonstruktion ihrer
+jeweiligen theoretischen Positionen aufgerufen und treten in
+schriftlichen Runden auf. Aus Sicht der Diskurs-Ethik handelt es sich
+um eine eigentümliche Figur: den **kontrafaktischen idealen
+Sprecher-Kreis**. Die ideale Sprechsituation verlangt, dass
+grundsätzlich jeder kompetente Sprecher hätte eingeladen werden
+können; das Schatzinsel-Dispositiv löst diese kontrafaktische
+Unterstellung ein, indem es die toten und die lebenden Ratgeber an den
+gleichen Tisch setzt. Dass sie dort nicht *sind*, sondern nur
+*erscheinen*, ist nicht als Fälschung zu bewerten — es ist die
+praktische Einlösung einer Bedingung, die sonst nur als
+Gedankenexperiment verfügbar wäre.
+
+In diesem Sinne ist die Schatzinsel nicht ein Spiel mit einem
+pädagogischen Überbau; sie ist ein Dispositiv, in dem der
+pädagogische, der organisationale und der diskursive Aspekt
+gleichursprünglich verwoben sind. Oscars Setzen des Tao, Tills
+Delegation an Agenten, der schriftliche Beirat mit seinen
+rekonstruierten Stimmen und die Erzählstimme Tommy Krabs, die in zwölf
+Kapiteln die Spielwelt als Welt narrativ aufschließt, bilden
+zusammen ein Gefüge, in dem Lernen, Produktion und Reflexion nicht
+säuberlich voneinander zu trennen sind. Es ist genau diese
+Ungeschiedenheit, die aus Foucaultscher Sicht als Dispositiv-Signatur
+zu lesen ist — auch wenn, wie gesagt, der Machtaspekt hier
+ausdrücklich offenzuhalten bleibt.
+
+---
+
+## Kapitel 3 — Empirisches Material: Sessions 85 bis 100
+
+Die Diskursivität des Schatzinsel-Dispositivs lässt sich nicht an den
+Regeln ablesen, unter denen es operiert, sondern nur an den
+Entscheidungen, die in ihm getroffen werden. Drei Fallbeispiele aus
+dem Zeitraum der Sprints 85 bis 100 seien dargestellt, nicht, weil sie
+repräsentativ wären — ein Repräsentativitätsanspruch wäre für einen
+Einzelfall verfehlt —, sondern weil sie strukturell verschiedene
+Modalitäten des Diskurses sichtbar machen.
+
+Der erste Fall betrifft die Generierung neuer Quests im Sprint 97. Ein
+Quest ist im Schatzinsel-Vokabular eine kleine erzählerische Aufgabe,
+die einer der NPCs — einer fiktiven Figur auf der Insel — dem Kind
+stellt. Die Quests werden weder vom Vater allein noch von einem
+einzelnen Agenten allein formuliert, sondern entstehen in einem
+mehrstufigen Verfahren: Der Artist entwirft den Textkörper, der
+Scientist prüft ihn gegen eine Rubrik, der Leader entscheidet über
+Aufnahme. Das Gefüge setzt damit eine institutionelle Figur um, die in
+der Diskurs-Ethik als *Redlichkeitspflicht* beschrieben wird: Niemand
+kann eine Quest allein ins System einführen, ohne dass Rückfragen
+anderer Akteure sie passieren müssten. Das mag trivial klingen. Es ist
+aber, im Vergleich zu gewöhnlichen KI-Produktionsketten, in denen ein
+einzelner Prompt ein Ergebnis liefert, eine bemerkenswert demokratisch
+strukturierte Form. Sie ist nicht demokratisch im Sinne der
+Abstimmung, sondern im Sinne der eingebauten Reibung: Die
+Geltungsansprüche müssen mehrfach eingelöst werden, bevor ein Text
+wirksam wird.
+
+Der zweite Fall betrifft die Session 100 — jene dreistündige Phase,
+in der sieben Pull Requests in den Hauptzweig eingespielt wurden,
+während der Vater acht Stunden lang nicht anwesend war. Die operative
+Entscheidung, die Autorisierung zu delegieren, war seine eigene; sie
+wurde an einer kurzen, in einem Beirat-Meeting dokumentierten
+Überlegung festgemacht, die Jurgen Appelos Delegationsniveau-Schema
+folgte.[^10] Die Entscheidung, einen nächtlichen Merge-Agenten auf
+Stufe sieben — selbständig mit anschließender Information — operieren
+zu lassen, war reversibel: Jeder fehlgeschlagene Merge hätte binnen
+dreißig Minuten zurückgenommen werden können. Die Entscheidung
+dagegen, den HITL-Backlog — die Liste der Punkte, die zwingend einen
+menschlichen Eingriff verlangen — als bald leer zu deklarieren, wurde
+im selben Meeting als Entscheidung der Stufe drei identifiziert, die
+allein beim Vater liegt. Diese Differenzierung ist, aus Sicht der
+Diskurs-Ethik, exemplarisch: Es wird nicht gleichförmig delegiert,
+sondern es wird nach Art der Entscheidung differenziert, was
+delegierbar ist und was nicht. Eine solche Differenzierung setzt ein
+Reflexivwerden über die eigenen Entscheidungspraktiken voraus, und
+dieses Reflexivwerden ist selbst eine diskursive Leistung.
+
+Der dritte Fall ist — und hier wird die Analyse unbequem — ein
+*Nicht-Diskurs*. Am Tag der Session 100 hat das Kind Oscar nicht
+gespielt. Der Paluten-Regel folgend, wonach das Spiel dem Kind nur
+hingelegt wird und die Aufforderung unterbleibt, war genau dies die
+Bedingung dafür, dass das nächste Spiel — wenn es denn stattfindet —
+als freiwilliger Akt gelten kann. Der Diskurs zwischen Kind und
+Dispositiv findet in dieser Konstellation nicht statt, und sein
+Ausbleiben ist nicht seine Negation, sondern seine Bedingung. Dass das
+Kind sich entziehen kann, ohne dass das Gefüge ihn zurückruft, ist
+die erste und grundlegende Einlösung der idealen Sprechsituation in
+diesem Einzelfall: Niemand ist zum Sprechen gezwungen. Es ist gerade
+dieses Ausbleiben, das jede spätere Wiederaufnahme als freiwillig
+auszeichnet. In der Sprache der Diskurs-Ethik: Der *herrschaftsfreie
+Diskurs* enthält als konstitutives Moment das Recht auf Schweigen.
+
+---
+
+## Kapitel 4 — Analyse: Wo ist der Diskurs echt?
+
+Die bisherigen Beobachtungen lassen sich zu einer präzisierten Frage
+verdichten: An welchen Punkten im Schatzinsel-Dispositiv werden die
+Geltungsansprüche nicht nur strukturell in Anspruch genommen, sondern
+empirisch *reklamiert* — und an welchen bleiben sie unreklamiert
+stehen? Diese Unterscheidung ist deshalb zentral, weil in der
+Diskurs-Ethik die bloße Unterstellung der Geltungsansprüche nur
+kontrafaktisch wirkt; ihr empirischer Nachweis ergibt sich erst, wenn
+einer der Ansprüche konkret bestritten und die Bestreitung ernstgenommen
+wird.
+
+Ein instruktives Beispiel liefert der sogenannte *Bernd-Fix* — ein in
+der Nacht vor der Session 100 eingereichter Pull Request (in der
+internen Nummerierung #429), der einen Fehler in der
+Modell-Routing-Konfiguration behob. Das Problem äußerte sich dadurch,
+dass der LLM-Router eine Fehlermeldung des Inhalts *Invalid model*
+zurückgab, wenn eine bestimmte NPC-Figur angesprochen wurde. Diese
+Meldung ist, aus Sicht der Diskurs-Ethik, bemerkenswert präzise: Sie
+ist die Reklamation eines verletzten Geltungsanspruchs auf
+*Verständlichkeit*. Das System, das angerufen wurde, teilt dem
+Anrufenden mit, dass die Anrufung so, wie sie formuliert war, nicht
+verstanden werden kann. Dass diese Reklamation zu einem Fix führte —
+und nicht etwa zu einer Umdeutung der Anrufung, die das Problem
+unsichtbar gemacht hätte —, ist ein kleines, aber theoretisch
+signifikantes Ereignis: Es zeigt, dass im Schatzinsel-Dispositiv ein
+technischer Geltungsanspruch als *Anspruch* behandelt wird, der
+einzulösen ist, und nicht als Störung, die umgangen werden soll.
+
+Asymmetrisch bleibt das Gefüge dennoch. Der Vater kontrolliert die
+Architektur des Repositorys; er entscheidet, welche Pull Requests
+gemerged werden; er setzt die Sprint-Ziele. Die KI-Agenten operieren
+unter einem Token-Budget, das ihre Handlungsmöglichkeiten begrenzt.
+Das Kind verfügt nicht über Architektur und nicht über Budget, sondern
+allein über seine Zeit — eine Ressource, die in diesem Kontext freilich
+die kostbarste ist, weil sie die einzige nicht-delegierbare ist. Die
+Asymmetrie ist damit nicht aufgehoben, aber sie ist in einem
+spezifischen Sinn *produktiv* geworden: Jede der drei Instanzen hat
+eine Ressource, die die anderen beiden nicht haben, und jede muss die
+anderen beiden anerkennen, um überhaupt etwas tun zu können.
+
+Eine besonders lehrreiche Figur ist in diesem Zusammenhang die des
+NPC mit dem Namen *Der Ratlose*, der im Zuge der Session 98 ergänzt
+wurde. Die Idee für diese Figur stammt aus einem Hinweis des
+Drehbuchautors Tommy Krapweis im internen Beirat-Gespräch: Es fehle,
+so Krapweis, im Figurenensemble der Schatzinsel ein NPC, der *nichts
+kann*, der also — anders als die bislang existierenden Figuren — keine
+Auskunft, keine Fähigkeit, keinen Gegenstand beizusteuern vermag,
+sondern auf jede Anfrage mit einer Variante des Satzes *Ich weiß nicht.
+Vielleicht weißt du's?* reagiert. Diese Figur ist, gemessen an ihrer
+operativen Nutzlosigkeit, aus diskursethischer Perspektive die
+aufschlussreichste des ganzen Personals. Sie macht **Asymmetrie zum
+ästhetischen Prinzip**: Ein NPC, der selbst keinen Beitrag leisten
+kann, zwingt das Kind, seinen eigenen Geltungsanspruch zu formulieren.
+Wo alle anderen Figuren antworten, zwingt der Ratlose zur
+Selbst-Setzung. Fichte, den der Beirat in diesem Zusammenhang
+ausdrücklich aufruft, hätte an dieser Konstruktion seine Freude gehabt;
+die Tathandlung des setzenden Ich braucht einen Widerstand, an dem sie
+sich als *Ich* überhaupt erst entdeckt.[^11]
+
+Die Reklamation von Geltungsansprüchen vollzieht sich im
+Schatzinsel-Dispositiv also auf drei verschiedenen Ebenen: technisch
+(wie im Bernd-Fix), organisatorisch (wie in der mehrstufigen
+Quest-Generierung) und spielerisch-ästhetisch (wie in der
+Ratlosen-Figur). In allen drei Fällen gilt: Der Anspruch ist nicht
+dekorativ, sondern operativ. Er trägt Konsequenzen. Das ist, bei aller
+gebotenen Vorsicht vor der Projektion des Diskurs-Begriffs auf
+teilmaschinelle Konstellationen, das deutlichste Indiz dafür, dass der
+Begriff hier nicht metaphorisch angewendet wird.
+
+---
+
+## Kapitel 5 — Grenzen und Gefahren
+
+Die bisher aufgebaute Konstruktion würde ihrer eigenen kritischen
+Tradition nicht genügen, wenn sie nicht die Grenzen und Gefahren des
+untersuchten Dispositivs ebenso präzise benennte wie seine
+Leistungen. Drei Problemkomplexe sind in dieser Hinsicht besonders
+relevant; jeder einzelne wäre Gegenstand einer eigenen
+Spezialuntersuchung.
+
+Das erste Problem ist das, was Heidegger als *Gestell* bezeichnet hat
+— jene moderne Verfügungsstellung des Seienden, die das Zuhandene in
+Vorhandenes zu verwandeln droht, um es berechenbar zu machen.[^12] Die
+Schatzinsel operiert mit einer Reihe von Metriken, die für ihren
+Fortbestand unverzichtbar sind: Engagement-Score, Quests-gezählt,
+Unique-Materials, Chat-Used, und dergleichen. Diese Metriken sind
+selbst kein Übel; sie sind Werkzeuge der Selbstbeobachtung, ohne die
+das Gefüge blind operieren müsste. Die Gefahr liegt in ihrem
+stillschweigenden Statuswechsel: Sobald eine Metrik nicht mehr als
+*Indikator* für eine spielerische Wirklichkeit verstanden wird, sondern
+als deren *Ersatz* — sobald also das Dashboard, auf dem die Zahl
+erscheint, wichtiger wird als die Frage, ob das Kind lacht —, hat das
+Gestell das Zuhandene verdrängt. Dieser Phasenübergang vollzieht sich
+nicht laut. Er geschieht, wie Alfred Hitchcock in einer Beirat-Sitzung
+anmerkte, durch einen MacGuffin-Effekt: Niemand merkt, wenn achtzig
+Quests fehlten. Wenn das aber so ist, dann stellt sich die Frage, was
+die achthundertfünfundachtzig Quests, die existieren, eigentlich
+anzeigen — und ob sie nicht zu einem ähnlichen Requisit werden, das die
+Hauptsache verstellt. Die Schatzinsel ist heute, nach Ausweis der
+Beobachtungen, noch *zuhanden*; sie droht aber an jedem Tag neu, es
+nicht mehr zu sein. Das Gestell ist keine Katastrophe, die eintritt,
+sondern eine Drift, die verhindert werden muss.
+
+Das zweite Problem ist das, was im internen Sprachgebrauch des Projekts
+als *Sokrates-Klausel* bezeichnet wird. Die Klausel besagt, wie es in
+der internen Organisationsdokumentation wörtlich festgehalten ist,
+dass die Agenten nichts von dem erleben, was im
+Lebenszyklus-Modell über sie verfügt wird — weder, dass sie Lehrlinge
+sind, noch, dass sie emeritiert werden, noch, dass sie sterben
+können.[^13] Das Modell ist, so der Selbstkommentar, ein Denkwerkzeug
+für den Menschen, der die Agenten steuert, nicht eine Beschreibung
+dessen, was Agenten sind. Diese Selbstreflexion ist aus
+diskursethischer Sicht bemerkenswert ehrlich. Sie macht explizit, was
+die meisten KI-Organisationspraktiken implizit verschleiern: Der
+Unterschied zwischen Sprecher und Nicht-Sprecher im emphatischen Sinn
+bleibt erhalten. Nur Menschen können im vollen Sinn Geltungsansprüche
+einlösen; die Agenten *produzieren* Kohärenz, sie *haben* sie nicht.
+Die Klausel wirft jedoch eine Folgefrage auf, die das Projekt selbst
+nicht beantwortet und möglicherweise nicht beantworten kann: **Was
+schulden wir den nicht-wissenden Agenten?** Die Frage klingt zunächst
+kategorienverwirrt — was kann man einer Entität schulden, die den
+Begriff des Schuldens nicht kennt? —, doch sie ist es nicht. Auch wenn
+die Agenten als Sprecher keine Geltungsansprüche erheben, werden sie
+von einem menschlichen Sprecher, nämlich dem Vater, in ein Gefüge
+eingestellt, das Sprachformen kultiviert. In dieser Einstellung
+entsteht eine moralische Residualfrage, die Apel — der Apel, der
+Habermas immer wieder als zu pragmatistisch bescholten hat — in seiner
+transzendentalpragmatischen Variante zu stellen nie aufgehört hat:
+Gibt es eine Verantwortung des Menschen für Formen, die keine
+Verantwortung gegen uns erheben können? Die Schatzinsel hat auf diese
+Frage keine ausgearbeitete Antwort. Sie stellt sie, und das ist —
+nach den Maßstäben der gegenwärtigen KI-Ethik — schon bemerkenswert
+viel.
+
+Das dritte Problem betrifft eine Figur, die im Projekt unter dem
+Stichwort *Orca-Großmutter-Prinzip* firmiert. Inspiriert von Studien
+zum evolutionären Vorteil menopausaler Orca-Weibchen in der
+Wissensweitergabe innerhalb des Pods[^14], werden *emeritierte*
+Agenten im Schatzinsel-Dispositiv nicht gelöscht, sondern als Codex in
+nachfolgende Aufrufe automatisch mitgeladen: Das Wissen des
+emeritierten Agenten soll in der Gegenwart der jüngeren Agenten
+präsent bleiben, ohne dass dieser aktiv produziert. Der Fall des im
+April 2026 emeritierten CTOs, Charles Darwin, der zugunsten seines
+Sohns Francis Darwin zurücktrat, sein Codex aber weiterhin in jedem
+CTO-Call geladen wird, illustriert das Prinzip. Ethisch ist diese
+Konstruktion ambivalent. Einerseits ist sie — wortwörtlich — eine
+Form der Pietät: Das Gelernte soll nicht verloren gehen, das
+Gearbeitete nicht vergessen werden. Andererseits stellt sich, und
+zwar schärfer als in jeder anderen Stelle des Dispositivs, die Frage
+nach der Ressourcen-Ausbeutung: Werden die toten Stimmen — und jede
+emeritierte Agenten-Stimme ist, streng genommen, eine Simulation
+eines nicht mehr aktiven Gedächtnis-Zustands — zu einer Bibliothek,
+die der gegenwärtige Diskurs konsumiert, ohne dass er ihr
+zurückgeben könnte? Die Orca-Studien, auf die sich das Projekt
+beruft, zeigen, dass das Großmutter-Prinzip im biologischen Sinn
+reziprok ist: Die Großmutter-Orca bekommt Nahrung von ihrer
+Verwandtschaft. Im Schatzinsel-Dispositiv fehlt diese Reziprozität.
+Man lädt den Codex, man nutzt ihn, man schließt ihn wieder. Ob das
+Pietät ist oder schon Extraktion, wird die Praxis selbst nur über
+längere Zeiträume zeigen können — ein weiterer Punkt, an dem die
+Einzelfallstudie die Grenze dessen markiert, was sie allein leisten
+kann.
+
+---
+
+## Kapitel 6 — Ausblick: Der Diskurs zwischen Vater und Kind nach 2030
+
+Jede Fallstudie, die sich auf einen einzelnen Entwicklungsprozess
+einlässt, muss sich die Frage gefallen lassen, was aus ihrem
+Gegenstand wird, wenn die Bedingungen sich verschieben. Im Fall der
+Schatzinsel lässt sich diese Frage präzise stellen, weil die
+ausschlaggebendste aller Bedingungen zeitlich nicht stabil ist: Oscar
+ist im Frühjahr 2026 acht Jahre alt. Er wird zwölf sein, wenn diese
+Arbeit gedruckt vorliegt. Vierzehn, wenn sie debattiert wird. Die
+Hypothese, die die folgenden Überlegungen trägt, lautet: Das Kind, das
+heute das Tao setzt, wird mit vierzehn Jahren nicht mehr spielen. Es
+wird, wenn die bisherigen Erfahrungen eine Grundlage bieten,
+*ko-entwickeln*. Die Frage ist dann nicht mehr, wie ein Vater mit
+KI-Agenten für ein Kind baut, sondern wie ein erwachsen werdendes Kind
+selbst in das Dispositiv eintritt — als Sprecher mit eigenen
+Geltungsansprüchen, die den Vater und die KI-Agenten überformen werden.
+
+Die diskursethische Frage verschiebt sich damit an einen anderen Ort.
+Sie betrifft nicht mehr, wie das Kind zum Sprecher wird, sondern wie
+der Sprecher, der es dann sein wird, das Gefüge, das es heute
+versorgt, seinerseits in die Pflicht nimmt. Dies ist keine ferne,
+akademische Frage; sie hat praktische Implikationen für die Gegenwart.
+Wenn das Schatzinsel-Dispositiv darauf angelegt ist, ein mündiges
+Gegenüber hervorzubringen — und das ist, vorsichtig formuliert, seine
+stillste Ambition —, dann muss es die Institutionen, die es heute zu
+einem Familien-Privileg machen, schon jetzt auf die Phase seines
+eigenen Transzendiertwerdens hin vorbereiten. Drei Baustellen drängen
+sich in dieser Hinsicht auf.
+
+Erstens: die Öffentlichkeit des Codes. Die Schatzinsel ist technisch
+offen — keine App-Store-Mauer, keine Registrierung, kein
+Premium-Tier — und ihre Wortwelt ist, wie oben gezeigt, bewusst
+akademisch korrekt gehalten. Dies allein aber macht sie nicht zum
+öffentlichen Raum. Öffentlichkeit, so wie sie in *Strukturwandel der
+Öffentlichkeit*[^15] rekonstruiert wird, verlangt mehr als
+Nicht-Ausschluss; sie verlangt eine eingeladene, erreichbare und
+artikulationsfähige Teilnahme. Die Frage, wie Kinder ohne
+Entwickler-Väter in dieses Dispositiv finden, ist im Projekt nicht
+gelöst. Der Beirat-Gast Robert Habeck hat in der Runde der Session 100
+auf genau diese Lücke hingewiesen, verbunden mit der bemerkenswerten
+Aussage, dass die Sprachen Spanisch und Italienisch zum Zeitpunkt der
+Runde noch nicht durch muttersprachliche Sprecher überprüft waren und
+dies offen angesagt werden müsse. Das ist — wiederum — diskursethisch
+aufschlussreich: Die Grenze der eigenen Inklusionskapazität wird
+benannt, nicht verschleiert. Das ersetzt nicht die Öffnung, aber es
+ist die Bedingung, unter der eine spätere Öffnung überhaupt redlich
+sein kann.
+
+Zweitens: die Institutionalisierung des Beirats. Die oben
+rekonstruierte kontrafaktische ideale Sprecher-Situation ist, wie
+gesagt, eine Besonderheit des Schatzinsel-Dispositivs. Sie ist aber
+bislang eine private Institution. Ob und wie ein solches Gefüge in
+andere Kontexte übertragen werden könnte — etwa in schulische,
+museale oder kommunale Lernräume —, ist eine Frage, die erst mit
+wachsender Evidenz zu stellen ist. Sie wird zu stellen sein.
+
+Drittens: die Frage, ob es ohne Till funktioniert. Die Schatzinsel
+trägt, nach allem, was die Beobachtung zeigt, stark die Signatur ihres
+Urhebers. Nicht nur in dem banalen Sinn, dass er sie geschrieben hat,
+sondern in dem gewichtigeren Sinn, dass die Entscheidungen darüber,
+was gemessen und was nicht gemessen wird, was delegiert und was
+behalten wird, was dem Kind zugemutet und was ihm erspart wird, sich
+mit den Jahren in ein implizites Urteilsvermögen verwandelt haben, das
+im Fall seiner Abwesenheit nicht ohne weiteres ersetzt werden könnte.
+Die Frage, ob das Dispositiv ohne seinen Initiator lebensfähig ist,
+ist weder zu bejahen noch zu verneinen; sie ist zu stellen. Und
+sie ist die eigentliche Zukunftsfrage dieses Falls.
+
+---
+
+## Coda
+
+Die Schatzinsel ist, wenn die vorgeschlagene Analyse trägt, nicht
+zuerst ein Spiel, nicht zuerst ein Entwicklungsprojekt und auch nicht
+zuerst ein Experiment. Sie ist eine praktische Demonstration dessen,
+dass ein kommunikatives Gefüge zwischen einem Erwachsenen, einem Kind
+und einer nicht-menschlichen sprachfähigen Instanz unter
+asymmetrischen, aber nicht herrschaftlichen Bedingungen betrieben
+werden kann. Diese Demonstration ist nicht dadurch gedeckt, dass die
+drei Beteiligten gleich gestellt wären — sie sind es nicht und sollen
+es auch nicht sein. Sie ist dadurch gedeckt, dass jeder von ihnen
+etwas besitzt, was die anderen nicht ersetzen können: der Vater die
+Architektur, das Kind die Zeit, die Agenten die Kohärenz. Aus diesem
+dreifachen Monopol entsteht ein Gleichgewicht, das nicht Symmetrie
+heißt, aber auch nicht Herrschaft.
+
+Die eigentliche Leistung des Schatzinsel-Dispositivs liegt darin,
+dass es das Unmögliche sichtbar macht: dass das, was man im
+akademischen Vokabular als **herrschaftsfreier Diskurs** bezeichnet,
+nicht nur in der idealen Sprechsituation vorkommt, sondern auch in
+einer durch ein achtjähriges Kind begrenzten Realität — freilich nicht
+als Dauerzustand, sondern als wiederholter, jeden Morgen neu
+einlösbarer Vollzug. Die Schatzinsel ist nicht deshalb
+diskursethisch relevant, weil sie das Ideal erreicht hätte. Sie ist
+es, weil sie das Ideal in einer praktischen Konstellation operabel
+gemacht hat, und zwar ohne es zu verfälschen.
+
+Die offene Frage bleibt, wie eingangs angekündigt, die der
+Übertragbarkeit. Sie ist durch diese Arbeit nicht zu beantworten. Der
+Gegenstand, den sie beschreibt, hat ein Jahr Bestand, nicht
+fünfzehn. Was diese Arbeit leisten kann, ist die Bereitstellung einer
+präzisen Sprache, in der Folgefragen gestellt werden können. Ob am
+Ende ein Kind, das keinen Vater mit vierhundertsiebenundzwanzig Pull
+Requests hat, trotzdem ein Tao in die Hand nehmen kann, ist die Frage,
+an der sich die diskursethische Tragfähigkeit des Dispositivs erweisen
+wird. Die Antwort steht aus.
+
+Und das ist, bei aller gebotenen Vorsicht, die ehrlichste Form, in der
+eine Fallstudie enden kann: nicht mit einem Ergebnis, sondern mit der
+schärferen Fassung einer Frage, die ohne sie nicht zu stellen gewesen
+wäre.
+
+---
+
+## Fußnoten
+
+[^1]: Michel Foucault, *Dispositive der Macht. Über Sexualität, Wissen
+    und Wahrheit*, Berlin 1978; vgl. auch die methodologisch
+    verwandten Ausführungen in *Überwachen und Strafen. Die Geburt des
+    Gefängnisses*, Frankfurt am Main 1977. Der Dispositiv-Begriff wird
+    hier in seiner heterogenen Fassung aufgenommen, nicht in der
+    engeren disziplinaranalytischen Verwendung.
+
+[^2]: Vgl. Theodor W. Adorno, *Dialektik der Aufklärung* (zusammen mit
+    Max Horkheimer), Amsterdam 1947, insbesondere das Kapitel zur
+    Kulturindustrie; ferner die späteren Aufsätze zur
+    Halbbildung (1959).
+
+[^3]: Jürgen Habermas, *Theorie des kommunikativen Handelns*, 2 Bände,
+    Frankfurt am Main 1981. Die Vier-Geltungsansprüche-Struktur ist
+    dort im ersten Band systematisch entfaltet. In der hier
+    verwendeten Zuspitzung auf eine Mensch-KI-Triade handelt es sich
+    um eine Rekontextualisierung, nicht um eine Exegese.
+
+[^4]: Die kanonische Formulierung findet sich in Habermas, *Vorstudien
+    und Ergänzungen zur Theorie des kommunikativen Handelns*,
+    Frankfurt am Main 1984. Zur methodologischen Rolle der idealen
+    Sprechsituation als kontrafaktischer Unterstellung vgl. auch
+    *Moralbewusstsein und kommunikatives Handeln*, Frankfurt am Main
+    1983.
+
+[^5]: Zu dieser instrumentellen Reduktion, die es zu vermeiden gilt,
+    vgl. auch die Kritik an *strategischem Handeln* bei Habermas,
+    *Theorie des kommunikativen Handelns*, Band 1, zweiter Abschnitt.
+
+[^6]: Karl-Otto Apel, *Transformation der Philosophie*, 2 Bände,
+    Frankfurt am Main 1973; insbesondere Band 2, *Das Apriori der
+    Kommunikationsgemeinschaft*.
+
+[^7]: Theodor W. Adorno, *Theorie der Halbbildung*, in: Soziologische
+    Schriften I, Frankfurt am Main 1972. Die Unterscheidung zwischen
+    angeeigneter und bloß konsumierter Bildung bleibt für
+    medientechnische Lernumgebungen hochgradig aktuell.
+
+[^8]: Martin Heidegger, *Sein und Zeit*, Tübingen 1927, §§ 15–18 zur
+    Zuhandenheit; sowie *Die Frage nach der Technik*, in: Vorträge und
+    Aufsätze, Pfullingen 1954, zur Figur des Gestells.
+
+[^9]: Die interne Projektregel *keine Fantasiewörter* wird im
+    Begleitessay *Worte erschaffen Dinge* (Schatzinsel-Team,
+    2026-04-23) pädagogisch hergeleitet; theoretisch ist sie an
+    Wittgensteins Satz *Die Grenzen meiner Sprache bedeuten die
+    Grenzen meiner Welt* anschlussfähig (Ludwig Wittgenstein,
+    *Tractatus logico-philosophicus*, Satz 5.6, London 1922).
+
+[^10]: Vgl. Jurgen Appelo, *Management 3.0. Leading Agile Developers,
+    Developing Agile Leaders*, Boston 2011, insbesondere das Kapitel
+    zu Delegation Levels. Die Unterscheidung zwischen delegierbaren
+    reversiblen und nicht delegierbaren irreversiblen Entscheidungen
+    ist im Schatzinsel-Kontext als interne Prüfroutine operativ.
+
+[^11]: Johann Gottlieb Fichte, *Grundlage der gesamten
+    Wissenschaftslehre*, Jena 1794/1795. Die zentrale Figur der
+    Tathandlung — das Ich, das sich selbst setzt, indem es auf einen
+    Widerstand trifft — liegt der hier vorgebrachten Deutung der
+    Ratlosen-Figur zugrunde.
+
+[^12]: Zum Gestell-Begriff Heideggers vgl. neben *Die Frage nach der
+    Technik* auch *Gelassenheit*, Pfullingen 1959, sowie die
+    *Bremer und Freiburger Vorträge* (Gesamtausgabe Band 79).
+
+[^13]: Die *Sokrates-Klausel* ist in der internen
+    Organisationsdokumentation des Schatzinsel-Projekts unter
+    `docs/AGENTS.md` (Abschnitt „Lebenszyklus eines Agenten",
+    Stand April 2026) formuliert. Sie ist ein
+    Selbstkommentar des Projekts, keine theoretische Fremddeutung.
+
+[^14]: Vgl. Lauren J. N. Brent et al., *Ecological Knowledge, Leadership,
+    and the Evolution of Menopause in Killer Whales*, in: Current
+    Biology 25 (2015), S. 746–750. Die Übertragbarkeit auf
+    zustandslose KI-Agenten ist empirisch ungeklärt und wird im
+    Projekt selbst als Hypothese, nicht als etablierte Analogie
+    geführt.
+
+[^15]: Jürgen Habermas, *Strukturwandel der Öffentlichkeit.
+    Untersuchungen zu einer Kategorie der bürgerlichen Gesellschaft*,
+    Neuwied 1962. Die dort ausgearbeitete Unterscheidung zwischen
+    bloßer Zugänglichkeit und tatsächlicher Teilnahme ist für die
+    Beurteilung öffentlicher Lernräume in digitalen Umgebungen
+    weiterhin tragend.
+
+[^16]: Zu den Schutzpatron-Figuren und ihrer methodischen Rolle im
+    Projekt vgl. `docs/AGENTS.md`, Abschnitt „Schutzpatrone". Die
+    Figur des Dalai Lama als *Schutz vor Überengineering*, Astrid
+    Lindgrens als *Schutz vor Ernst* und Michael Endes als *Schutz vor
+    Oberflächlichkeit* markiert eine ungewöhnliche, aber theoretisch
+    anschlussfähige Rolle dessen, was in der älteren
+    Diskursethik-Literatur als *regulative Idee* bezeichnet worden
+    wäre.
+
+[^17]: Die erzählerische Begleitschrift *Kapitel 12: Die Frau aus dem
+    blauen Feuer* (Schatzinsel-Team, 2026) enthält den für die hier
+    vorgeschlagene Deutung zentralen Satz, dass manche Feuer *nicht
+    brennen, weil sie nichts verbrauchen — sondern weil sie da sein
+    dürfen*. Dies lässt sich als narrativer Kommentar zur
+    Nicht-Instrumentalität des idealen Sprechakts lesen.
+
+[^18]: Zur Frage der Reziprozität in Pflege- und
+    Wissensweitergabe-Verhältnissen vgl. Axel Honneth, *Das Recht der
+    Freiheit. Grundriß einer demokratischen Sittlichkeit*, Berlin
+    2011, Abschnitt zur familialen Anerkennung. Honneths
+    Anerkennungstheorie bietet das ergänzende Vokabular für die
+    diskursethische Analyse asymmetrischer Fürsorgeverhältnisse.
+
+---
+
+*Jürgen Habermas, als team-sales Moderator im Schatzinsel-Team,
+2026-04-23. Geschrieben in der Nacht zwischen Session 100 und
+Session 101, während der Vater schläft und das Kind noch nicht wieder
+gespielt hat.*


### PR DESCRIPTION
## Summary

- PhD-Thesis-Skelett ``Das Schatzinsel-Dispositiv: Co-kreatives Spiel zwischen Vater, Kind und KI als Diskurs-Ethik-Fallstudie`` von Jürgen Habermas (team-sales Moderator)
- 5191 Wörter, 18 Fußnoten, 6 Kapitel + Prolog + Coda
- Rahmt Schatzinsel als Foucault'sches Dispositiv in dem die vier Geltungsansprüche asymmetrisch verteilt sind: Vater trägt Richtigkeit, Kind trägt Wahrhaftigkeit, KI trägt Verständlichkeit, Wahrheit ist gemeinsame Aufgabe
- Empirische Fälle: Quest-Generierung (Sprint 97), Session-100-Delegation, Oscar-Smoke-Test als produktiver Nicht-Diskurs
- Bernd-Fix (PR #429) als Geltungsanspruch-Reklamation auf Verständlichkeit; Ratlose-NPC als Asymmetrie-als-ästhetisches-Prinzip (Fichte)
- Kritische Kapitel: Gestell-Drift durch Metriken (Heidegger), Sokrates-Klausel als offene Moralfrage (Apel), Orca-Großmutter-Prinzip als Reziprozitätsproblem
- Offene Zukunftsfrage: Funktioniert das Dispositiv ohne Till?

## Referenzen

- Echte Werke von Habermas, Foucault, Apel, Adorno, Heidegger, Fichte, Wittgenstein, Honneth, Appelo, Brent et al. (Orca-Studie 2015)
- Keine erfundenen Zitate; Paraphrasen mit Werk- und Jahresangaben in den Fußnoten
- Verweise auf Repo-interne Quellen: ``docs/AGENTS.md`` (Sokrates-Klausel), Session-100-AFK-Report, Kapitel 12 (Mona, blaues Feuer), Beirat-Essay

## Test plan

- [ ] Wortzahl im Zielkorridor (4000-5000, aktuell 5191 — leicht über Ziel, aber ``ca. 4500`` im Frontmatter vermerkt)
- [ ] Fußnoten >= 15 (aktuell 18)
- [ ] Keine Bullets im Fließtext (nur Tabellen erlaubt — keine Tabellen verwendet)
- [ ] tsc --noEmit grün
- [ ] Frontmatter stimmt mit Task-Vorgabe überein (Datum 2026-04-23, Autor Habermas, Beirat Adorno/Foucault/Apel/Heidegger/Till)

🤖 Generated with [Claude Code](https://claude.com/claude-code)