### PR TITLE
fix(physik): Baryon-Bauplan — 4 Korrekturen (Masse, Spin, Farbladung, Pauli-Workaround)

### DIFF
--- a/docs/metrics/2026-04-22-standardmodell-komplett.md
+++ b/docs/metrics/2026-04-22-standardmodell-komplett.md
@@ -100,3 +100,67 @@ Zwischenschritt zur Atom-Bildung erhöht Oscars Entdeckungspfad.
 - 23 automerge-Tests grün (10 bestehend + 13 neu)
 - 44 verwandte Tests grün (atom-recognizer, mass-map, unit)
 - `tsc --noEmit` grün (Material-Interface um `spin?` erweitert)
+
+---
+
+## Nachtrag 2026-04-22 — Baryon-Bauplan-Audit (Till)
+
+Till hat vier Probleme im Baryon-Bauplan gefunden. Alle vier in
+`fix/baryon-bauplan` gefixt.
+
+### 1. Neutron-Masse leicht größer als Proton
+
+Real: Proton 938.272 MeV/c², Neutron 939.565 MeV/c² (Neutron ~0.14%
+schwerer, wegen schwererem down-Quark + EM-Selbstenergie). Im Spiel
+waren beide bei `mass: 20`. Jetzt: Neutron `mass: 21` (+5%). Effekt
+auf Curvature-Map minimal, Ordnung stimmt.
+
+### 2. Farbladung — ehrlich dokumentiert (nicht modelliert)
+
+Bisheriger Kommentar `"Farbneutral via drei verschiedene Farbladungen"`
+war irreführend: Yang und Yin haben im Spiel keine Farb-Varianten.
+Wir modellieren die Dreiheit nur über Flavor (uud/udd).
+
+Entscheidung: **Abstraktion beibehalten, Kommentar ehrlich machen**.
+Eine Mechanik mit drei Farb-Yangs/-Yins würde die Quark-Ladder
+(Yang² → Charm) komplett umbauen — aus Spielbarkeits-Gründen
+ausgespart. Dokumentiert in `automerge.js` (TRIPLET_RULES-Block) und
+`materials.js` (Proton/Neutron-Definition).
+
+### 3. Spin-Feld für alle Fermionen
+
+Bisher hatten nur Bosonen (γ, W, Z, H) und Mesonen/Positron spin-Felder.
+Baryonen (Proton, Neutron) und alle Quarks/Leptonen fehlten. Alle
+Fermionen haben jetzt `spin: 0.5`:
+
+- Gen-1-Quarks: yin, yang
+- Gen-2-Quarks: charm, strange
+- Gen-3-Quarks: mountain (top), cave (bottom)
+- Leptonen: electron, muon, tau
+- Neutrinos: neutrino, neutrino_mu, neutrino_tau
+- Baryonen: proton, neutron
+
+### 4. Pauli verhindert Baryon-Bildung — Craft-Rezept als Fix
+
+Grid-Triplet-Merge (Yang+Yang+Yin → Proton) wird durch den Pair-Merge
+Yang+Yang → Charm blockiert: sobald der zweite Yang auf einer Kante
+landet, ist Charm da, bevor Yin gelegt werden kann. Oscar kommt nicht
+zum Ziel.
+
+Fix: Baryon als Craft-Recipe.
+```
+2 Yang + 1 Yin → 1 Proton   (uud, Ladung +1)
+1 Yang + 2 Yin → 1 Neutron  (udd, Ladung  0)
+```
+
+Grid-Triplet bleibt als emergent bonus für Physik-Nerds (diagonale
+Platzierung).
+
+### Tests
+
+Neue Suite "Baryon-Bauplan-Konsistenz" + "INSEL_CRAFTING_RECIPES —
+Baryon-Craft" in `ops/tests/automerge.test.js`. `package.json`
+erweitert: automerge.test.js ist jetzt Teil von `npm run test:unit`
+(war vorher nicht eingehängt).
+
+72 Tests grün nach den Fixes. `tsc --noEmit` grün.

--- a/ops/tests/automerge.test.js
+++ b/ops/tests/automerge.test.js
@@ -403,3 +403,47 @@ describe('INSEL_MATERIALS — Baryon-Bauplan-Konsistenz', () => {
     });
 });
 
+// === Baryon-Craft-Rezepte (Pauli-Workaround) ===
+// Grid-Triplet-Merge wird durch Yang+Yang → Charm blockiert. Craft ist
+// der direkte Weg für Oscar. Ladung/Nukleonen physikalisch konsistent.
+describe('INSEL_CRAFTING_RECIPES — Baryon-Craft', () => {
+    let ctx;
+    let recipes;
+    let materials;
+
+    beforeEach(() => {
+        ctx = createBrowserContext();
+        loadScript(path.join(WORLD, 'materials.js'), ctx);
+        loadScript(path.join(WORLD, 'recipes.js'), ctx);
+        recipes = ctx.INSEL_CRAFTING_RECIPES;
+        materials = ctx.INSEL_MATERIALS;
+    });
+
+    it('Proton-Recipe existiert: 2 yang + 1 yin → 1 proton', () => {
+        const r = recipes.find(x => x.result === 'proton');
+        assert.ok(r, 'Proton-Craft-Recipe fehlt');
+        assert.equal(r.ingredients.yang, 2);
+        assert.equal(r.ingredients.yin, 1);
+        assert.equal(r.resultCount, 1);
+    });
+
+    it('Neutron-Recipe existiert: 1 yang + 2 yin → 1 neutron', () => {
+        const r = recipes.find(x => x.result === 'neutron');
+        assert.ok(r, 'Neutron-Craft-Recipe fehlt');
+        assert.equal(r.ingredients.yang, 1);
+        assert.equal(r.ingredients.yin, 2);
+        assert.equal(r.resultCount, 1);
+    });
+
+    // Ladungs-Bilanz Proton: 2·(+2/3) + 1·(-1/3) = +1 ✓
+    // Ladungs-Bilanz Neutron: 1·(+2/3) + 2·(-1/3) = 0 ✓
+    // Symbolisch über Ergebnis-Material verifiziert (yin/yang ohne charge).
+    it('Proton-Ergebnis hat charge=+1 (uud)', () => {
+        assert.equal(materials.proton.charge, 1);
+    });
+
+    it('Neutron-Ergebnis hat charge=0 (udd)', () => {
+        assert.equal(materials.neutron.charge, 0);
+    });
+});
+

--- a/ops/tests/automerge.test.js
+++ b/ops/tests/automerge.test.js
@@ -338,3 +338,68 @@ describe('INSEL_AUTOMERGE — Standardmodell komplett', () => {
         assert.equal(result.result, 'qi');
     });
 });
+
+// === Baryon-Bauplan-Audit (Till, 2026-04-22) ===
+// Masse-Ordering, Spin-Konsistenz, Farbladungs-Dokumentation.
+describe('INSEL_MATERIALS — Baryon-Bauplan-Konsistenz', () => {
+    let ctx;
+    let materials;
+
+    beforeEach(() => {
+        ctx = createBrowserContext();
+        loadScript(path.join(WORLD, 'materials.js'), ctx);
+        materials = ctx.INSEL_MATERIALS;
+    });
+
+    // Fix 1: Neutron real leicht schwerer als Proton (+0.14% in der Natur).
+    it('neutron.mass > proton.mass (real: 939.565 > 938.272 MeV/c²)', () => {
+        assert.ok(typeof materials.proton.mass === 'number');
+        assert.ok(typeof materials.neutron.mass === 'number');
+        assert.ok(
+            materials.neutron.mass > materials.proton.mass,
+            `neutron.mass (${materials.neutron.mass}) muss > proton.mass (${materials.proton.mass}) sein`
+        );
+    });
+
+    // Fix 3: Alle Fermionen (Quarks, Leptonen, Baryonen) haben spin = 0.5.
+    it('alle Gen1-Quarks haben spin=0.5 (Fermionen)', () => {
+        assert.equal(materials.yin.spin, 0.5, 'yin (down-Quark) ist Fermion');
+        assert.equal(materials.yang.spin, 0.5, 'yang (up-Quark) ist Fermion');
+    });
+
+    it('alle Gen2-Quarks haben spin=0.5 (Fermionen)', () => {
+        assert.equal(materials.charm.spin, 0.5);
+        assert.equal(materials.strange.spin, 0.5);
+    });
+
+    it('alle Gen3-Quarks haben spin=0.5 (mountain=top, cave=bottom)', () => {
+        assert.equal(materials.mountain.spin, 0.5, 'mountain = Top-Quark');
+        assert.equal(materials.cave.spin, 0.5, 'cave = Bottom-Quark');
+    });
+
+    it('alle geladenen Leptonen haben spin=0.5', () => {
+        assert.equal(materials.electron.spin, 0.5);
+        assert.equal(materials.muon.spin, 0.5);
+        assert.equal(materials.tau.spin, 0.5);
+    });
+
+    it('alle Neutrinos haben spin=0.5', () => {
+        assert.equal(materials.neutrino.spin, 0.5);
+        assert.equal(materials.neutrino_mu.spin, 0.5);
+        assert.equal(materials.neutrino_tau.spin, 0.5);
+    });
+
+    it('Baryonen (Proton, Neutron) haben spin=0.5 (Drei-Quark-Fermionen)', () => {
+        assert.equal(materials.proton.spin, 0.5);
+        assert.equal(materials.neutron.spin, 0.5);
+    });
+
+    // Bosonen bleiben bei ihren Spins (Regression).
+    it('Bosonen-Spin intakt (Regression)', () => {
+        assert.equal(materials.photon.spin, 1,   'γ: Vektor-Boson');
+        assert.equal(materials.w_boson.spin, 1,  'W: schwaches Vektor-Boson');
+        assert.equal(materials.z_boson.spin, 1,  'Z: schwaches Vektor-Boson');
+        assert.equal(materials.higgs_boson.spin, 0, 'H: Skalar-Boson');
+    });
+});
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "test:unit": "node --test ops/tests/unit.test.js ops/tests/elemente-recipes.test.js",
+    "test:unit": "node --test ops/tests/unit.test.js ops/tests/elemente-recipes.test.js ops/tests/automerge.test.js",
     "test:e2e": "npx playwright test --config ops/tests/playwright.config.js",
     "typecheck": "tsc --noEmit"
   },

--- a/src/world/automerge.js
+++ b/src/world/automerge.js
@@ -91,22 +91,32 @@
             result: 'metal',
             msg: '⚪ Rot + Grün + Blau → Metall! Alle Farben zusammen!'
         },
-        // Baryonen — gebundene Quark-Tripletts (Farbneutral via drei verschiedene Farbladungen)
+        // Baryonen — gebundene Quark-Tripletts.
         // Gen1-only: NUR yang/yin, NICHT charm/strange/mountain/cave.
         //
         // Hauptweg für Oscar: Craft-Recipe (src/world/recipes.js) — 2 Yang + 1 Yin.
         // Grund: der Pair-Merge Yang+Yang → Charm greift sofort auf Kanten-
         // Nachbarschaft, bevor das dritte Quark platziert werden kann. Der
         // Grid-Triplet-Match hier ist emergent bonus für diagonale Setups.
+        //
+        // FARBLADUNG — spielerisch abstrahiert.
+        // Reale Baryonen brauchen drei verschiedene Farbladungen (R/G/B),
+        // damit die Kombination farbneutral ist (QCD-Confinement: freie
+        // farbgeladene Teilchen existieren nicht). Yang/Yin haben im Spiel
+        // aber KEINE Farb-Varianten — wir modellieren die Dreiheit allein
+        // über die Flavor-Kombination (uud/udd). Eine Mechanik mit drei
+        // Farb-Yangs/Yins würde die Quark-Ladder (Yang² → Charm) komplett
+        // umbauen — aus Spielbarkeits-Gründen ausgespart. Abstraktion,
+        // nicht Korrektheit. Audit: Till, 2026-04-22.
         {
             materials: ['yang', 'yang', 'yin'],
             result: 'proton',
-            msg: '🔴 Yang + Yang + Yin → Proton! (uud, Farbneutral)'
+            msg: '🔴 Yang + Yang + Yin → Proton! (uud)'
         },
         {
             materials: ['yang', 'yin', 'yin'],
             result: 'neutron',
-            msg: '⭕ Yang + Yin + Yin → Neutron! (udd, Farbneutral)'
+            msg: '⭕ Yang + Yin + Yin → Neutron! (udd)'
         },
     ];
 

--- a/src/world/automerge.js
+++ b/src/world/automerge.js
@@ -92,7 +92,12 @@
             msg: '⚪ Rot + Grün + Blau → Metall! Alle Farben zusammen!'
         },
         // Baryonen — gebundene Quark-Tripletts (Farbneutral via drei verschiedene Farbladungen)
-        // Gen1-only: NUR yang/yin, NICHT charm/strange/mountain/cave
+        // Gen1-only: NUR yang/yin, NICHT charm/strange/mountain/cave.
+        //
+        // Hauptweg für Oscar: Craft-Recipe (src/world/recipes.js) — 2 Yang + 1 Yin.
+        // Grund: der Pair-Merge Yang+Yang → Charm greift sofort auf Kanten-
+        // Nachbarschaft, bevor das dritte Quark platziert werden kann. Der
+        // Grid-Triplet-Match hier ist emergent bonus für diagonale Setups.
         {
             materials: ['yang', 'yang', 'yin'],
             result: 'proton',

--- a/src/world/materials.js
+++ b/src/world/materials.js
@@ -207,9 +207,13 @@ window.INSEL_MATERIALS = {
     train:   { emoji: '🚂', label: 'Emma',    color: '#8B0000', border: '#660000', charge: 0, mass: 30 },
     // === BARYONEN — gebundene Quark-Tripletts (Farbneutral: R+G+B) ===
     // Proton  = uud (Yang+Yang+Yin), Ladung +1, stabil — Kern der Materie
-    // Neutron = udd (Yang+Yin+Yin),  Ladung  0, frei instabil (~15min β⁻)
+    // Neutron = udd (Yang+Yin+Yin),  Ladung  0, frei instabil (~15 min β⁻).
+    //   Reale Massen: Proton 938.272 MeV/c², Neutron 939.565 MeV/c² —
+    //   Neutron ist ~0.14% schwerer (down-Quark schwerer als up +
+    //   EM-Selbstenergie). Im Spiel grob mit 20/21 abgebildet (+5%);
+    //   minimal spürbar in der Curvature-Map, aber nicht verzerrend.
     proton:  { emoji: '🔴', label: 'Proton',  color: '#E74C3C', border: '#C0392B', charge: 1, mass: 20 },
-    neutron: { emoji: '⭕', label: 'Neutron', color: '#ECF0F1', border: '#BDC3C7', charge: 0, mass: 20 },
+    neutron: { emoji: '⭕', label: 'Neutron', color: '#ECF0F1', border: '#BDC3C7', charge: 0, mass: 21 },
     // === BLACKHOLE — Einsauger + Hawking-Rückgabe (S101) ===
     // Emoji 🌑 (New Moon) statt 🕳️ (Cave) — Kollision mit Höhle vermieden.
     // Extreme Masse → Raumkrümmung-Delle maximiert, frisst Nachbarn,

--- a/src/world/materials.js
+++ b/src/world/materials.js
@@ -208,13 +208,18 @@ window.INSEL_MATERIALS = {
     shop:    { emoji: '🏪', label: 'Laden',   color: '#E8A020', border: '#C07010', charge: 0, mass: 10 },
     ocean:   { emoji: '🌊', label: 'Meer',    color: '#0D2B6E', border: '#071848', charge: 0, mass: 0, unbaubar: true },
     train:   { emoji: '🚂', label: 'Emma',    color: '#8B0000', border: '#660000', charge: 0, mass: 30 },
-    // === BARYONEN — gebundene Quark-Tripletts (Farbneutral: R+G+B) ===
+    // === BARYONEN — gebundene Quark-Tripletts ===
     // Proton  = uud (Yang+Yang+Yin), Ladung +1, stabil — Kern der Materie
     // Neutron = udd (Yang+Yin+Yin),  Ladung  0, frei instabil (~15 min β⁻).
     //   Reale Massen: Proton 938.272 MeV/c², Neutron 939.565 MeV/c² —
     //   Neutron ist ~0.14% schwerer (down-Quark schwerer als up +
     //   EM-Selbstenergie). Im Spiel grob mit 20/21 abgebildet (+5%);
     //   minimal spürbar in der Curvature-Map, aber nicht verzerrend.
+    // FARBLADUNG: spielerisch abstrahiert. Reale Baryonen brauchen drei
+    //   verschiedene Farbladungen (R/G/B) für Farbneutralität (QCD-
+    //   Confinement). Yang/Yin haben im Spiel keine Farb-Varianten —
+    //   wir modellieren die Dreiheit über Flavor (uud/udd) allein.
+    //   Spielbarkeit vor Vollständigkeit. Siehe docs/metrics/.
     proton:  { emoji: '🔴', label: 'Proton',  color: '#E74C3C', border: '#C0392B', charge: 1, mass: 20, spin: 0.5 },
     neutron: { emoji: '⭕', label: 'Neutron', color: '#ECF0F1', border: '#BDC3C7', charge: 0, mass: 21, spin: 0.5 },
     // === BLACKHOLE — Einsauger + Hawking-Rückgabe (S101) ===

--- a/src/world/materials.js
+++ b/src/world/materials.js
@@ -48,21 +48,22 @@ window.INSEL_MATERIALS = {
     // === 1 — TAO (Singularität, alles in einem Punkt) ===
     tao:      { emoji: '☯️', label: 'Tao',       color: '#808080', border: '#606060' },
     // === 3 — Drei Quarks = ein Proton (Up-Up-Down) ===
-    yin:      { emoji: '⚫', label: 'Yin',       color: '#1A1A1A', border: '#000000' },  // Down-Quark
-    yang:     { emoji: '⚪', label: 'Yang',      color: '#F0F0F0', border: '#D0D0D0' },  // Up-Quark
-    qi:       { emoji: '✨', label: 'Qi',        color: '#FFD700', border: '#DAA520' },  // Starke Kernkraft
+    // Gen-1-Quarks: Fermionen, spin 1/2
+    yin:      { emoji: '⚫', label: 'Yin',       color: '#1A1A1A', border: '#000000', spin: 0.5 },  // Down-Quark
+    yang:     { emoji: '⚪', label: 'Yang',      color: '#F0F0F0', border: '#D0D0D0', spin: 0.5 },  // Up-Quark
+    qi:       { emoji: '✨', label: 'Qi',        color: '#FFD700', border: '#DAA520' },              // Starke Kernkraft (Gluon-Proxy)
     // === GENERATION 2 — Charm & Strange (schwere Quarks, brauchen Beschleuniger) ===
-    charm:    { emoji: '💫', label: 'Charm',     color: '#E8B4F8', border: '#C77DDB' },  // Charm-Quark: schweres Yang (Generation 2)
-    strange:  { emoji: '🌀', label: 'Strange',   color: '#7B2FBE', border: '#5B1F8E' },  // Strange-Quark: schweres Yin (Generation 2)
-    antimatter:{ emoji: '⚛️', label: 'Antimaterie', color: '#1A0033', border: '#0D001A' },  // Charm + Strange = gebundene Gegensätze
+    charm:    { emoji: '💫', label: 'Charm',     color: '#E8B4F8', border: '#C77DDB', spin: 0.5 },  // Charm-Quark: schweres Yang (Gen 2)
+    strange:  { emoji: '🌀', label: 'Strange',   color: '#7B2FBE', border: '#5B1F8E', spin: 0.5 },  // Strange-Quark: schweres Yin (Gen 2)
+    antimatter:{ emoji: '⚛️', label: 'Antimaterie', color: '#1A0033', border: '#0D001A' },          // Charm + Strange = gebundene Gegensätze
     // === LEPTONEN — die leichten Teilchen (spüren keine starke Kraft / kein Qi!) ===
-    electron: { emoji: '🔹', label: 'Elektron',  color: '#0080FF', border: '#0060CC' },  // Gen 1: leichtestes geladenes Lepton
-    muon:     { emoji: '🔸', label: 'Myon',      color: '#9B59B6', border: '#7D3C98' },  // Gen 2: schweres Elektron, kosmisch
-    tau:      { emoji: '🔻', label: 'Tau',       color: '#FF4500', border: '#CC3700' },  // Gen 3: schwerstes Lepton
+    electron: { emoji: '🔹', label: 'Elektron',  color: '#0080FF', border: '#0060CC', spin: 0.5 },  // Gen 1: leichtestes geladenes Lepton
+    muon:     { emoji: '🔸', label: 'Myon',      color: '#9B59B6', border: '#7D3C98', spin: 0.5 },  // Gen 2: schweres Elektron, kosmisch
+    tau:      { emoji: '🔻', label: 'Tau',       color: '#FF4500', border: '#CC3700', spin: 0.5 },  // Gen 3: schwerstes Lepton
     // === NEUTRINOS — Geister-Teilchen (durchdringen alles, fast masselos) ===
-    neutrino:    { emoji: '👻', label: 'Neutrino',       color: '#E8E8FF', border: '#C8C8E8' },  // Gen 1: Elektron-Neutrino
-    neutrino_mu: { emoji: '👻', label: 'Myon-Neutrino',  color: '#D0D0FF', border: '#B0B0E8' },  // Gen 2
-    neutrino_tau:{ emoji: '👻', label: 'Tau-Neutrino',   color: '#B8B8FF', border: '#9898E8' },  // Gen 3
+    neutrino:    { emoji: '👻', label: 'Neutrino',       color: '#E8E8FF', border: '#C8C8E8', spin: 0.5 },  // Gen 1: Elektron-Neutrino
+    neutrino_mu: { emoji: '👻', label: 'Myon-Neutrino',  color: '#D0D0FF', border: '#B0B0E8', spin: 0.5 },  // Gen 2
+    neutrino_tau:{ emoji: '👻', label: 'Tau-Neutrino',   color: '#B8B8FF', border: '#9898E8', spin: 0.5 },  // Gen 3
     // === BOSONEN — Kraftteilchen (Oscar liebt Bosonen) ===
     // Qi ✨ IST das Gluon (starke Kraft, spin 1, masselos) — Doppel-Name: Dao-Name + Physik-Name.
     // Tao ☯️ ist NICHT gleich Higgs — Tao = Singularität (Urzustand), Higgs = massives Skalar-Boson.
@@ -126,7 +127,7 @@ window.INSEL_MATERIALS = {
     moon:     { emoji: '🌙', label: 'Mond',     color: '#F7DC6F', border: '#F1C40F' },
     lightning:{ emoji: '⚡', label: 'Blitz',    color: '#F7DC6F', border: '#F4D03F' },
     volcano:  { emoji: '🌋', label: 'Vulkan',   color: '#E74C3C', border: '#C0392B' },
-    mountain: { emoji: '🏔️', label: 'Berg',    color: '#95A5A6', border: '#7F8C8D', charge: 0, mass: 20 },
+    mountain: { emoji: '🏔️', label: 'Berg',    color: '#95A5A6', border: '#7F8C8D', charge: 0, mass: 20, spin: 0.5 },  // Top-Quark (Gen 3, Fermion)
     diamond:  { emoji: '💎', label: 'Diamant',  color: '#AED6F1', border: '#85C1E9' },
     sword:    { emoji: '⚔️', label: 'Schwert',  color: '#BDC3C7', border: '#95A5A6' },
     shield:   { emoji: '🛡️', label: 'Schild',  color: '#F0B27A', border: '#E59866' },
@@ -185,7 +186,9 @@ window.INSEL_MATERIALS = {
     dock:     { emoji: '⚓', label: 'Hafen',         color: '#5DADE2', border: '#2E86C1' },
     castle:   { emoji: '🏰', label: 'Schloss',      color: '#95A5A6', border: '#7F8C8D', charge: 0, mass: 25 },
     // === HÖHLEN & EDELSTEINE ===
-    cave:     { emoji: '🕳️', label: 'Höhle',       color: '#4A4A4A', border: '#2C2C2C' },
+    // cave = Bottom-Quark (Gen 3, Fermion) — spin 1/2. Keine Curvature-Masse
+    // (Höhle hat im Spiel keine Mass-Delle), aber Spin physikalisch korrekt.
+    cave:     { emoji: '🕳️', label: 'Höhle',       color: '#4A4A4A', border: '#2C2C2C', spin: 0.5 },
     stalactite:{ emoji: '🪨', label: 'Tropfstein',  color: '#8B8589', border: '#696364' },
     gem:      { emoji: '💎', label: 'Edelstein',    color: '#E040FB', border: '#AB00D9' },
     // === BIBLIOTHEK VON ALEXANDRIA ===
@@ -212,8 +215,8 @@ window.INSEL_MATERIALS = {
     //   Neutron ist ~0.14% schwerer (down-Quark schwerer als up +
     //   EM-Selbstenergie). Im Spiel grob mit 20/21 abgebildet (+5%);
     //   minimal spürbar in der Curvature-Map, aber nicht verzerrend.
-    proton:  { emoji: '🔴', label: 'Proton',  color: '#E74C3C', border: '#C0392B', charge: 1, mass: 20 },
-    neutron: { emoji: '⭕', label: 'Neutron', color: '#ECF0F1', border: '#BDC3C7', charge: 0, mass: 21 },
+    proton:  { emoji: '🔴', label: 'Proton',  color: '#E74C3C', border: '#C0392B', charge: 1, mass: 20, spin: 0.5 },
+    neutron: { emoji: '⭕', label: 'Neutron', color: '#ECF0F1', border: '#BDC3C7', charge: 0, mass: 21, spin: 0.5 },
     // === BLACKHOLE — Einsauger + Hawking-Rückgabe (S101) ===
     // Emoji 🌑 (New Moon) statt 🕳️ (Cave) — Kollision mit Höhle vermieden.
     // Extreme Masse → Raumkrümmung-Delle maximiert, frisst Nachbarn,

--- a/src/world/recipes.js
+++ b/src/world/recipes.js
@@ -137,6 +137,19 @@ window.INSEL_CRAFTING_RECIPES = [
     { name: 'Mars',  result: 'mars', resultCount: 1, ingredients: { moon: 1, ice: 1 }, desc: 'Mond + Eis = Mars (Der rote Planet ist eisig kalt — und der nächste Schritt nach dem Mond!)' },
     { name: 'Marslandung', result: 'alien', resultCount: 1, ingredients: { mars: 1, rocket: 1 }, desc: 'Mars + Rakete = Alien (Eine Rakete auf dem Mars — und plötzlich: Besuch!)' },
 
+    // === BARYONEN — direkte Craft-Rezepte (Pauli-Workaround) ===
+    // Grid-Triplet-Merge (Yang+Yang+Yin → Proton) ist theoretisch da, aber
+    // in der Praxis schwer: der Pair-Merge Yang+Yang → Charm greift sofort,
+    // wenn der User den zweiten Yang auf eine Kante legt. Oscar kommt gar
+    // nicht dazu, den Yin-Baustein zu platzieren.
+    //
+    // Lösung: Craft-Rezept als direkter Weg. Grid-Triplet bleibt als
+    // emergent bonus für Physik-Nerds, die's mit diagonaler Platzierung
+    // schaffen. Ladungs-Bilanz stimmt: 2·(+2/3) + 1·(-1/3) = +1 (Proton),
+    // 1·(+2/3) + 2·(-1/3) = 0 (Neutron). Audit: Till, 2026-04-22.
+    { name: 'Proton',  result: 'proton',  resultCount: 1, ingredients: { yang: 2, yin: 1 }, desc: '2 Yang + 1 Yin = Proton (uud, Kernbaustein, Ladung +1)' },
+    { name: 'Neutron', result: 'neutron', resultCount: 1, ingredients: { yang: 1, yin: 2 }, desc: '1 Yang + 2 Yin = Neutron (udd, Kernbaustein, Ladung 0)' },
+
     // === HAUPTGRUPPEN-ELEMENTE — echte Chemie zum Anfassen ===
     // Direkte Rezepte für Z ≤ 20: Z·Proton + N·Neutron + Z·Elektron → Element
     // Ladungs-Summe immer 0. Massen-Summe = atomicMass = Z+N (Periodensystem).


### PR DESCRIPTION
## Hintergrund

Till hat den Baryon-Bauplan im Spiel audiert und vier Probleme identifiziert. Alle vier in atomaren Commits gefixt.

## Die 4 Probleme + Fixes

### 1. Neutron-Masse gleich Proton-Masse

Real: Proton 938.272 MeV/c², Neutron 939.565 MeV/c² — Neutron ist ~0.14% schwerer (down-Quark schwerer als up + EM-Selbstenergie).

**Fix:** Neutron `mass: 20 → 21` (+5%). Curvature-Map-Effekt minimal, Ordnung stimmt.

### 2. Falscher Farbladungs-Kommentar

Der Kommentar behauptete "Farbneutral via drei verschiedene Farbladungen" — aber Yang/Yin haben im Spiel keine Farb-Varianten.

**Fix:** Abstraktion beibehalten, Kommentar ehrlich machen. Eine echte Farbladungs-Mechanik würde die Quark-Ladder (Yang² → Charm) komplett umbauen — aus Spielbarkeits-Gründen ausgespart. Dokumentiert in `automerge.js`, `materials.js` und `docs/metrics/2026-04-22-standardmodell-komplett.md`.

### 3. Fehlendes Spin-Feld für Fermionen

Bisher hatten nur Bosonen (γ, W, Z, H) + Mesonen/Positron ein `spin`-Feld. Baryonen und alle Quarks/Leptonen fehlten.

**Fix:** Alle Fermionen jetzt mit `spin: 0.5`:
- Gen-1-Quarks: yin, yang
- Gen-2-Quarks: charm, strange
- Gen-3-Quarks: mountain (top), cave (bottom)
- Leptonen: electron, muon, tau
- Neutrinos: neutrino, neutrino_mu, neutrino_tau
- Baryonen: proton, neutron

### 4. Pauli verhindert Baryon-Bildung (Spielmechanik-Bug)

Grid-Triplet-Merge (Yang+Yang+Yin → Proton) wird durch den Pair-Merge Yang+Yang → Charm blockiert: sobald Oscar den zweiten Yang auf eine Kante legt, ist Charm da, bevor Yin gelegt werden kann.

**Fix:** Baryon als Craft-Recipe:
- `2 Yang + 1 Yin → 1 Proton` (uud, Ladung +1)
- `1 Yang + 2 Yin → 1 Neutron` (udd, Ladung 0)

Grid-Triplet bleibt als emergent bonus für diagonale Setups.

## Commits (atomar)

1. `fix(materials): Neutron-Masse 21 (real leicht schwerer als Proton)`
2. `fix(materials): Spin-Feld für alle Fermionen (Quarks, Leptonen, Baryonen)`
3. `feat(recipes): Baryon-Craft-Rezepte (Proton, Neutron) — Pauli-Workaround`
4. `docs(physik): Farbneutralität ehrlich kommentiert (abstrahiert, nicht modelliert)`

## Tests

- 72 unit tests grün (bis dahin 37, jetzt +35)
- Neue Suites: "Baryon-Bauplan-Konsistenz", "INSEL_CRAFTING_RECIPES — Baryon-Craft"
- `package.json` erweitert: `automerge.test.js` läuft jetzt in `npm run test:unit` (war vorher nicht eingehängt)
- `tsc --noEmit` grün

## Test plan

- [ ] `npm run test:unit` grün
- [ ] `npx tsc --noEmit` grün
- [ ] Craft-UI: Proton/Neutron-Rezept erscheint in der Craft-Liste (Voraussetzungen: Yang + Yin bereits entdeckt)
- [ ] Grid-Triplet weiterhin funktionsfähig (Tests Zeile 56-92 in automerge.test.js)
- [ ] Keine Curvature-Regressionen durch Neutron-Mass-Update

---

Audit: Till.
Beirat: Max Planck (Opus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)