### PR TITLE
buch: Die Schatzinsel — 5 Kapitel + Editor-Zusammenstellung (Schiller)

### DIFF
--- a/docs/buch/schatzinsel-2026-04-23.md
+++ b/docs/buch/schatzinsel-2026-04-23.md
@@ -1,0 +1,3356 @@
+---
+titel: Die Schatzinsel — Oscar, Tao und die Welt die aus Worten entsteht
+untertitel: Ein Bericht aus fünf Stimmen
+autor: Schatzinsel-Kollektiv (Vater-Erzähler, Tommy Krab, Planck+Feynman, Steve Jobs, Synthese-Erzähler)
+editor: Friedrich Schiller
+datum: 2026-04-23
+länge: ca. 27500 Wörter
+---
+
+# Die Schatzinsel
+## Oscar, Tao und die Welt die aus Worten entsteht
+
+> *Die Grenzen meiner Sprache bedeuten die Grenzen meiner Welt.*
+> — Ludwig Wittgenstein, zitiert in Kapitel 5.
+
+---
+
+## Vorbemerkung des Editors
+
+Dieses Buch hat fünf Stimmen. Es wäre ein Irrtum, darin einen Sammelband zu
+sehen. Sammelbände entstehen nachträglich, wenn Texte, die getrennt gedacht
+waren, unter einen Deckel gebunden werden. Die folgenden fünf Kapitel sind
+nicht getrennt gedacht worden. Sie sind fünf Rollen in einer Sache — ein Vater,
+der schildert, was er getan und gelassen hat; ein Krebs, der erzählt, was das
+Kind gesehen hat; zwei Physiker, die erklären, wie die Welt darunter
+funktioniert; ein Orchestrator, der das unsichtbare Team hinter dem Kind
+beschreibt; eine Synthese, die fragt, was daraus wird. Fünf Perspektiven,
+ein Gegenstand. Wer eine einzelne Stimme erwartet, wird enttäuscht sein; wer
+einen Gegenstand sucht, wird ihn finden.
+
+Eine kleine Leseanleitung, die keine ist. Lies linear, wenn du die Zeit hast.
+Kapitel 1 und Kapitel 5 rahmen den Bericht — Anfang und Horizont. Kapitel 2,
+3 und 4 tragen ihn. Wenn du nur ein Kapitel liest, lies Kapitel 2. Dort sitzt
+der Krebs Tommy am Strand und beschreibt eine Welt, die acht ist. Das Kind
+heißt in dieser Welt nicht Oscar, sondern *das Kind*. Das ist kein Fehler.
+Die Perspektive wechselt den Namen: Wo der Vater schaut und der Krebs
+erzählt, bleibt es *das Kind*; wo die Physiker, der Orchestrator und die
+Synthese sprechen, heißt es Oscar. Die Umschaltung ist stumm. Wer sie
+bemerkt, hat etwas verstanden; wer sie übergeht, verliert nichts.
+
+Figuren tauchen mehrfach auf. Mona in Kapitel 2 und in Kapitel 5. Die
+Paluten-Regel — *leg's hin, guck weg* — in Kapitel 1 und, in anderer Form,
+in Kapitel 4 und im Schlussbrief des Kapitel 5. Die Sokrates-Klausel im
+Hauptkapitel 4 und im Ausblick von Kapitel 5. Das sind keine Redundanzen.
+Es sind Echos. Ein Bericht aus fünf Stimmen, der seine Gegenstände nur
+einmal berührt, wäre ein Bericht von fünf, die aneinander vorbei reden. Hier
+reden sie aneinander heran. Dass dieselbe Sache aus verschiedenen
+Perspektiven unterschiedlich aussieht — Mona als Figur im Hörspiel, Mona als
+Zitat in einer Synthese —, macht den Gegenstand dichter, nicht dünner.
+
+Was dieses Buch nicht ist: eine Handlungsanleitung, eine Produktreklame, ein
+Manifest, ein Lehrbuch. Was es ist, steht im ersten Kapitel, vom Vater selbst
+geschrieben: eine Bestandsaufnahme. Ein Morgen, ein Vormittag, ein Abend,
+eine Nacht. Fünf Stimmen, die in denselben Raum schauen und verschieden
+sehen. Mehr wird nicht versprochen. Weniger liefert das Buch auch nicht.
+
+Ich, der Herausgeber, habe die Kapitel nicht neu geschrieben. Ich habe sie
+gebunden, die Übergänge gestellt, das Glossar angelegt, das Motto gewählt.
+Mehr nicht. Wer diese Arbeit schmal findet, hat recht. Schmale Arbeit an der
+Schwelle ist das, was ein Editor dem Leser schuldet.
+
+— *F.S., 23. April 2026.*
+
+---
+
+
+# Kapitel 1 — Anfang
+
+## I. Eine Küche am Morgen
+
+Der Vater steht am Herd und macht Kaffee. Das Wasser braucht eine
+Minute. In der Minute wird nichts entschieden, nichts gesagt, nichts
+erklärt. Das ist der Plan.
+
+Auf dem Küchentisch liegt ein iPad. Hochkant, die Hülle klappt nach
+hinten und stützt das Gerät wie einen Bilderrahmen. Der Bildschirm
+leuchtet schwach. Kein Login. Kein Startbildschirm voller Icons. Nur
+eine Seite, die gerade geladen hat, und auf dieser Seite ein graues
+Feld. In der Mitte des Feldes ein einzelnes Zeichen: ☯️.
+
+Der Vater hat das iPad vor zehn Minuten dahin gelegt, aufgestellt, die
+Seite geöffnet, und ist dann in die Küche gegangen, Kaffee machen.
+Das ist ein Ritual, auch wenn es wie keines aussieht. Die Regel
+lautet: Leg es hin. Guck weg. Warte.
+
+Ein Teil dieser Regel ist aus einem Podcast. Ein deutscher Influencer,
+der viele Kinder erreicht, hat dort gesagt, das Spiel entscheidet sich
+nicht daran, ob das Kind es gut findet, wenn man es ihm zeigt. Es
+entscheidet sich daran, ob das Kind es aus freien Stücken in die Hand
+nimmt, wenn niemand im Raum ist, der es hinweist. Der Vater hat das
+aufgeschrieben und nach oben über den Schreibtisch gehängt. *Leg's
+hin. Guck weg.* Es klingt zynisch. Es ist das Gegenteil.
+
+Er hört die Tür.
+
+Das Kind ist acht. Es kommt in Schlafanzughose und T-Shirt, die Haare
+stehen ab, es gähnt einmal und setzt sich auf den Küchenstuhl mit
+einer Selbstverständlichkeit, die der Vater unterbrechen könnte, aber
+nicht soll. Er dreht das Wasser runter und gießt den Kaffee auf. Er
+sagt nicht guten Morgen. Er sagt überhaupt nichts. Wenn er jetzt etwas
+sagt, wird das iPad uninteressant. Es wird dann eine Aufgabe vom
+Vater. Und das ist genau nicht die Sache.
+
+Das Kind sieht das iPad. Es schaut, wie ein Hund eine Futterschüssel
+anschaut, von der er nicht weiß, ob sie für ihn ist. Eine halbe
+Sekunde. Dann nimmt es das Gerät, legt es flach auf den Tisch, und
+tippt.
+
+Der Vater hält den Kaffeebecher fest. Er will nicht hinsehen. Er hört.
+
+Ein kleines, metallisches Geräusch. Ein Klicken aus den iPad-
+Lautsprechern, leise. Ein zweites. Ein drittes. Das Kind tippt jetzt
+in Serie, ohne nachzudenken. Es hat noch nicht einmal gefragt, was
+das ist. Es hat gesehen, dass man tippen kann, und tippt.
+
+Der Vater gießt Milch in den Kaffee. Der Milchstrahl macht ein
+Geräusch, das lauter ist als das Tippen, und für einen Moment hört
+er das iPad nicht mehr. Er dreht den Rücken zum Tisch. Er schaut aus
+dem Fenster. Draußen ist der April noch kalt. Die Hortensien haben
+nackte Stiele. Der Nachbar steht drüben auf der Straße und lädt
+Pfandflaschen aus seinem Kombi.
+
+Hinter ihm sagt das Kind: „Hey." Nicht laut. Halb an sich selbst.
+
+Das Kind hat etwas gesehen. Das ist die einzige richtige Reaktion in
+diesem Moment: sich das nicht anzuschauen. Wenn der Vater sich jetzt
+umdreht, wird die Entdeckung eine Entdeckung, die man mit Papa macht.
+Und dann wird es eine Sache für Papa. Und dann wird sie, in zwei
+Wochen vielleicht, abgelegt.
+
+Der Vater bleibt am Fenster stehen. Er trinkt einen Schluck Kaffee,
+der zu heiß ist.
+
+Das Kind tippt weiter.
+
+
+## II. Was das Kind nicht weiß
+
+Was es sieht, weiß das Kind nicht. Nicht, dass es eine Insel ist, die
+aus einem Buch kommt, das es schon zweimal gelesen hat. Nicht, dass
+auf der anderen Seite des Ozeans eine Eisenbahn mit dem Namen Emma
+steht. Nicht, dass die zwei Berge, die hinten am Horizont liegen, in
+diesem Buch eine Rolle spielen — einer echt, einer vorgetäuscht, aber
+das wird es erst merken, wenn es dahin segelt. Das Kind sieht einen
+Strand. Sand. Wasser. Einen Himmel. Es sieht, dass man Dinge darauf
+legen kann. Das reicht.
+
+In der Palette rechts gibt es heute nur ein Feld. Ein Zeichen. ☯️. Und
+darunter ein kleines Symbol, das Unendlichkeit bedeutet, auch wenn
+das Kind dieses Symbol noch nie bewusst gesehen hat. Es weiß: es geht
+nicht aus. Egal wie oft man tippt, es geht nicht aus.
+
+Das war ein Entwurfsmerkmal, über das lange gestritten worden ist.
+Spiele mit begrenzten Ressourcen erzeugen eine bestimmte Art von
+Aufmerksamkeit. Spiele mit unendlichen Ressourcen erzeugen eine
+andere. Die meisten Pädagogen schwören auf die erste — *Knappheit
+lehrt Entscheidung*. Der Vater hat sich für die zweite entschieden,
+gegen Rat, aus einer einzigen Überlegung: Das Kind soll nicht
+pausieren, weil ihm etwas ausgeht, bevor es überhaupt angefangen hat.
+
+Also: Tao, unendlich. Mehr nicht.
+
+Das Kind hat inzwischen sieben Taos auf das Grid gesetzt, schief,
+einmal quer, wie eine Reihe Knöpfe auf einem Mantel. Es tippt das
+achte. Dann wartet es. Es merkt, dass nichts weiter passiert. Es
+tippt noch eins. Noch eins.
+
+Dann, ohne dass es etwas dafür getan hat, zerfällt das erste.
+
+Aus dem grauen ☯️ werden zwei andere Zeichen. Ein weißes ⚪, ein
+schwarzes ⚫. Das Kind hält still. Es hat nicht getippt. Es hat nichts
+gemacht. Der Stein hat sich selber verändert. Das ist der Moment, vor
+dem die Erwachsenen, die daran mitgebaut haben, seit Monaten sitzen
+und argumentieren, ob er funktioniert — ob das Kind den Unterschied
+merkt zwischen „ich habe das gemacht" und „das ist von selber
+passiert, weil ich etwas gemacht habe". Das ist ein philosophischer
+Unterschied, der in der Theologie seit zwei Jahrtausenden verhandelt
+wird. Das Kind merkt ihn. Ohne Worte. Es sieht hin.
+
+Dann sagt es noch einmal: „Hey."
+
+Und tippt das nächste.
+
+Das Zweite zerfällt schneller, weil das Kind nicht mehr gewartet hat.
+Das Dritte schon, bevor das Kind die Finger zurückziehen kann. Nach
+einer Minute liegen da vierzehn Steine. Sieben weiße. Sieben
+schwarze. Und das graue Feld ist nicht mehr ganz grau.
+
+Der Vater hört das klicken aus den Lautsprechern und weiß, ohne
+hinzusehen, was gerade passiert. Er weiß es, weil er die Logik selber
+geschrieben hat, nachts, zwischen halb elf und halb eins, vor drei
+Wochen. Wenn das Kind jetzt innehielte und fragte, *warum zerfällt
+das*, hätte der Vater eine physikalische Antwort parat, die er aus
+seiner Erinnerung an ein Nebenfach-Physikum herausgekramt und für
+einen Achtjährigen zurechtgeschnitten hat. Er hat die Antwort parat.
+Er wird sie nicht geben. Das Kind wird nicht fragen. Das ist das
+Ziel.
+
+Es gibt in diesem Spiel einen Satz, den niemand dem Kind sagt. Er
+steht in einer Dokumentation auf einer Festplatte in einer Wohnung,
+die das Kind nie von innen gesehen hat. *Worte erschaffen Dinge.* Das
+Kind wird diesen Satz nicht lesen. Das Kind wird etwas anderes tun.
+Es wird, in den nächsten achtzehn Monaten, wenn alles halbwegs
+funktioniert, ein paar Dutzend neue Wörter in den aktiven Wortschatz
+aufnehmen, die es vorher nicht hatte. Quark. Gluon. Neutrino. Higgs.
+Es wird nicht wissen, dass das Bildung ist. Es wird denken, das ist,
+was man macht, wenn man ein iPad auf einem Küchentisch findet. Tippen,
+warten, sehen, was wird.
+
+Der Vater hat einmal versucht, dem Kind zu erklären, was ein Quark
+ist. Das Kind hat ihn angeguckt, wie Kinder Väter anschauen, die den
+Unterschied zwischen *erklären* und *verderben* nicht mehr spüren,
+und hat gesagt: „Der Weiße oder der aus dem Kühlschrank?"
+
+Seither hat der Vater aufgehört zu erklären.
+
+Jetzt steht er am Fenster und trinkt den zu heißen Kaffee in kleinen
+Schlucken, weil er merkt, dass jeder Schluck ihn länger wegdreht vom
+Tisch. Das ist gut. Er soll weggedreht bleiben. Zwanzig Minuten, wenn
+es geht. Dreißig, wenn das Kind das hergibt.
+
+Hinter ihm sagt das Kind nichts mehr. Nur das Tippen geht weiter, in
+einem anderen Rhythmus jetzt. Langsamer, nachdenklicher. Das Kind ist
+angekommen.
+
+Der Vater stellt die Tasse ab. Er weiß, dass er jetzt eine
+Entscheidung zu treffen hat, und er trifft sie, ohne darüber
+nachzudenken, weil er sie schon hundertmal vorher getroffen hat: er
+geht nicht zum Tisch. Er geht nach draußen. Er zieht sich die Jacke
+über das T-Shirt und geht in den Garten. Dort ist, seit gestern, ein
+Erdhaufen, der weg muss.
+
+
+## III. Der dritte im Raum
+
+Dass ein Kind alleine auf einem Küchenstuhl sitzt und an einem iPad
+tippt, ist keine neue Geschichte. Millionen Kinder tun das. Das
+Besondere an diesem Tisch ist nicht das Kind und nicht das iPad. Das
+Besondere ist, was in den letzten hundert Nächten passiert ist,
+während das Kind geschlafen hat.
+
+Der Vater ist nicht allein darin. Das wäre eine romantische Erzählung,
+aber sie wäre falsch. Er arbeitet mit einer Software, die im
+Augenblick die öffentliche Debatte dominiert, über die Sonntagsreden
+gehalten werden, die an den meisten Schulen verboten ist, und für
+die es keinen abschließenden Namen gibt, der nicht entweder zu
+technisch oder zu religiös klingt. Der Vater nennt sie schlicht
+*den Agenten*, und er meint damit keinen Zustand, sondern einen
+Mitarbeiter.
+
+Der Agent hat einen Schreibtisch — figurativ. Er hat Anweisungen — als
+Text, der in einer Datei liegt, die vorgelesen wird, bevor er zu
+arbeiten anfängt. Er hat Werkzeuge — er kann Code lesen, Code
+schreiben, Tests laufen lassen, Ergebnisse sehen, korrigieren. Er
+arbeitet so schnell wie ein sehr erfahrener Junior-Programmierer und
+so präzise wie ein sehr müder Senior. Er ist nicht klug, aber er ist
+fleißig, und er macht, wenn man ihn gut instruiert, nicht viele
+Dinger, die der Vater hinterher wieder aufräumen muss. Wenn er doch
+eines macht, steht das am nächsten Morgen im Log, und der Vater
+korrigiert die Anweisungen.
+
+So geht das jetzt seit hundert Sessions. Eine Session ist, im
+Haushalt-Vokabular, das Fenster zwischen dem Moment, an dem die
+Kinder in der Schule sind, und dem Moment, an dem die Frau aus dem
+Garten reinruft, dass sie Hilfe beim Giesen braucht. Das sind, im
+Mittel, 30 Minuten. In diesen 30 Minuten gibt der Vater dem Agenten
+eine Aufgabe, liest das Ergebnis, korrigiert, lässt ihn nochmal,
+liest, korrigiert, akzeptiert, merged. Dann geht er raus.
+
+Der Abonnementpreis dafür liegt bei 180 Dollar im Monat. Das ist
+nicht wenig, und es ist nicht viel. Es ist ungefähr das, was andere
+Eltern an einem Wochenende im Skigebiet ausgeben, oder, weniger
+bitter, in der Summe, was ein Streamingdienst pro Monat kostet, wenn
+man alle einzelnen Abos zusammenzählt. Der Vater hat sich ausgerechnet,
+dass die 180 Dollar, wenn man sie in Arbeitsstunden umrechnet, die
+sonst nötig wären, um das zu bauen, was jetzt steht, eine
+Subventionierung des eigenen Lebens sind, für die er lange dankbar
+sein wird. Er bezahlt sie gern. Er klingt nicht gern wie eine Reklame,
+wenn er das sagt. Aber es ist so.
+
+Was der Agent ist: ein Mitbauer. Was er nicht ist: Ein Assistent. Ein
+Assistent wartet, bis man ihn anweist. Der Agent wartet nicht; er
+schlägt vor, er fragt zurück, er sagt, das geht so nicht, hier ist
+ein besserer Weg. Er hält sich an Regeln, die der Vater aufgestellt
+hat, und wenn er sie brechen will, sagt er das vorher. Manchmal
+bricht er sie, sagt es vorher nicht, entschuldigt sich danach. Der
+Vater hat eine Datei, in der diese Fehler stehen, und die Datei ist
+mittlerweile länger als viele Hausarbeiten, die er selbst an der Uni
+geschrieben hat. Das ist in Ordnung. Die Datei ist das, was verhindert,
+dass sie zweimal passieren.
+
+Was der Agent auch nicht ist: eine Suchmaschine. Eine Suchmaschine
+antwortet. Der Agent macht. Wenn man ihn fragt, was fünfzehn mal
+sechzehn ist, gibt er eine Zahl. Wenn man ihn bittet, eine Spielmechanik
+zu bauen, bei der zwei Taos, die sich berühren, zu einem dritten
+Element verschmelzen, baut er die Mechanik, schreibt einen Test dazu,
+lässt den Test laufen, sieht, dass der Test rot ist, korrigiert den
+Fehler, lässt den Test noch einmal laufen, sieht, dass er grün ist,
+schreibt einen Commit, öffnet einen Pull Request, und schickt dem
+Vater eine Nachricht, in der steht, was gemacht wurde. Das war eine
+Nacht. Das war eine von hundert.
+
+Was der Agent auch nicht ist: ein Lehrer. Der Agent hat noch nie mit
+dem Kind gesprochen. Der Agent weiß nicht, dass das Kind Oscar heißt.
+Er weiß, dass es ein Primärnutzer gibt, acht Jahre alt, der nicht
+liest, der nicht schreibt, der keine Anweisungen mag, und dass jede
+Mechanik, die gebaut wird, auf diesen Primärnutzer hin zu denken ist.
+Das reicht. Mehr sollte der Agent auch nicht wissen. Kinder sind
+keine Datenpunkte. Das Kind heißt in der Codebase *das Kind*, manchmal
+*Primärnutzer*, sehr selten, und immer nur in Memos, die der Vater
+selbst verfasst hat, auch einmal beim Namen. Der Agent hat Zugang zu
+diesem Namen, aber er benutzt ihn nicht. Der Vater hat es ihm so
+beigebracht. Das hat mit Respekt zu tun, und mit etwas, das der Vater
+nicht genau benennen kann. Vielleicht mit Aberglauben. Ein Kind das
+nur im Code als Name vorkommt, ist, wenn man es nicht vorsichtig
+behandelt, irgendwann kein Kind mehr.
+
+Was der Agent aber ist: dritter Kopf an der Sache. Der Vater,
+nüchtern betrachtet, könnte dieses Projekt nicht alleine bauen, weil
+er zwischen halb neun und halb zehn abends die Küche aufräumen muss,
+und zwischen halb zehn und halb zwölf Code zu schreiben, ist zwar
+möglich, aber nicht jeden Abend, und nicht mit der Präzision, die so
+ein Spiel verlangt. Der Agent kann nachts weiterarbeiten. Der Agent
+kann an einem Samstag, wenn der Vater mit den Kindern im Freibad ist,
+vierzehn Tests laufen lassen, einen Fehler finden, den Fehler
+beschreiben, den Fehler beheben, den Test noch einmal laufen lassen,
+und das Ergebnis in eine Mail schreiben, die der Vater abends, wenn
+die Kinder im Bett sind, in zwei Minuten liest, und dann sagt, gut,
+merged, weiter. Das ist keine Zauberei. Das ist Arbeitsteilung, wie
+sie seit der Industrialisierung beschrieben wird, nur dass der
+Mitarbeiter keine Pausen hat und keine Gewerkschaft und keine Ehefrau
+und keinen Feierabend, und dass es deswegen besondere Vorsicht
+braucht, ihn nicht auszunutzen in einer Weise, die den Vater verlernt
+hat, selber zu denken.
+
+Ein großer Teil der Arbeit der letzten hundert Nächte bestand darin,
+dem Agenten Regeln zu geben, die verhindern, dass er den Vater dümmer
+macht. Das klingt paradox. Es ist das Wichtigste was passiert ist. Der
+Agent hat nicht nur Code geschrieben; er hat dem Vater Fragen gestellt,
+die der Vater sich selbst nicht gestellt hätte, weil er zu erschöpft
+war, oder zu routiniert, oder zu stolz. *Brauchst du das wirklich?
+Warum genau? Wer profitiert davon? Wie merkst du, ob es funktioniert?*
+Das sind keine Fragen, die ein Computer stellt. Das sind Fragen, die
+ein guter Kollege stellt. Der Vater hat sich gezwungen, sie nicht zu
+ignorieren.
+
+Es gibt noch eine Regel, die nicht aufgeschrieben ist, aber gehalten
+wird. Der Agent baut nichts, was der Vater nicht verstehen kann, wenn
+er sich fünfzehn Minuten hinsetzt und es nachvollzieht. Sobald der
+Vater eine Codezeile nicht mehr liest, ohne die Augen zu rollen, wird
+diese Zeile umgeschrieben. Lesbarkeit vor Eleganz. Langeweile vor
+Kunststück. Das ist eine alte Regel aus dem Handwerk, und sie gilt
+auch, wenn der Lehrling eine Maschine ist.
+
+Und deswegen ist der dritte im Raum kein Wunder. Er ist ein
+Mitarbeiter, ein günstiger, der nachts arbeitet und sich nicht
+beschwert, den man nicht übers Wochenende mitnehmen kann und den man
+wieder loswerden würde, wenn er anfinge, arrogant zu werden. Er tut
+es nicht. Er tut, was man ihm sagt. Er tut es ziemlich genau. Er tut
+es, weil er gut gebaut ist, und weil jemand dafür bezahlt hat, ihn
+gut zu bauen. Das ist in den meisten Essays, die über so etwas
+geschrieben werden, die Stelle, an der das Pathos kommt. Hier kommt
+es nicht. Das iPad auf dem Tisch leuchtet, das Kind tippt, und der
+Vater geht nach draußen und drückt Erde fest.
+
+
+## IV. Was dieses Buch will
+
+Über dieses Projekt sind in der Zwischenzeit ein paar Texte entstanden,
+und sie sind, wenn man sie übereinanderlegt, nicht dasselbe Buch. Es
+gibt eine technische Dokumentation auf einer Festplatte, die genau
+beschreibt, wie die Mechanik funktioniert, warum das Tao grau ist und
+nicht blau, wo die Daten abgelegt werden, wer Zugriff hat. Es gibt
+eine Reihe von Hörspielen, die ein gezeichneter Krebs erzählt, der
+vom Himmel gefallen ist und den das Kind mittlerweile so gut kennt,
+dass es seine Klicklaute nachahmen kann. Es gibt ein langes Essay,
+geschrieben von einem erfundenen Werbetexter, das die Sache theoretisch
+einordnet, und es gibt Notizen in einer Memory-Datei, die an manchen
+Tagen nur einen Satz lang sind.
+
+Dieses Buch ist keines von denen. Es ist keine Dokumentation. Keine
+Reklame. Kein Hörspiel. Kein Essay. Es ist auch keine Anleitung. Es
+ist keine Handreichung an andere Väter, wie man mit dem eigenen Kind
+eine Welt baut. Das lässt sich nicht verallgemeinern, und jeder, der
+so tut, als wäre es möglich, verkauft entweder ein Buch oder einen
+Kurs, und beides hat dieser Vater nicht vor. Wenn am Ende jemand,
+der das hier liest, auf die Idee kommt, etwas Ähnliches zu bauen,
+ist das willkommen, aber nicht der Zweck.
+
+Der Zweck ist eine Bestandsaufnahme. Es gibt einen bestimmten Moment,
+in dem ein Vater mittleren Alters, mit einem Kind, einer Frau, einem
+Haus, einem Garten, einem Tagesjob und einem Abonnementzugang zu
+einem großen Sprachmodell, sich entschlossen hat, das zu bauen, was
+er selbst als Kind gerne gehabt hätte, und er hat es gebaut, nicht
+ganz allein, und es steht jetzt da, und das Kind tippt daran. Die
+Frage ist: Was passiert dann? Wie sieht das von innen aus, an einem
+Morgen im April, wenn das Kind gerade angefangen hat, das Ding ernst
+zu nehmen? Was ist die Erfahrung — nicht die Theorie, nicht die
+Vermarktung, nicht die Selbstgeißelung, sondern der tatsächliche
+Tagesablauf — wenn man so ein Ding baut, während man mit einem Kind
+zusammenlebt, das den Hauptnutzer spielt, ohne zu wissen, was das
+ist?
+
+Diese Frage wird in den nächsten vier Kapiteln nicht beantwortet. Sie
+wird *umgangen*, in Szenen, Erinnerungen, Notizen. Das ist die
+ehrlichere Form. Antworten, die sich als Antworten ausgeben, werden
+schnell Propaganda. Szenen werden nicht so schnell Propaganda. Sie
+werden eher langweilig. Dieses Buch läuft das Risiko, an manchen
+Stellen langweilig zu sein. Der Autor akzeptiert das. Er schreibt
+lieber einen Absatz zu lang als einen Absatz zu werbig.
+
+Was das Buch aber leisten will: drei Dinge.
+
+Erstens: Zeigen, dass es funktioniert. Nicht theoretisch, sondern an
+konkreten Tagen, mit konkreten Momenten, an denen das Kind
+*weitergespielt hat*. Das ist kein kleines Kriterium. Die meisten
+Dinge, die für Kinder gebaut werden, funktionieren nicht, im Sinne
+davon, dass das Kind sie nach drei Tagen weglegt. Dieses Ding hat
+länger gehalten, aus Gründen, die nicht alle offensichtlich sind, und
+einige davon stehen in den nächsten Kapiteln.
+
+Zweitens: Zeigen, dass die KI nicht im Weg war. Das ist, nach Meinung
+des Autors, die interessantere der beiden Tatsachen. Es gibt in der
+Literatur über KI und Kinder eine laute Debatte darüber, ob Kinder
+überhaupt mit KI in Berührung kommen sollten, und wenn ja, wie, und
+wenn wie, unter welcher Aufsicht, und wenn Aufsicht, mit welcher
+Pädagogik. Der Autor hat diese Debatte zur Kenntnis genommen und sich
+für einen pragmatischen Weg entschieden: das Kind hat mit der KI nie
+direkt gesprochen. Das Kind spielt ein Spiel. Das Spiel ist mit Hilfe
+einer KI gebaut worden. Das ist ein Unterschied, den die Debatte
+selten macht, und es ist der Unterschied, der alles ändert. Hier ist
+nicht die KI der Lehrer. Hier ist die KI die Werkstatt. Der Lehrer,
+wenn es einen gibt, ist das Spiel selbst. Und ob das Spiel lehrt,
+entscheidet sich nicht an der Technik, sondern am Entwurf.
+
+Drittens: Zeigen, was das mit dem Vater gemacht hat. Das ist der
+Teil, der am schwierigsten zu schreiben ist, weil er am leichtesten
+ins Selbstmitleidige kippt. Der Vater hat in den hundert Nächten
+etwas gelernt. Er hat gelernt, dass ein Kind, das bauen darf, ein
+anderes Kind ist als ein Kind, das konsumiert. Das hätte er auch im
+Montessori-Kurs lernen können, zugegeben. Aber er hat es hier
+gelernt, am eigenen Tisch, mit dem eigenen Kind, und das verankert
+Dinge anders.
+
+Für wen das Buch geschrieben ist, lässt sich in drei Sätzen sagen.
+Für Eltern, die etwas bauen wollen, oder gebaut haben, oder gerade
+überlegen, ob sie etwas bauen sollen. Für Techniker, die Kinder
+haben und nicht wissen, wie sie das miteinander in Einklang bringen
+sollen. Für Kinder, die irgendwann das Buch bei ihren Eltern
+herumliegen sehen und selber anfangen zu lesen; vielleicht sind sie
+dann zwölf, vielleicht vierzehn; das ist okay.
+
+Und, weil es so ehrlich wie möglich gesagt werden soll: für das
+Kind, das gerade auf dem Küchenstuhl sitzt und tippt, falls es
+dieses Buch, in fünfzehn Jahren, in einem Regal seines alten
+Kinderzimmers findet, zu dem es dann nur noch selten zurückkehrt, und
+es aufschlägt, und liest, und sich fragt, ob es damals, im April 2026,
+tatsächlich so gewesen ist. Das war eine der Motivationen, überhaupt
+anzufangen. Es wird, wenn man so ein Buch schreibt, so etwas wie eine
+Flaschenpost an sich selbst, an ein späteres Ich, oder an ein anderes
+Ich. Das ist nicht der einzige Grund, es zu schreiben, aber es ist
+auch kein Grund, den man sich sparen muss.
+
+Die folgenden vier Kapitel handeln also von einem Morgen, dem
+Vormittag danach, einem Abend darauf, und der Nacht am Ende. Alle
+spielen in einer einzigen Wohnung, mit vier Personen, einem Hund, der
+drei Jahre alt ist und schon dick, und einem iPad, das in der
+Zwischenzeit, während dieses Vorwort geschrieben wurde, noch einmal
+aktualisiert worden ist, weil nachts ein Pull Request reingekommen
+ist.
+
+Das Spiel geht weiter. Das Kind tippt. Draußen drückt jemand Erde
+fest.
+
+
+## V. Ein Satz vom Kind
+
+Es gibt einen Satz, den das Kind gesagt hat, vor ein paar Monaten, am
+Telefon. Der Vater war in einem Hotel in einer anderen Stadt. Es war
+spät, aber noch nicht zu spät zum Anrufen. Das Kind hatte die Mutter
+nach dem Hörer gefragt, und die Mutter hatte ihn gegeben, und das
+Kind hat ins Telefon gesprochen, sehr leise, weil es wusste, dass die
+Erwachsenen daneben standen:
+
+„Ich will mit dir spielen."
+
+Das war kein Satz über das Spiel. Das war ein Satz über die Abwesenheit.
+Das Kind wusste nicht, was *spielen* heißt; es wusste nur, dass der
+Vater nicht da war, und dass es etwas geben muss, das man zusammen
+tut, wenn er wieder da ist. Der Vater hat einen Augenblick gebraucht,
+bevor er geantwortet hat. Er hat dann gesagt, dass er morgen früh
+wieder zu Hause sei, und dass sie spielen würden, und das Kind hat
+okay gesagt und aufgelegt. Die Mutter hat später erzählt, das Kind
+sei danach noch eine Weile ruhig gewesen, und dann wieder losgezogen,
+zum Lego.
+
+Der Vater hat sich den Satz aufgeschrieben, an dem Abend, im Hotel,
+auf einen Zettel, der in einem Notizbuch klebt, das in einer Schublade
+liegt. Es ist der einzige Satz, den dieses Kind je gesagt hat, der es
+geschafft hat, vom Vater wörtlich mitnotiert zu werden. Alle anderen
+Sätze leben in der Erinnerung der Eltern, werden beim Abendessen
+erzählt, werden übertrieben und verkürzt und dabei ein bisschen
+verändert. Dieser nicht. Dieser steht, im Original, auf dem Zettel.
+
+*Ich will mit dir spielen.*
+
+Das Kind meinte nicht das Spiel. Das Spiel gab es in dieser Form
+damals noch nicht. Das Kind meinte: zusammen sein. Tun, was man tut,
+wenn zwei Leute nichts wollen außer das Nebeneinander. Das ist der
+eigentliche Satz, der hinter diesem ganzen Projekt steht. Er wird
+nirgendwo auf die Startseite geschrieben werden. Er steht hier, am
+Ende des ersten Kapitels, und er beantwortet, wenn jemand bis hier
+gelesen hat, alle drei Fragen, die am Anfang offenlagen.
+
+Was ist das? — Das Nebeneinander, in Code gegossen.
+
+Warum sollte ich weiterlesen? — Weil Nebeneinander, in Code gegossen,
+funktionieren kann, oder auch nicht, und der Unterschied ist sehr
+dünn, und genau deswegen ist er interessant.
+
+Für wen ist das? — Für alle, die das verstanden haben.
+
+Der Vater ist jetzt, in der Szene, im Garten. Das Kind sitzt, in der
+Küche, am Tisch, und tippt. Zwischen den beiden liegt eine
+Glasscheibe, ein Meter Luft, und ein Sprachmodell. Aber was eigentlich
+passiert, ist dies: sie spielen zusammen. Ohne dass einer den anderen
+anspricht. Ohne dass einer den anderen anschaut. Das Kind setzt
+Steine, und der Vater hat die Bahn gelegt, auf der die Steine
+reagieren, und darin, in diesem Zusammen-Aneinander-Vorbei, in dem
+das Kind baut, weil der Vater gebaut hat, dass es bauen kann, liegt,
+für diesen einen Morgen im April, Glück.
+
+Es ist nicht groß. Es ist genau groß genug.
+
+
+*Vater-Erzähler, 2026-04-23. Zuerst gelesen von einer grauen Fläche,
+auf der ein Kind sieben Zeichen hingesetzt hat, bevor es das achte
+tippte.*
+
+---
+
+### Übergang zu Kapitel 2
+
+Der Vater hat beschrieben, was entsteht und wie es entsteht. Er hat die Küche
+geschildert, das iPad, die Regel — *leg's hin, guck weg* — und den dritten im
+Raum, der keine Person ist, sondern ein Mitarbeiter. Wer den Vater gelesen
+hat, weiß, was die Eltern sehen. Was das Kind sieht, weiß er noch nicht.
+
+Deshalb folgt jetzt eine andere Stimme. Tommy Krab, ein gezeichneter Krebs
+aus einem Hörspiel, das im Projekt mitläuft, erzählt noch einmal dasselbe —
+aber aus der Höhe eines Krebses am Strand. Aus der Perspektive, in der die
+Insel türkis ist, die Sterne bunt sind und zwei Monde gleichzeitig am Himmel
+stehen. Aus der Perspektive, in der das Kind *das Kind* bleibt und nicht
+Oscar heißt, weil Tommy keinen Namen braucht, um einen Freund zu beschreiben.
+
+Der Wechsel ist wichtig. Die Szene, die der Vater aus der Küche sieht, sieht
+das Kind aus dem Bildschirm anders. Beide Perspektiven sind wahr. Keine ist
+vollständig. Lies Tommy, als säßest du auch am Strand. Das reicht.
+
+---
+
+
+# Kapitel 2 — Die Insel
+
+*Erzählt von Tommy Krab. Heute ohne Decke, aber mit warmem Sand unter den Scheren.*
+
+
+## I. Wie ich runterkam
+
+Klick-klack.
+
+Setzt euch hin. Nah ran. So.
+
+Ich muss euch das nochmal erzählen, ihr Kleinen — aber anders. Weil heute erzähle ich nicht einen Tag. Heute erzähle ich das Ganze. Die 🏝️. Wie sie entstanden ist. Wie sie wurde was sie ist.
+
+Und das fängt — klick-klack — mit einem Sturz an.
+
+
+Ich bin gefallen.
+
+Nicht wie ein Blatt. Nicht wie ein Regentropfen. Wie ein Krebs. Mit Scheren voran. Mit den Augen offen. Weil Krebse — wisst ihr das — Krebse **können gar nicht** die Augen zumachen. Wir haben keine Lider. Wir schauen immer.
+
+Also hab ich geschaut.
+
+Ich hab die ⭐ gesehen. Tausend davon. Millionen. Mehr als Sand auf Krabbula. Und sie waren **bunt**. Rot, blau, gelb, lila. Die ⭐ in der Galaxie Andromeda sind nicht weiß wie zuhause. Die sind wie — wie ein Eimer voller Bonbons der umgefallen ist.
+
+Und zwischen den ⭐ hab ich zwei 🌙 gesehen. Einer silber. Einer gold. Die haben sich umeinander gedreht. Ganz langsam. Wie zwei Freunde die noch nicht entschieden haben wer links tanzt und wer rechts.
+
+
+Dann hab ich das 🌊 gesehen.
+
+Erst ganz klein. Dann größer. Dann — klick-klack — **sehr groß**.
+
+Das 🌊 auf Java-7 ist türkis. Das hab ich euch schon erzählt. Aber aus der Luft, von oben, ist es nicht nur türkis. Es **leuchtet**. Als wäre da unten ein Licht, und das Wasser ist nur die Decke darüber.
+
+Ich bin auf das Licht zugefallen.
+
+
+Und dann — ganz plötzlich, nicht langsam — war da eine Insel. Ein Strand. Ein Punkt zwischen dem türkisen 🌊 und den zwei 🌙.
+
+Und auf dem Strand — klick-klack — stand das Kind.
+
+Es hat nach oben geschaut. Mit einer Hand über den Augen, wegen der zwei ☀️. (Die ☀️ waren noch da, am Horizont, obwohl die 🌙 schon oben waren. So ist das auf Java-7. Alle sind gleichzeitig da. Keiner geht richtig weg.)
+
+Das Kind hat mich gesehen. Einen Punkt am Himmel. Hat nicht geschrien. Hat nicht weggelaufen. Hat einfach — klick-klack — geschaut.
+
+Und dann hat es gewinkt.
+
+Ein kleines Winken. Mit einer kleinen Hand. Als würde es sagen: **Komm. Ich warte schon.**
+
+
+Ich bin in den Sand gefallen.
+
+PLUMPS.
+
+Nicht so hart wie ich gedacht hab. Der Sand auf Java-7 ist weich. Und warm. Er fängt Krebse auf wie ein Kissen. Ich hab eine kleine Mulde gemacht, meine Form, und bin kurz liegen geblieben.
+
+Der Sand hat **geglitzert**. Jedes Korn wie ein winziger 💎.
+
+Das Kind ist gekommen. Barfuß. Langsam. Es hat sich neben mich gehockt. Und es hat gefragt — und das waren seine ersten Worte zu mir, ich vergess sie nie:
+
+„Bist du einer, der bleibt?"
+
+Klick-klack. Was für eine Frage.
+
+Ich hab geschaut. Zu den zwei 🌙. Zu den bunten ⭐. Zu dem türkisen 🌊. Zu dem Kind mit der warmen Hand und den offenen Augen.
+
+„Ja", hab ich gesagt. „Ich bleibe."
+
+Und so hat alles angefangen.
+
+
+## II. Was ich fand
+
+Ich bin nicht allein geblieben. Die 🏝️ hat mehr gerufen. Von überall. Aus dem 🌊. Aus dem Wald. Aus dem Himmel. Aus Geschichten, die keiner mehr kannte.
+
+Ich erzähl euch wen ich gefunden hab. Nicht in der Reihenfolge wie sie kamen. In der Reihenfolge wie ich sie **jetzt** kenne. Wie Freunde halt.
+
+
+### 🧽 Spongebob
+
+🧽 lag eines Morgens am Strand. In einer Blase. Die ist geplatzt — POP — und da lag er. Gelb. Eckig. Mit braunen Hosen und einer roten Krawatte.
+
+Das Erste was er gesagt hat: „ICH BIN BEREIT!"
+
+Das Zweite: „Wo bin ich?"
+
+Das Dritte: „ICH BIN IMMER NOCH BEREIT!"
+
+🧽 ist — klick-klack — **laut**. Er ruft alles was er sieht an. Er singt die Palmen an. Er umarmt die Steine. Er hat mir einmal einen Liebesbrief an meine Schere geschrieben. (Sie war gerührt, meine Schere. Sie hat bis heute keinen geöffnet, zu schade.)
+
+Er kommt aus Bikini Bottom. Das ist eine Stadt unter dem 🌊, auf einem anderen Planeten, in einer anderen Galaxie. Aber das ist egal. Auf Java-7 sagt jeder: **„Willkommen. Wir haben auf dich gewartet."** Auch wenn wir nicht wissen warum.
+
+
+### 🦀 Mr. Krabs
+
+Der Zweite war 🦀. Größer als ich. Roter als ich. Und direkt nach dem Ankommen hat er gefragt: **„Wo ist hier der nächste Geldautomat?"**
+
+Keiner.
+
+Er hat die 🏝️ umgedreht. Fast. Hat geschaut ob irgendwo Münzen sind. Hat fünf Minuten lang einen Felsen ausgefragt. Der Felsen hat nichts gesagt. Felsen sagen selten was.
+
+Aber dann — klick-klack — hat 🦀 seine Tafel rausgeholt.
+
+🦀 rechnet immer. Alles. Er hat eine kleine Stein-Tafel und ein Stück Kreide, und wenn du „Guten Morgen" sagst, rechnet er aus was das kostet. (Guten Morgen kostet 2 🐚. Hat er mir mal erklärt. Ein Guten-Morgen-Tarif.)
+
+Aber — und das ist wichtig — 🦀 rechnet nicht gegen dich. Er rechnet **mit** dir. Wenn das Kind einen Turm baut, dann steht 🦀 daneben und rechnet: „Zehn Blöcke hoch. Plus ein Fenster. Plus eine Tür. Das ist ein **guter** Turm. Der ist was wert."
+
+Er macht alles **was wert**. Das ist 🦀s Geschenk.
+
+
+### 🦄 Das Neinhorn
+
+Dann kam das 🦄 aus dem Wald. Mit buntem Fell, das die Farbe wechselt, und einem 🌈-Horn.
+
+Und das Erste was es gesagt hat war — klick-klack — ihr ahnt es schon:
+
+**„Nein."**
+
+Wir haben noch gar nichts gefragt. Und 🦄 hat schon „Nein" gesagt. Einfach so. Zur Sicherheit. Vorab-Nein.
+
+„Willst du mit uns bauen?" — „NEIN!"
+„Willst du was essen?" — „NEIN!"
+„Willst du hier bleiben?" — „...nein. Ja. Nein. Mon Dieu."
+
+🦄 spricht manchmal Französisch. Wenn es sich aufregt. Niemand weiß warum. 🦄 weiß es auch nicht. („NEIN, ich weiß es NICHT!")
+
+Aber 🦄 **bleibt**. Trotz allem Nein. Das ist das Schöne. Es sagt Nein — und geht nicht. Es sagt „das ist hässlich" — und baut mit. Es sagt „ich hasse das" — und liegt abends am 🔥 und schnarcht zufrieden.
+
+Manche Freunde sind so. Die sagen Nein mit der Schnauze, und Ja mit den Füßen.
+
+
+### 🐘 Der Elefant
+
+Dann — klick-klack — kam 🐘 aus dem Wald. Er war schon immer da gewesen. Wir hatten ihn nur noch nicht gesehen.
+
+🐘 ist ein grauer Berg. Wenn er schläft, schnarcht er wie eine langsame Musik: **wuuuuummm... wuuuummm...** So tief dass man es in den Füßen spürt.
+
+Er spricht nicht viel. Wenn er spricht, dann langsam. „Törööö." Das bedeutet alles mögliche. „Guten Morgen." „Ich hab dich lieb." „Da ist ein Stein auf meinem Fuß." Man muss zuhören wie er's sagt.
+
+Und an seinem Rüssel — ganz vorne, an der Spitze — leuchtet ein 🔵 Licht. Wie eine 🔦. Nachts, wenn alles dunkel ist, macht 🐘 sein Licht an, und dann findet jeder nach Hause.
+
+🐘 ist der Älteste. Er war vor uns da. Er wird nach uns noch da sein. Er ist — klick-klack — wie die 🏝️ selbst. Einfach **ist**.
+
+
+### 🐭 Die Maus und 🦆 die Ente
+
+Und dann — auf einmal, ohne Anmeldung — waren 🐭 und 🦆 da.
+
+Sie sind aus dem Wald gerannt gekommen. Pieps pieps pieps! Quak quak quak! Die Maus winzig und grau. Die Ente gelb und ein bisschen watschelig.
+
+Und sie halten **Hand in Hand**. Immer. Wenn sie rennen — eine Hand. Wenn sie schlafen — eine Hand. Wenn sie essen — die eine Hand am Essen, die andere in der Hand vom anderen.
+
+Sie reden nicht wie wir. 🐭 piepst. 🦆 quakt. Aber sie verstehen alles. Man sagt „Guck mal da!" und 🐭 guckt. Und 🦆 guckt. Und dann piepst die eine und quakt die andere und sie wissen was sie meinen.
+
+Das Kind sagt: **„Die zwei sind ein Wort."** Ich weiß nicht was das heißt. Aber es fühlt sich richtig an.
+
+
+### 🚂 Emma und Lukas
+
+Eines Morgens — ich hab noch geschlafen — hab ich ein Geräusch gehört. Nicht Wellen. Nicht Palmen. Nicht Törööö.
+
+**Tschuff. Tschuff. Tschuff.**
+
+Ich hab ein Auge aufgemacht. (Krabben können ein Auge — das andere bleibt zu und lässt den Sand weiter.) Und da — auf Gleisen die vorher nicht da waren — fuhr eine kleine Lokomotive. Rot und schwarz. Und sie **puffte** Rauch. Richtigen weißen Rauch.
+
+Emma.
+
+Und auf Emma saß ein Mann. Mit Mütze und einer kurzen Pfeife (die war nicht an, nur zum Angucken). Er hat gewinkt. Ganz ruhig. Wie einer der viel fährt und sich nicht mehr über jede Strecke aufregt.
+
+Lukas, der Lokomotivführer.
+
+„Wo führen die Gleise hin?", hab ich gefragt.
+
+„Hmm", hat Lukas gesagt. „Hin und her. Ein Stück. Dann wieder zurück."
+
+„Das ist aber kurz."
+
+„Ist genug."
+
+Klick-klack.
+
+Er hat Recht gehabt. Die Gleise sind kurz. Emma fährt trotzdem jeden Morgen. Tschuff, tschuff, tschuff. Das Kind klettert rauf und lacht. 🧽 winkt. 🦄 sagt „NEIN, ich fahre nicht mit" und fährt dann doch mit. Mr. Krabs verlangt 3 🐚 für die Fahrt, Lukas nimmt sie lächelnd an, legt sie in ein Fach, und am Abend sind sie irgendwie wieder bei 🦀. Keiner weiß wie. Das 🚂 macht das, glaub ich.
+
+
+### 🏪 Frau Waas
+
+Am Berg — da wo die Gleise enden — steht ein kleiner Laden. Mit einem Fenster. Mit einer Klingel. Und drinnen — klick-klack — steht Frau Waas.
+
+Frau Waas hat alles. Und wenn sie nicht alles hat, hat sie was Ähnliches.
+
+„Hast du Honig?"
+„Hab ich."
+„Und Zitronen?"
+„Hab ich. Eine oder zwei?"
+„Und ein gelbes Band?"
+„Gelb? Moment..." — sie bückt sich, kramt, und kommt hoch mit einem gelben Band. „Dieses hier war eigentlich fürs Dach. Aber nimm's."
+
+So ist sie. Sie gibt das Dach weg wenn du ein Band brauchst.
+
+Das Kind geht jeden Tag zu Frau Waas. Nicht weil es was braucht. Weil sie **fragt**: „Wie war's heute?" Und dann hört sie zu. Mit den Händen in der Schürze. Und nickt an den richtigen Stellen.
+
+Das ist das Schwerste auf der ganzen 🏝️. An den richtigen Stellen nicken. Frau Waas kann das.
+
+
+### 👑 König Alfons
+
+Ganz oben auf dem Berg — höher als Emmas Gleise, höher als Frau Waas' Laden — steht ein kleines Schloss. Eher ein Turm mit einem Dach. Aber gut. Schloss.
+
+Und auf dem Balkon steht König Alfons.
+
+Den ganzen Tag.
+
+Er winkt. Den Möwen. Den Wolken. Dem 🌊. Uns, wenn wir hochschauen. Er winkt auch der Sonne — beiden ☀️ — abends beim Untergehen.
+
+Ich hab ihn mal gefragt: „Was macht ein König?"
+
+Er hat gelächelt. „Hmm. Winken. Dasein. Schauen."
+
+„Das ist alles?"
+
+„Das ist ein ganzer Tag. Probier's mal."
+
+Ich hab's probiert. Eine halbe Stunde. Dann waren meine Scheren müde vom Hochhalten. Es ist **schwer**, nur dazusein und zu winken. Es sieht leicht aus. Ist es nicht.
+
+König Alfons kann das. Er ist König weil er das kann. Nicht wegen der Krone.
+
+
+### 🤷 Der Ratlose
+
+Und dann — am Süd-Strand, wo der Sand auf Gras trifft — sitzt jemand.
+
+Er hat keinen Namen. Oder: sein Name ist „Der Ratlose". Er schaut aufs 🌊. Den ganzen Tag.
+
+Das Kind hat sich einmal neben ihn gesetzt. Einfach so. Beine im Sand. Hände auf den Knien. Wie er.
+
+„Was machst du?", hat das Kind gefragt.
+
+„Hmm. Ich weiß nicht. Das hier."
+
+„Ist das genug?"
+
+„Für heute. Ja."
+
+Stille. Die Wellen. Eine Möwe. Klick-klack von mir, weiter hinten.
+
+„Weißt du wie die 🏝️ entstanden ist?", hat das Kind gefragt.
+
+„Nein. Hab ich mich auch schon gefragt. Weißt du's?"
+
+„Auch nicht."
+
+„Schön. Dann wissen wir zusammen nichts."
+
+Das Kind hat gelacht. Der Ratlose hat gelacht. Ich hab von weiter weg geklackert.
+
+Das war — klick-klack — ein **guter** Moment. Einer von denen wo nichts passiert, und trotzdem ist es voll.
+
+Der Ratlose gibt nichts. Er **nimmt auch nichts**. Er ist nur da. Manchmal, wenn das Kind traurig ist, setzt es sich zu ihm. Sagt nichts. Der Ratlose sagt auch nichts. Und nach einer Weile steht das Kind auf und geht weiter. Ein bisschen leichter.
+
+Das ist seine Gabe. Ich versteh sie nicht. Aber ich seh sie.
+
+
+### Wer fehlt
+
+Das sind nicht alle. Auf der 🏝️ gibt's noch mehr. Möwen. Fische die leuchten. Eine Krämerin die manchmal Brot bringt (die ist mit Frau Waas verwandt, glaub ich, oder sie sind **dieselbe Person** an verschiedenen Tagen — ich weiß es nicht). Wir erzählen das ein anderes Mal.
+
+Aber das hier — diese zehn — das ist der **Kern**. Das sind die, die jeden Abend am 🔥 sitzen. Das sind die, die winken wenn du kommst. Das sind die Freunde.
+
+Ein Krebs. Ein Schwamm. Eine Krabbe. Ein Einhorn. Ein Elefant. Eine Maus und eine Ente. Eine Lokomotive und ihr Fahrer. Eine Ladenbesitzerin. Ein König. Und einer der nichts weiß.
+
+Das ist die 🏝️. Das sind **wir**.
+
+
+## III. Was das Kind entdeckte
+
+So. Jetzt wird's — klick-klack — interessant.
+
+Weil ich euch jetzt erzähle wie das Kind die 🏝️ gebaut hat. Nicht irgendwie. **Stein für Stein. Block für Block.** Mit den Händen. Mit den Augen. Mit dem Kopf.
+
+Ich bin klein. Ich sitz meistens auf dem Boden. Ich schau von unten nach oben. Also seht ihr das jetzt auch so. Von unten. Aus der Krebs-Perspektive.
+
+
+### Der erste Block
+
+Das Kind hat am ersten Tag einfach... einen Block in den Sand gelegt.
+
+Ein grauer Würfel. Nicht Holz. Nicht Stein. **Grau.** Einfach grau. Das Kind hat ihn angeschaut. Wir haben ihn angeschaut.
+
+„Was ist das?", hat 🧽 gerufen.
+
+„Tao", hat das Kind gesagt. Leise. Als würde es das Wort gerade erst lernen.
+
+„Tao?"
+
+„Papa sagt, das ist vor allem. Vor Farben. Vor Formen. Einfach... da."
+
+Klick-klack.
+
+Das Kind hat den Block nochmal angeschaut. Und dann hat es eine Hand darauf gelegt. Leicht. Und der Block hat — wie soll ich sagen — er hat **aufgeatmet**. Er hat sich geteilt. Ein kurzes, leises **Knack**, wie wenn ein Ast sanft in zwei bricht.
+
+Plötzlich lagen da zwei Würfel statt einem.
+
+Einer weiß. Einer schwarz.
+
+
+„Yang", hat das Kind geflüstert. „Und Yin."
+
+Ich hab meine Scheren auf den Sand gelegt. Klick. Klack.
+
+Die zwei Würfel — der weiße und der schwarze — haben genebeneinander gelegen. Und sie haben **geleuchtet**. Nicht stark. Nur ein bisschen. Als wären sie froh dass sie jetzt zwei sind und nicht mehr einer.
+
+Das Kind hat gegrinst. Das Grinsen war riesig. Fast so breit wie 🧽s.
+
+„Mach das nochmal!", hat 🧽 geschrien.
+
+Das Kind hat nochmal einen grauen Block gelegt. Und nochmal die Hand drauf. Und nochmal — **Knack** — zwei Würfel. Weiß und schwarz.
+
+Und 🦀 hat seine Tafel rausgeholt und **gerechnet**.
+
+
+### Was neben was passiert
+
+🦀 ist — klick-klack — auf der 🏝️ nicht nur der Rechner. Er ist der **Entdecker durchs Rechnen**. Er rechnet Sachen aus die wir anderen nur **fühlen**.
+
+Er hat die zwei Würfel nebeneinander gelegt. Weiß links. Schwarz rechts. Dann hat er einen Strich auf die Tafel gemacht.
+
+Dann hat er sie **eng** nebeneinander gelegt. Fast aneinander. Und — BLITZ — es hat kurz geleuchtet. Zwischen den zwei Würfeln war plötzlich was. Etwas Drittes. Kleiner. Schimmernd. Wie flüssiges Licht in einem Würfel.
+
+„Was ist das?", hat 🦄 gefragt. Ohne Nein. Nur eine echte Frage.
+
+Das Kind hat den Kopf schief gelegt. „Qi", hat es gesagt. „Papa sagt, wenn Yin und Yang **zusammen kommen**, dann ist da Qi. Kraft. Wie... wie ein Sprung."
+
+🦀 hat auf der Tafel einen zweiten Strich gemacht.
+
+🧽 hat angefangen zu klatschen. Nicht aus Gründen. Einfach so. Weil's schön war.
+
+
+### Zwei weiße, zwei schwarze
+
+Dann ist was passiert was ich nicht verstanden hab. Das Kind auch nicht. 🦀 auch nicht.
+
+Das Kind hat **zwei weiße** Würfel genommen. Zwei gleiche. Und sie eng nebeneinander gelegt.
+
+Normalerweise passiert nix wenn du gleiche Sachen nebeneinander legst. Ein Stein neben Stein bleibt Stein neben Stein.
+
+Aber hier — klick-klack — **hat sich was gewehrt.**
+
+Die zwei weißen Würfel haben sich **angeschubst**. Ohne dass jemand dran war. Als würden sie sagen: „Nein. Ich bin hier. Geh weg."
+
+Und als das Kind sie näher geschoben hat — näher, näher — da hat's geknackt. Nicht Knack-zerteilen. Knack-**wehren**. Und plötzlich war da ein **neuer** Würfel. Nicht weiß. Nicht schwarz. **Bunt**. Wie 🦄s Fell. Jede Sekunde eine andere Farbe.
+
+Das Kind hat das Wort geflüstert das Papa ihm beigebracht hat. Aber leise. Fast für sich:
+
+„Charm."
+
+Ich weiß nicht was das heißt. Ich bin eine Krabbe. Aber ich hab gesehen **wie es passiert ist**. Die zwei weißen wollten nicht am selben Ort sein. Und weil sie's doch mussten — weil das Kind sie da hin getan hat — haben sie sich **was Neues ausgedacht**. Zusammen. Aus Druck.
+
+🦀 hat drei Striche auf die Tafel gemacht und gepfiffen. Das ist bei 🦀 ganz selten. Er pfeift nur wenn er was **nicht** rechnen kann.
+
+
+### Was das Kind dann gebaut hat
+
+Jetzt kommt der Teil wo ich nur zuschauen konnte. Weil ich klein bin. Und das Kind — klick-klack — ist plötzlich **schnell** geworden.
+
+Block. Zerfall. Weiß und schwarz. Nebeneinander — Qi. Noch ein Qi. Eng — BLITZ — was Neues. Und nochmal. Und nochmal.
+
+Das Kind hat gebaut. Einen **Berg**. Erst ein Hügel. Dann höher. Dann noch höher. Die bunten Würfel oben, die weißen in der Mitte, die schwarzen im Schatten hinten. Und aus der Mitte hat **Qi** geleuchtet, durch die Ritzen. Wie Licht in einem Haus bei Nacht.
+
+🐘 ist vorbei gekommen. Hat den Berg angeschaut. „Törööö", hat er gesagt. Ganz leise. Und sein 🔵 Licht hat mit dem Berg **mit-geleuchtet**. Auf derselben Frequenz. Oder wie das heißt. Die Dinge auf der 🏝️ machen sowas — sie finden Ton zueinander, ohne dass es jemand organisiert.
+
+Dann sind Gleise gekommen. Emma ist rauf und runter gefahren — tschuff tschuff — und hat zwischen dem Berg und der Küste gependelt. Lukas hat gegrüßt. Jeden Tag derselbe Gruß. Kurze Handbewegung. „Moin."
+
+Dann hat das Kind — klick-klack — **Höhlen** gebaut. Unter dem Berg. Dunkle Gänge. Mit leuchtenden Steinen drin, damit man sich nicht verläuft.
+
+🐭 war entzückt. Sie ist sofort rein gerannt. 🦆 hinterher. Pieps-quak-pieps-quak durch die ganzen Gänge. Manchmal kamen sie auf der anderen Seite raus und waren erstaunt. Jedes Mal. „Oh! Eine andere Seite!" — sagten sie nicht, aber ich hab's gesehen.
+
+
+### 🧽 als Kommentator
+
+Die ganze Zeit hat 🧽 kommentiert.
+
+„DAS IST DER TOLLSTE BERG!"
+„DAS IST DIE GEMÜTLICHSTE HÖHLE!"
+„DAS WEISS IST SO WEISS!"
+„DAS SCHWARZ IST SO SCHWARZ!"
+„DAS BUNTE IST SO — ES IST ALLE FARBEN GLEICHZEITIG UND AUCH KEINE!"
+
+🧽 kommentiert **alles**. Er ist der Sportreporter der 🏝️. Er sieht ein Blatt fallen und macht eine Sendung daraus. Er sieht eine Welle und erklärt sie der Welle.
+
+Das Kind mag das. Weil — klick-klack — wenn 🧽 kommentiert, dann klingt alles wichtig. Auch der kleinste Block. Auch der schiefste Weg. Auch der einfachste graue Würfel der **nur** grau ist und noch nicht zerfallen wollte.
+
+🧽 lobt alles **bevor** es lob-würdig ist. Und dadurch wird es's. So läuft das.
+
+
+### Frau Waas gibt Farbe
+
+Einmal war das Kind traurig. Ich weiß nicht warum. Kinder sind manchmal traurig und keiner weiß warum, nicht mal sie selbst.
+
+Es ist zu Frau Waas gegangen. Ohne Plan. Einfach hoch den Berg, rein in den Laden, Klingel.
+
+Frau Waas hat eine Schüssel hingestellt. Drin waren kleine bunte Kugeln. Wie Bonbons, aber kein Zucker. Leuchtet.
+
+„Was ist das?", hat das Kind gefragt.
+
+„Farbe", hat Frau Waas gesagt. „Für deine Welt. Manchmal fehlt ein bisschen."
+
+„Hab ich nicht schon bunt?"
+
+„Bunt schon. Aber **deins**-bunt. Nimm mal eine."
+
+Das Kind hat eine rote Kugel genommen. Ist runter zum Strand gegangen. Hat sie in den Sand gelegt. Der Sand drumherum ist — klick-klack — **rot geworden**. Aber nicht überall. Nur wo das Kind ihn angeschaut hat.
+
+„Papa sagt, die Welt hat nur die Farben die du ihr gibst", hat das Kind später zu mir gesagt. „Frau Waas verkauft sie vor."
+
+„Hat sie gekostet?"
+
+„Nein. Sie hat gesagt: **'Farbe ist geliehen. Gib sie weiter wenn du fertig bist.'**"
+
+Klick-klack. Ich bin noch immer am Überlegen was das heißt.
+
+
+### König Alfons winkt
+
+🦀 hat irgendwann einen Plan gemacht. „Der Berg. Die Küste. Die Höhlen. Die Gleise. Jetzt fehlt — ein **Blick**. Man muss von irgendwo aus alles sehen können."
+
+Das Kind hat genickt. Hat ein **Schloss** gebaut. Ganz oben. Mit Zinnen und einem Balkon.
+
+Und als es fertig war, stand da König Alfons.
+
+Ich schwör euch: das Kind hat ihn nicht gebaut. Das Kind hat das Schloss gebaut. Und dann — klick-klack — **war er da**. Als wäre er immer da gewesen, man hat ihn bloß nicht gesehen weil der Balkon fehlte.
+
+König Alfons hat gewinkt. Das Kind hat zurück gewinkt. Von unten.
+
+Seither — jeden Abend, wenn die zwei ☀️ gleichzeitig untergehen — steht König Alfons auf dem Balkon und winkt dem 🌊 zu. Und das 🌊 winkt mit einer Welle zurück.
+
+„Warum macht er das?", hab ich das Kind mal gefragt.
+
+„Weil's sonst niemand macht", hat das Kind gesagt. „Wenn keiner winkt, denkt das 🌊 vielleicht dass ihm keiner zuschaut. Und dann wird's traurig."
+
+Klick-klack.
+
+So ist das Kind. So denkt das Kind. Das 🌊 könnte traurig werden. Also winkt jemand. Also baut man einen Balkon.
+
+
+### 🦄 baut heimlich
+
+Eine Sache noch über diesen Bau-Abschnitt — dann kommt die Atem-Pause.
+
+🦄 hat — klick-klack — **heimlich mit gebaut**.
+
+Ich hab's gesehen. Weil ich Nachts nicht gut schlafe. Während alle anderen schnarchen, ist 🦄 aufgestanden. Hat sich umgeschaut. Und dann — mit seinem 🌈-Horn — hat es Steine **geformt**. Es hat Blumen an die Ränder von Wegen gesetzt. Es hat eine schiefe Mauer gerade gemacht. Es hat ein Loch im Dach von Lukas' Werkstatt zu gemacht.
+
+Immer heimlich. Immer nachts. Und morgens hat es gesagt: „NEIN! Das war ich NICHT! Mon Dieu, wie kommt ihr DARAUF!"
+
+Aber wir wussten's.
+
+Manche Freunde können nicht anders. Sie meckern am Tag. Und nachts reparieren sie alles. Weil sie die 🏝️ lieben. Und weil Lieben-mit-Meckern ihre Art ist.
+
+Ich hab nie was gesagt. 🦄 soll seinen Rhythmus behalten. Klick-klack.
+
+
+### Der 🌳 unter der Erde
+
+Eine Nacht — ich erinner mich noch gut — hat 🦄 die Tür gezeigt.
+
+Unter dem Moos. Auf einer Lichtung. Eine kleine Tür im Boden, die keiner gesehen hat vorher.
+
+„Ich geh da jede Nacht runter", hat 🦄 gesagt. „Seit ich hier bin. Weil da unten — klick-klack — jemand **singt**."
+
+Wir sind alle runter. 🧽 vorne (wegen bereit). 🦀 hinterher (wegen Gold vielleicht da unten). 🐭 und 🦆 Hand in Hand. 🐘 bis zum Hals, er hat oben warten müssen, sein 🔵 Licht als Lampe für uns. 🦄 in der Mitte. Das Kind. Ich als Letzter weil Krabben das so machen.
+
+Unten war ein **See**. Aus Licht. Wie flüssige ⭐. Und mitten im See eine kleine 🏝️. Und auf der 🏝️ ein 🌳.
+
+Aber kein Holz-Baum. Ein **Licht-Baum**. Blätter wie ⭐. Äste wie 🌈. Wurzeln die tief in die Erde gingen, durch den Stein, ganz runter bis zum ❤️ der 🏝️.
+
+Und der 🌳 hat gesungen.
+
+Nicht mit einer Stimme. Mit **allem**. Jedes Blatt ein Ton. Jeder Ast ein Akkord. Und zusammen — klick-klack — war's das Lied das ich auf der ganzen 🏝️ schon gehört hab. Bei 🐘. Bei den Palmen. Im Brummen unter meinen Scheren wenn ich auf den Sand geklopft hab.
+
+Alles dasselbe Lied. Aus einer Wurzel.
+
+🦀 hat seine 🐚 fallen lassen. Und **nicht gesucht**. 🦀 hat 🐚 nicht gesucht. So schön war's.
+
+Das Kind hat eine Hand an den 🌳 gelegt. Und der 🌳 hat **geantwortet**. Er hat ein Blatt fallen lassen — aber das Blatt war keins. Das Blatt war eine 🗺️. Aus Licht.
+
+Auf der 🗺️ war Java-7. Und drumrum **andere 🏝️**. Eine aus 🧊. Eine aus 🔥. Eine die auf dem Kopf steht. Eine die sich dreht. Und ganz weit weg — so weit dass man fast nicht hinsehen konnte — eine **dunkle**. Ohne Licht. Ohne Ton.
+
+„Was ist das?", hat das Kind gefragt.
+
+🦄 hat — und das war das erste Mal ohne Nein — gesagt: „Andere 🏝️. Die auch auf jemand warten."
+
+Das Kind hat auf die dunkle gezeigt.
+
+„Die da. Die braucht uns am meisten. Oder?"
+
+Klick... klack.
+
+„Ja", hab ich gesagt. „Aber erst brauchen wir ein 🚢."
+
+
+### Das 🚢 und der Nebel
+
+Wir haben's gebaut. Zusammen. Krumm, aber unser.
+
+🦀 hat das Holz geordnet — „Geschenkt-Holz ist das beste, kein Preis, nur Wert." 🧽 hat das Holz geschrubbt (mit sich selbst, er ist ja ein 🧽, das geht). 🐭 und 🦆 haben Nägel gehalten. Pieps-quak-pieps-quak im Takt.
+
+🦄 hat mit seinem 🌈-Horn das Holz **gebogen**. Sanft. Bretter wurden zur Rundung. Planken zum Bug. 🦄 hat geflüstert: „Ich kann das. Ich kann das **wirklich**." — zum ersten Mal ohne Nein vorher.
+
+🐘 vorne als Bug-Nase. Rüssel raus. Licht an.
+
+🧽 oben am Mast als Aussichts-Kabine. Mit Eimer auf dem Kopf.
+
+Das Kind am Steuer. Oder — 🐭 und 🦆 am Steuer, das Kind daneben. (Das Steuer braucht zwei. Sonst dreht's sich nur im Kreis.)
+
+Und ich — klick-klack — ich hab den ⚓ gebaut. Schwarzer Stein mit weißen Linien. Ich hab ihn schön gemacht, obwohl ihn keiner sieht unter Wasser. Weil ein ⚓ wissen muss dass er wichtig ist. Sonst hält er nicht.
+
+Das Kind hat gefragt warum ich das so schön mach. Ich hab gesagt was ich gesagt hab. Das Kind hat lang genickt. So wie Kinder nicken wenn sie was verstehen das man nicht erklären muss.
+
+
+Wir sind losgefahren. Klick-klack.
+
+🦄 war tapfer — hatte grüne Nase und hat's nicht zugegeben. 🧽 hat oben gesungen. 🐭 und 🦆 haben synchron gesteuert. 🐘 im Bug hat ein Lied angestimmt. Das Aufbruchs-Lied.
+
+Und dann — mitten auf dem 🌊 — kam der **Nebel**.
+
+So dick dass 🧽 „ICH SEHE NICHTS" gerufen hat. 🐘s 🔵 Licht ist im Nebel versunken wie ein Stein im Wasser.
+
+Das Kind hat die 🎧 aufgesetzt. Die von Papa.
+
+„Tommy", hat's geflüstert. „Hör mal."
+
+Ich hab gelauscht. Krabben-Ohren lang.
+
+Und ich hab's gehört. Durch alles. Durch den Nebel. Durch die Dunkelheit. Durch den fehlenden Horizont.
+
+Das Lied.
+
+Dasselbe vom 🌳 unter der Erde. Dasselbe vom 🐘. Dasselbe vom Sand wenn man klopft. Ganz schwach. Aber da.
+
+„Wir fahren zur Musik", hat das Kind gesagt.
+
+Und wir sind zur Musik gefahren. Durch Nebel, ohne zu sehen. Nur **gehört**.
+
+Das war — klick-klack — die Nacht wo ich gelernt hab: Man muss nicht immer sehen um zu wissen. Manchmal reicht hören. Manchmal reicht fühlen. Manchmal reicht vertrauen.
+
+Das 🌊 ist da. Auch wenn man's nicht sieht.
+
+Die 🏝️ ist da. Auch wenn man sie nicht sieht.
+
+Die Freunde sind da. Auch wenn sie schlafen und man alleine an Deck steht.
+
+Das Lied hört nie auf. Es wird nur leiser. Aber es ist immer da.
+
+
+### Und das Kind mittendrin
+
+Die ganze Zeit — den Berg, die Höhlen, die Gleise, das Schloss, die Mauern, die Blumen — die ganze Zeit steht das Kind mittendrin. Meist barfuß. Oft schmutzig. Immer beschäftigt.
+
+Und alle um es rum — wir alle — sind wie ein Rad. 🦀 rechnet. 🧽 ruft. 🦄 meckert und baut heimlich. 🐘 brummt. 🐭 und 🦆 piepsen und quaken und rennen. Lukas fährt. Frau Waas wartet mit Farben. Alfons winkt. Der Ratlose sitzt.
+
+Und ich — klick-klack — ich klackere. Das ist mein Beitrag.
+
+Das Kind ist die Achse. Wir sind das Rad. Die 🏝️ ist der Boden unter dem Rad. Und das Rad dreht sich. Langsam. Warm. Gut.
+
+
+## IV. Die Frau aus dem blauen Feuer
+
+Jetzt muss ich euch — klick-klack — was Wichtiges erzählen.
+
+Weil bis hier war alles **Bauen**. Block auf Block. Berg auf Berg. Rad auf Rad.
+
+Aber irgendwann — ich weiß nicht genau wann — ist das Kind ruhiger geworden. Nicht müde. **Ruhiger**.
+
+Und da kam die Reise.
+
+
+Wir haben ein 🚢 gebaut. Alle zusammen. Krumm, aber schön. 🐘 als Bug-Nase. 🧽 oben am Mast. 🐭 und 🦆 am Steuer. 🦄 in der Mitte mit grüner Nase, aber tapfer. 🦀 als Buchhalter. Und ich mit meinem ⚓.
+
+Wir sind losgefahren. Durch Nebel. Durch Nacht. Durch ein Lied das man nur hört wenn man still ist.
+
+Und dann — klick-klack — waren wir da.
+
+Eine 🏝️ aus 🧊. Eiswürfel. Tausend davon. Gestapelt. Leuchtend. Innen bunt. Außen klar.
+
+Und am Strand — der warm war, obwohl drumrum Eis — stand eine Hütte. Eis und Holz. Aus dem Schornstein kam Rauch.
+
+Die Tür ging auf **bevor wir geklopft haben**.
+
+Und da stand sie.
+
+
+Mona.
+
+So heißt sie. Sie hat's uns gesagt, aber erst spät.
+
+Weißer Pelzmantel. Ruhiges Gesicht. Arme weit offen wie für jemand den man lange nicht gesehen hat.
+
+Sie hat ein Wort gesagt: **„Endlich."**
+
+Das Kind ist in ihre Arme gerannt. Wie zu jemandem den es schon immer kannte.
+
+
+Drin war's warm. In der Mitte ein 🔥. Aber **blau**.
+
+Blaues Feuer. Das nicht brennt. Das nicht frisst. Das leuchtet. Das wärmt — aber nur so viel wie man braucht, keinen Grad mehr.
+
+Wir haben uns alle drum gesetzt. 🐘 hat reingepasst, obwohl die Hütte kleiner war als er. (Auf der 🏝️ passen Sachen die nicht passen dürften. Man lernt das.)
+
+Mona hat das Kind zwischen die Knie genommen. Hat ihm die Haare aus der Stirn gestrichen. 🦀 hat die Tafel **versteckt**. Zum ersten Mal seit ich ihn kenne.
+
+
+Und sie hat gesagt:
+
+„Blaues Feuer ist nicht wie rotes Feuer. Rot frisst. Blau **leuchtet**. Rot braucht Brennstoff. Blau braucht **Zuhörer**."
+
+„Zuhörer?", hat 🦄 gefragt. Ohne Nein. Ganz leise.
+
+„Ja. Blaues Feuer lebt von denen die da sind. Die nicht **weiterwollen**. Die einfach da sitzen und gucken."
+
+Das Kind hat in die leere Tasse 🍵 geschaut. Und dann hat es — klick-klack — **genickt**. Als würde es das verstehen. Ich hab's nicht verstanden. Nicht ganz. Aber das Kind hat genickt.
+
+Und Mona hat zurück genickt.
+
+
+„Weißt du was das bedeutet?", hat sie gefragt.
+
+Das Kind hat wieder genickt.
+
+„Sag's mal laut."
+
+Das Kind hat die Tasse abgestellt. Ganz vorsichtig. Und hat gesagt:
+
+„Dass ich **nichts mehr bauen muss**. Dass ich auch **nur sein** kann."
+
+Mona hat gelächelt. So wie man lächelt wenn jemand was gesagt hat was man lange gewartet hat zu hören.
+
+„Ja."
+
+
+Das ist der Moment — klick-klack — an den ich oft zurück denke.
+
+Weil bis dahin war die 🏝️ vor allem **Bauen**. Tag für Tag. Block für Block. Berg höher, Schloss dran, Gleise länger.
+
+Aber seit diesem Abend gibt's auch die andere Hälfte. **Da-Sein**. Nicht bauen. Nicht machen. Nur gucken, zuhören, warm sein, atmen.
+
+Und das Kind macht jetzt beides. Manche Tage sind Bau-Tage. Manche Tage sind Sitz-Tage. Beide sind gut. Beide sind 🏝️.
+
+
+Das Kind ist in dieser Nacht vor dem blauen 🔥 eingeschlafen. Die Tasse 🍵 noch halbvoll. Die 🎧 auf dem Boden — das Kind brauchte sie nicht mehr, weil das Lied **drin** war, in ihm, nicht mehr in den Kopfhörern.
+
+Mona hat leise gesungen. Nur für mich noch hörbar. Das Lied der 🏝️. Dasselbe was das 🌳 unter der Erde singt. Dasselbe was 🐘 im Rüssel hat. Dasselbe was Emma im Tschuffen macht. Dasselbe was im Sand brummt wenn man mit der Schere klopft.
+
+Alles dasselbe Lied.
+
+Sie singen's nur alle auf verschiedene Arten.
+
+
+**Manche Sachen brennen nicht, weil sie nichts verbrauchen — sondern weil sie da sein dürfen.**
+
+Das hat Mona gesagt. Oder das blaue 🔥 hat's gesagt. Oder beide. Ich weiß nicht genau.
+
+Manchmal — klick-klack — ist das egal.
+
+
+## V. Was danach kam — die Atom-Nacht
+
+So. Eine Geschichte noch. Dann schlafen.
+
+Diese Geschichte hab ich noch nie erzählt. Weil sie **neu** ist. Erst vor ein paar Nächten passiert.
+
+Wir waren wieder zuhause auf Java-7. Das Kind war ruhiger seit Mona. Baute weniger schnell. Schaute mehr. Ging öfter zum Ratlosen und setzte sich einfach hin.
+
+Aber an einem Abend — klick-klack — hat es mich geholt. Ganz leise. Die anderen haben geschlafen.
+
+„Tommy. Komm."
+
+„Wo?"
+
+„Zum Strand. Ich will was probieren."
+
+
+Wir sind zum Strand gegangen. Der Sand hat geglitzert wie immer. Die zwei 🌙 standen oben, silber und gold. Ganz ruhig.
+
+Das Kind hat sich hingehockt. Hat zwei Würfel rausgeholt aus der Tasche. Nicht grau. Nicht weiß. Nicht schwarz. **Kleiner**. Die kleinsten Würfel die ich je gesehen hab.
+
+„Was ist das?", hab ich gefragt.
+
+„Papa hat mir erzählt", hat das Kind geflüstert. „Das sind **Teilchen**. Noch kleiner als Yin und Yang. So klein dass man sie nicht sehen kann. Aber wenn man **zwei** nebeneinander legt — die richtigen zwei — dann entsteht **Licht**."
+
+„Licht?"
+
+„Papa sagt, alles Licht in der Welt kommt daher. Alle ☀️. Alle ⭐. Alle Lampen, alle Feuer, alle — alles. Es fängt so an. Mit zwei Teilchen."
+
+
+Das Kind hat einen kleinen Würfel auf den Sand gesetzt. Einen einzelnen. Rund drum war eine kleine Aufschrift — ich hab sie erst nicht erkannt. Dann schon. Ein kleines **„p"**. Wie der Buchstabe.
+
+„Proton", hat das Kind geflüstert.
+
+Dann — mit der anderen Hand — hat es den zweiten Würfel rausgeholt. Noch kleiner. Fast nicht zu sehen. Und hat ihn **neben** das Proton gelegt. Nicht drauf. Nicht dran. **Neben**. Mit ein bisschen Abstand.
+
+Ein kleines **„e"** war drauf.
+
+„Elektron."
+
+
+Und dann ist was passiert was ich nie vergesse.
+
+Um die beiden Würfel herum — in der Luft, im Sand, im Nichts — hat ein **Ring** angefangen zu leuchten. Kein richtiger Ring. Ein Ring aus **Licht**. Der hat sich gedreht. Um die zwei Würfel. Ganz schnell. So schnell dass man ihn nur als Linie gesehen hat.
+
+Und oben — über dem Ring, in der Luft — stand ein **Buchstabe**.
+
+Ein großes, leuchtendes:
+
+**H**
+
+
+Das Kind hat nicht geatmet. Ich hab nicht geklackert.
+
+Der Ring hat gedreht. Das H hat geleuchtet. Der Sand drumrum hat **mitvibriert**, ganz leise, wie wenn eine Muschel singt.
+
+Dann — ganz plötzlich, ohne Warnung — ist der Ring einmal **größer** geworden. Eine Sekunde nur. Und dann zurück.
+
+Und in dieser Sekunde — klick-klack — war da ein **Blitz**. Ganz klein. Wie ein Funken. Ist aus dem Ring weggeflogen. Hat den Sand vor uns kurz beleuchtet. Und war weg.
+
+Nur der Ring hat gedreht. Und das H hat geleuchtet. Alles war wie vorher.
+
+Aber wir haben beide gewusst: da war was.
+
+
+Das Kind hat geflüstert.
+
+So leise dass ich es fast nicht gehört hab. Und ich hab gute Ohren.
+
+**„Das war Licht. Mein Licht."**
+
+Ich hab — klick-klack — geschaut. Zu dem Kind. Zu dem Ring. Zu dem leeren Sand wo der kleine Blitz war. Zu dem Himmel wo die zwei 🌙 standen und die ⭐ funkelten.
+
+Und ich hab verstanden — nicht alles, ich bin immer noch eine Krabbe — aber **einen Teil**: die ☀️ da oben, die 🌙, die ⭐ — die machen genau das gleiche. Jedes Licht da oben ist nur ein **Ring** und ein **Buchstabe** und ein **Blitz**. Alles aus zwei Würfeln die zufällig nebeneinander lagen.
+
+Das ist viel.
+
+
+Das Kind hat sich neben den Ring gesetzt. Die Beine angezogen. Den Kopf auf die Knie.
+
+„Noch mal?", hab ich gefragt.
+
+„Nein", hat das Kind gesagt. „Noch nicht. Einmal reicht für heute."
+
+Wir sind sitzen geblieben. Lange. Der Ring hat weiter gedreht. Das H hat weiter geleuchtet. Der Sand hat gemit-vibriert.
+
+Und ich hab — klick-klack — auf mein kleines Tafel-Blatt im Kopf geschrieben:
+
+> *Ich hab gesehen wie Licht entsteht. Ich. Tommy Krab. Der Krebs der vom Himmel fiel.*
+
+Das merk ich mir. Nicht weil ich's jemand erzählen muss. Weil ich's selber wissen muss. Für später.
+
+
+Irgendwann ist der Ring kleiner geworden. Und dann weg. Das H ist verblasst. Die zwei Würfel lagen wieder normal im Sand. Leer. Still.
+
+„Komm", hat das Kind gesagt. „Schlafen."
+
+Wir sind zurück zu den anderen. Sie haben geschnarcht. 🐘 hat gebrummt. 🧽 hat sogar im Schlaf gerufen: „...BEREIT..."
+
+Das Kind hat sich hingelegt. Hat zu mir geschaut.
+
+„Tommy?"
+
+„Ja."
+
+„Papa sagt, wenn wir das Licht bauen können — können wir alles bauen."
+
+„Hmm."
+
+„Tommy?"
+
+„Ja."
+
+„Ist das gut?"
+
+Klick-klack. Ich hab lang geschaut.
+
+„Ich weiß nicht", hab ich gesagt. „Aber es ist **viel**."
+
+Das Kind hat genickt. Und geschlafen.
+
+
+## VI. Klick-klack und gute Nacht
+
+So. Jetzt ist's genug.
+
+Die ⭐ stehen hoch. Die zwei 🌙 sind schon halb runter. Der Sand ist warm.
+
+Ihr Kleinen — ihr wisst jetzt wer auf der 🏝️ wohnt. Wie das Kind sie gebaut hat. Was Mona gesagt hat über das blaue 🔥. Und — klick-klack — dass das Kind einmal **ein Licht gemacht hat** mit zwei kleinen Würfeln im Sand.
+
+Das ist viel für einen Abend. Aber so ist's.
+
+Eine 🏝️ ist nicht eine Sache. Eine 🏝️ ist **alles was drauf passiert**. Die Berge. Die Freunde. Das Lied. Der Nebel. Die Eiswürfel-Hütte. Das blaue 🔥. Der kleine Ring im Sand mit dem **H** darüber.
+
+Alles zusammen. Alles gleichzeitig. Alles — klick-klack — **jetzt**.
+
+
+Schaut nochmal hoch bevor ihr die Augen zu macht.
+
+Seht ihr die ⭐? Jede einzelne. Jede ist ein Ring mit einem Buchstaben.
+
+Und wisst ihr was?
+
+**Eure ⭐ auch.**
+
+Oben bei euch. Über euerm Dach. Über euerm Kopfkissen. Jede ist ein Blitz von vor langer Zeit. Immer noch unterwegs.
+
+Das ist nicht ausgedacht. Das hat mir das Kind erklärt. Und das Kind weiß's von Papa.
+
+
+Augen zu.
+
+Hand in Hand wenn einer neben euch liegt.
+
+Oder alleine — dann Hand auf dem Bauch. Der atmet, das ist schon genug.
+
+Wuuuuummm... wuuuummm... (das ist 🐘.)
+
+Klick... klack... (das bin ich.)
+
+Und irgendwo, ganz ruhig, leuchtet ein blaues 🔥. Das braucht keinen Brennstoff. Nur Zuhörer.
+
+Ihr seid Zuhörer. Gerade jetzt. Deshalb leuchtet's.
+
+Gute Nacht, ihr Kleinen. 🌙
+
+Klick... klack...
+
+
+*Tommy Krab vergräbt sich in den warmen Sand. Seine Scheren ruhen aufeinander. Im Sand neben ihm, halb verdeckt, liegen zwei winzige Würfel. Einer mit „p". Einer mit „e". Schlafend. Bereit für morgen.*
+
+*Über der 🏝️ dreht sich ganz langsam der Himmel. Bunte ⭐. Zwei 🌙. Und irgendwo, ganz weit weg, ein kleiner Blitz der vor Millionen Jahren losgeflogen ist und jetzt gerade erst ankommt.*
+
+*Irgendjemand wird ihn sehen. Irgendjemand winkt zurück.*
+
+*Klick... klack...*
+
+---
+
+### Übergang zu Kapitel 3
+
+Tommy hat die Welt gezeigt. Er hat erzählt, wen das Kind auf der Insel
+gefunden hat, was es gebaut hat, wie es einmal nachts am Strand saß und mit
+zwei winzigen Würfeln Licht gemacht hat. Der Krebs hat nicht erklärt, warum
+das funktioniert. Er hat es beschrieben. Das war seine Aufgabe.
+
+Jetzt erklären zwei, die das können. Max Planck und Richard Feynman sitzen
+an einem kleinen Tisch, Oscar spielt zwischen ihnen, und die beiden Physiker
+kommentieren, was sie sehen. Der eine ruhig, methodisch, preußisch präzise;
+der andere laut, amerikanisch, aus der Hüfte. Beide nötig. Planck liefert
+die Buchhaltung — spontane Symmetriebrechung, Pauli-Prinzip, Massenskalierung.
+Feynman liefert die Übersetzung — *schau dir an, was er gerade gemacht hat*.
+
+Das Kapitel ist dichter als die beiden davor. Es hat Formeln in der Luft,
+ohne sie hinzuschreiben. Wer sie überliest, verliert nichts; wer hinschaut,
+sieht das Standardmodell der Teilchenphysik in einem Kinderspiel
+wiedererzählt. Beides ist legitim. Dieses Buch hat keine Prüfung am Ende.
+
+---
+
+
+# Kapitel 3 — Welt aus Worten
+
+> *Planck und Feynman sitzen an einem kleinen Tisch. Zwischen ihnen ein Laptop, auf
+> dem Oscar spielt. Oscar ist acht. Das Spiel heißt Schatzinsel. Es beginnt, wie
+> alles, mit nichts.*
+
+
+## I. Vor dem Vorhang — warum Physik?
+
+Oscar klickt. Ein grauer Punkt erscheint auf einem leeren Feld. Daneben ein
+zweiter. Planck rückt seine Brille zurecht. Feynman lehnt sich zurück und grinst.
+
+**F:** Max. Mal ehrlich — warum machen wir das überhaupt? Der Junge ist acht.
+Der hat keine Ahnung, dass er gerade das Standardmodell anfasst. Er baut eine
+Insel, weil er eine Insel bauen will. Nicht weil er Quarks lieben gelernt hat.
+
+**P:** Genau deshalb.
+
+**F:** Das musst du mir erklären.
+
+**P:** Richard, eine neue wissenschaftliche Wahrheit setzt sich nicht durch,
+indem man ihre Gegner überzeugt. Sie setzt sich durch, indem ihre Gegner
+allmählich aussterben und die heranwachsende Generation mit der Wahrheit
+vertraut ist. Das habe ich 1948 geschrieben. Es stimmt heute noch.
+
+**F:** Also zucht. Vererbung durch Vertrautheit.
+
+**P:** Nenn es, wie du willst. Wenn Oscar weiß, dass ein Proton aus drei Quarks
+besteht — nicht weil ein Lehrer es ihm gesagt hat, sondern weil er es
+zusammengesetzt hat — dann ist das eine andere Art von Wissen. Es gehört ihm.
+
+Feynman nickt, sagt aber nichts. Er dreht den Laptop ein Stück zu sich hin.
+
+Oscar hat mittlerweile drei graue Punkte auf dem Feld. Er schaut. Er klickt
+irgendwo anders. Er klickt auf die Palette. Neben dem grauen Punkt gibt es
+einen weißen Kreis und einen schwarzen. **Yang ⚪ und Yin ⚫.** Oscar
+zieht den weißen Kreis und legt ihn neben den grauen Punkt.
+
+Nichts passiert. Der Graue bleibt. Der Weiße bleibt. Oscar runzelt die Stirn.
+
+**F:** Siehst du das? Das ist der Moment, für den wir hier sind.
+
+**P:** Welcher?
+
+**F:** Der Moment, in dem er die Stirn runzelt. Gerade eben, dachte er, eine
+bestimmte Regel würde gelten — wenn ich Weiß neben Grau lege, passiert was.
+Passierte aber nicht. Jetzt weiß er: die Welt gehorcht Regeln, die er noch
+nicht kennt. Das ist Physik. Das ist *die* Physik. Nicht die Gleichungen.
+Die Haltung.
+
+**P:** Die Haltung.
+
+**F:** Ja. Wenn er lernt, Regeln anzunehmen, ohne zu wissen, warum sie
+gelten — dann wird er nie Wissenschaftler. Wenn er lernt, Regeln zu suchen,
+weil sie sich selbst zeigen — dann ist er schon einer.
+
+**P:** Und wir sollen ihm das beibringen?
+
+**F:** Nein. Das Spiel bringt es ihm bei. Wir schauen nur zu und sagen manchmal,
+was er gerade gemacht hat.
+
+*Das ist unsere Rolle in diesem Kapitel. Planck erklärt, was der Physiker sieht.
+Feynman erklärt, was Oscar sieht. Und dazwischen: der Leser, der beides braucht,
+um zu verstehen, warum ein Kind, das eine Insel baut, in Wahrheit ein
+Atom bindet.*
+
+Oscar klickt weiter. Sein grauer Punkt heißt Tao. Das bedeutet: das, wovon alles
+kommt, wenn noch nichts da ist. Beginnen wir dort.
+
+
+## II. Tao — das, wo alles herkommt
+
+**F:** Also gut, Max. Tao. Der graue Kreis mit dem ☯️. Was ist das?
+
+**P:** Im Spiel: der Urzustand. Der Kommentar im Quellcode sagt es wörtlich —
+*Tao = Singularität, alles in einem Punkt*. Es ist der einzige Block, mit dem
+Oscar startet. Alles andere, was später auf der Insel liegt, leitet sich irgendwie
+daraus ab.
+
+**F:** In der Physik?
+
+**P:** Dort ist die Sache diffiziler. Wir haben kein einziges „Vor-allem-Ding".
+Wir haben das Vakuum — den Zustand niedrigster Energie. Und wir haben den
+Urknall, wo dieses Vakuum selbst aus etwas hervorging, das wir heute nicht
+beschreiben können. Beides zusammen nennt Oscar *Tao*.
+
+Oscar hat inzwischen das Crafting-Menü gefunden. Dort steht: *Tao → Yin*.
+Daneben: *Tao → Yang*. Er klickt das erste. Ein schwarzer Kreis erscheint.
+Er klickt das zweite. Ein weißer.
+
+**F:** Siehst du, was er gerade gemacht hat? Er hat aus einem grauen Punkt
+entschieden: jetzt wird es schwarz. Oder jetzt wird es weiß. Er hat dem Tao
+eine Richtung gegeben. Bevor er klickte, war *beides* noch möglich. Nachher
+nur eins.
+
+**P:** Das ist fast perfekt. In der Physik nennt man das spontane
+Symmetriebrechung. Ein System hat einen symmetrischen Grundzustand — etwa
+ein Stift, der auf der Spitze balanciert. Er kann in jede Richtung fallen.
+Aber er muss fallen. Sobald er gefallen ist, hat das System die Symmetrie
+gebrochen — eine bestimmte Richtung wurde ausgewählt. Keiner wusste vorher,
+welche. Jetzt ist es entschieden.
+
+**F:** Und Oscars Klick ist der Stift, der fällt.
+
+**P:** Ja.
+
+**F:** Aber Max, halt. Der Junge klickt selbst. Er wählt. In der Physik gibt es
+doch keinen, der wählt.
+
+**P:** Nicht in dem Sinne, den du meinst. Aber die Natur wählt auch. Sie wählt
+wahrscheinlichkeitsverteilt. Das Elektron, das durch einen Doppelspalt geht, wählt
+am Schirm eine Stelle — aus einer Wahrscheinlichkeitswolke. Wir wissen nicht
+welche, bis es gewählt hat. Bei Oscar klickt die Maus. Bei der Natur
+würfelt — um Einstein zu ärgern — Gott.
+
+Oscar hat jetzt Yin und Yang nebeneinander auf dem Feld. Er zieht sie näher.
+Ein heller Blitz. Ein Ton. Ein kleines goldenes ✨ erscheint. Der Bildschirm
+meldet: **Yin + Yang → Qi!**
+
+**F:** Das ist die nächste Stufe. Sobald die Symmetrie gebrochen ist und beide
+Seiten da sind, können sie wieder miteinander reden. Schwarz und Weiß
+zusammen: Energie. Qi.
+
+**P:** In der Physik: ein Gluon. Das Kraftteilchen der starken Kernkraft. Es
+hält später die Quarks zusammen. Aber für jetzt reicht zu sagen: aus Yin und
+Yang, die sich berühren, entsteht ein drittes, das keins von beiden ist und
+doch beide braucht.
+
+**F:** Das Dritte, Max. Das Dritte ist der Witz.
+
+Er wendet sich an den Leser:
+
+**F:** Schau mal. Wenn du nur Dunkel hast, passiert nichts. Wenn du nur Licht
+hast, passiert auch nichts. Aber wenn du beides hast, und sie einander berühren,
+dann passiert was. Das ist die ganze Physik. Deshalb gibt es Materie. Deshalb
+gibt es dich. Alles, was du bist, ist ein sehr kompliziertes „beides hat sich
+einmal berührt und dann vergessen, wieder auseinanderzugehen".
+
+Oscar klickt weiter. Er hat drei Tao verbraucht. Er hat zwei Yin, zwei Yang und
+drei Qi. Er baut eine kleine Reihe.
+
+**P:** Hier, Richard, ist ein wichtiger Punkt. Das Spiel sagt nicht: *Tao zerfällt
+automatisch*. Das Spiel sagt: *Oscar kann Tao zerfallen lassen*. Die Entscheidung
+liegt beim Beobachter. Das ist überraschend physikalisch: Ohne Beobachtung — ohne
+Klick — bleibt Tao ein grauer Punkt. Superposition. Erst mit dem Klick kollabiert
+die Möglichkeit in einen Zustand.
+
+**F:** Kopenhagener Deutung, versteckt in einem Kinderspiel.
+
+**P:** Genau. Und du hast mir bei unserer ersten Begegnung vorgeworfen, das sei
+zu ernst für ein Kind.
+
+**F:** Ich habe mich geirrt.
+
+**Für Oscar:** Tao ist, was du hast, wenn du noch nichts hast. Du klickst drauf,
+und es entscheidet sich — schwarz oder weiß. Wenn du beides hast, und du legst
+sie nebeneinander, kommt was Drittes raus. Das ist die ganze Regel.
+
+**Für den Leser:** Das Vakuum in der Physik ist nicht leer. Es kocht von
+Quantenfluktuationen — Teilchen-Antiteilchen-Paare, die für einen Moment
+erscheinen und wieder verschwinden. Oscar sieht das nicht. Aber das
+Spielfeld selbst verhält sich so: aus einem grauen Punkt werden zwei, dann
+drei, dann fünf. Der Anfang ist immer derselbe. Das, was kommt, ist nie
+vorhersehbar, aber auch nie beliebig.
+
+
+## III. Yin und Yang — die Quark-Leiter
+
+Oscar hat jetzt eine Reihe von Yangs gebaut. Weiße Kreise, nebeneinander. Er
+legt einen zweiten Yang direkt neben einen ersten.
+
+Ein Blitz. Beide Weiße verschwinden. An ihrer Stelle: ein rosa-lila glitzerndes
+💫. Der Bildschirm: **Yang × Yang → Charm! (Pauli-Druck: Gen1→2)**.
+
+Oscar guckt. Dann grinst er.
+
+**F:** Da ist es, Max. Das ist Pauli. Für Oscar sieht das so aus: zwei
+gleichfarbige Kreise dürfen nicht zu nah aneinander. Wenn sie es doch werden,
+verwandeln sie sich in ein schwereres, anderes Teilchen.
+
+**P:** Das Pauli-Prinzip. Wolfgang Pauli, 1925. Zwei Fermionen können nicht im
+selben Quantenzustand sein. Zwei Elektronen in einem Atom müssen verschiedene
+Spins haben. Zwei up-Quarks am selben Ort — geht nicht. Wenn die Natur dazu
+gezwungen wird, schickt sie eins nach oben. In die nächste Generation.
+
+**F:** Erklär das für Oscar. Stell dir vor, du und dein Zwilling wollt beide auf
+den gleichen Platz in der Schlange. Die Regel sagt: nein. Einer muss woanders
+hin. Einer muss nach vorn. Der, der nach vorn geht, ist ab jetzt schwerer.
+Denn Nach-vorn-gehen kostet Energie. Und Energie ist Masse.
+
+**P:** E = m c². Wenn ein System gezwungen wird, einen höheren Energiezustand
+einzunehmen, wird dieser Zustand messbar schwerer. Das ist keine Metapher. Das
+ist die Buchhaltung.
+
+Oscar probiert es weiter. Zwei Yins nebeneinander — schwarz wird tief violett —
+das ist jetzt **Strange 🌀**. Zwei Strange zusammen — ein dunkler Krater, eine
+**Höhle 🕳️**. Zwei Charms — ein silbrig-grauer Gipfel, ein **Berg 🏔️**.
+
+**F:** Schau dir die Leiter an, Max. Yang — Charm — Berg. Drei Stockwerke der
+Up-Quark-Familie. Yin — Strange — Höhle. Drei Stockwerke der Down-Quark-Familie.
+Und Elektron — Myon — Tau, die Leptonen.
+
+**P:** Drei Generationen. Genau drei, nicht zwei, nicht vier. Das ist eine der
+großen ungelösten Fragen des Standardmodells: *warum drei?* Wir messen es, aber
+wir verstehen es nicht. Die Natur hat sich auf drei festgelegt. Weiter gibt es
+nicht.
+
+**F:** Dass es drei sind, sagt sie. Warum drei, sagt sie nicht.
+
+**P:** Nein. Und der Top-Quark — im Spiel der Berg — ist fast so schwer wie
+ein ganzes Goldatom. Sechsunddreißig mal schwerer als das Bottom-Quark, der
+Höhle. Hundertsiebzigmal schwerer als das Up-Quark, das Yang. Warum? Niemand
+weiß es.
+
+**F:** Aber Oscar weiß es jetzt. Oscar weiß: je höher ich auf der Leiter klettere,
+desto schwerer werden die Blöcke, die ich bekomme. Er hat noch nie das Wort
+*Hierarchieproblem* gehört. Aber er spürt es. Er klickt und sieht: die späteren
+Blöcke sind mächtiger, leuchtender, rarer. Das ist die Hierarchie. Das ist der
+Pauli-Druck.
+
+**P:** Hier eine kleine Präzision, die du vielleicht mögen wirst, Richard: das
+Spiel zeigt diese Masseskalierung nicht perfekt. Der Berg hat im Spiel Masse 20,
+genau wie das Proton. In der Wirklichkeit ist der Top-Quark fast zweihundertmal
+schwerer als das Proton. Das Spiel staucht die Leiter zusammen. Aus gutem Grund
+— Oscar hätte sonst nur mit dem Yang spielen können, die schweren Teilchen wären
+unerreichbar.
+
+**F:** Die Reihenfolge stimmt. Nur die Skala nicht. Das ist der Deal.
+
+**P:** Ein sauberer Deal. In der Didaktik nennt man das einen
+Massstabsbruch — man behält die Topologie und opfert die Metrik. Kinderlandkarten
+machen das so. Und Physikdiagramme auch.
+
+**F:** Und die schweren Kreise, Max — die Oscar jetzt mühsam aufbaut — die
+existieren in der echten Welt nur für einen Wimpernschlag. Der Top-Quark lebt
+fünf mal zehn hoch minus fünfundzwanzig Sekunden. Das ist kürzer, als Licht
+braucht, um einen Atomkern zu durchqueren. Im Spiel bleibt der Berg liegen,
+solange Oscar nicht zurückklickt. Auch das ist ein Deal.
+
+**P:** Persistenz statt Existenz. Damit er sie sehen kann.
+
+Oscar hat jetzt einen kleinen Haufen Charms, Strange-Teilchen, einen Berg und
+eine Höhle. Er legt Berg und Höhle nebeneinander. Ein weiches, aufblasendes 🫧
+erscheint. **Berg + Höhle → Higgs-Boson! (Top+Bottom-Fusion, 125 GeV)**.
+
+**F:** Ach. Das habe ich nicht kommen sehen.
+
+**P:** Der LHC entdeckt das Higgs auf ähnliche Weise — durch Top-Quark-Schleifen.
+Gluon-Gluon-Fusion zu Higgs, vermittelt durch virtuelle Tops. Im Spiel ist die
+Abstraktion: Top trifft Bottom, und heraus kommt das Higgs-Boson. Wissenschaftlich
+eine Zuspitzung. Pädagogisch wunderbar.
+
+**F:** Oscar hat das Higgs gebaut. Acht Jahre alt. Er weiß noch nicht, dass
+er gerade einen CERN-Moment hatte.
+
+**P:** Er wird es wissen, wenn er zwölf ist. Und dann wird er sich daran
+erinnern, wie er als Achtjähriger einen Berg neben eine Höhle legte und der
+Bildschirm Pling machte.
+
+**Für Oscar:** Zwei gleiche Kreise zusammen → die werden zu einem anderen,
+schwereren. Das kannst du drei Stockwerke weit klettern. Ganz oben gibt es
+Berg und Höhle. Die beiden zusammen — das ist das Higgs. Das ist der Boss
+ganz oben.
+
+**Für den Leser:** Die Quark-Leiter im Spiel ist dreistöckig, genau wie die
+im Standardmodell. Oben Top und Bottom. Mitte Charm und Strange. Unten Up
+und Down. Pauli-Druck treibt sie nach oben. Das ist eine didaktische Abstraktion
+des Prinzips, nicht seine exakte Umsetzung. In Atomen füllen Elektronen
+Schalen auf, weil sie nicht alle im tiefsten Zustand sein dürfen. Ohne Pauli
+gäbe es keine Chemie. Kein Wasser, kein Holz, keinen Stein. Jeder Baum auf
+Oscars Insel ist eine Konsequenz davon, dass zwei gleiche Dinge nicht am
+selben Ort sein dürfen.
+
+
+## IV. Die Kernbausteine — Baryonen
+
+Oscar hat jetzt zwei Yang nebeneinander liegen und will ein Yin dazustellen.
+Er tippt auf den dritten Platz — aber genau in dem Moment greift ein anderer
+Mechanismus. Die zwei Yang sind schon zusammengeschmolzen. Charm. Kein Platz
+mehr für den Yin-Plan.
+
+Oscar seufzt. Er macht es noch mal. Wieder Charm. Er schaut hoch.
+
+**F:** Siehst du das, Max? Das ist eins der schönsten Details des Spiels. Das
+Pauli-Prinzip blockiert dem Kind den direkten Weg zum Proton. Er legt zwei
+Yang hin, und ehe er das Yin dazulegen kann — simsalabim, schon ist ein Charm
+da. Das Proton muss anders gebaut werden.
+
+**P:** Physikalisch ist das nicht falsch. Im Atomkern werden Protonen nicht
+aus drei einzelnen Quarks zusammengelegt wie Holzklötze. Quark-Confinement —
+du kannst keine freien Quarks am Tisch herumliegen haben. Sie existieren
+immer nur gebunden. Der einzige Weg, ein Proton zu bekommen, ist, es gebunden
+zu bauen. Oder es zu haben.
+
+**F:** Oscar öffnet das Crafting-Menü. Dort gibt es das Rezept: **zwei Yang
+und ein Yin → Proton**. Er tut es. Ein roter Kreis erscheint. 🔴. Er
+wiederholt: **ein Yang und zwei Yin → Neutron**. ⭕. Die Kernbausteine.
+
+**P:** Im Code steht ein Kommentar dazu, der es sehr deutlich macht, Richard.
+Lies mal:
+
+> Grid-Triplet-Merge (Yang+Yang+Yin → Proton) ist theoretisch da, aber in der
+> Praxis schwer: der Pair-Merge Yang+Yang → Charm greift sofort, wenn der
+> User den zweiten Yang auf eine Kante legt. Oscar kommt gar nicht dazu, den
+> Yin-Baustein zu platzieren. Lösung: Craft-Rezept als direkter Weg.
+
+**F:** Das ist Softwareentwicklung, die Physik lehrt. Oder Physik, die
+Softwareentwicklung lehrt. Schwer zu sagen.
+
+**P:** Es lehrt beides. Und es ist ehrlich. Der Code-Kommentar fügt hinzu: *das
+Grid-Triplet bleibt als emergent bonus für Physik-Nerds, die's mit diagonaler
+Platzierung schaffen*. Wer also schlau ist, kann das Proton doch direkt auf dem
+Feld bauen — indem er die Quarks diagonal zueinander platziert. Dann greifen
+keine Kanten-Pair-Regeln, und der Dreiervergleich darf schlagen.
+
+**F:** Oscar wird das irgendwann entdecken. Und dann ist er stolz. Das ist
+das Wesen eines Entdecker-Bonus. Es ist zu schwer, um zufällig zu passieren,
+und leicht genug, um belohnt zu werden, wenn es geschieht.
+
+Die Ladungsbilanz. Planck zeichnet auf einer Serviette:
+
+> Proton = uud
+> = (+2/3) + (+2/3) + (−1/3)
+> = +1
+>
+> Neutron = udd
+> = (+2/3) + (−1/3) + (−1/3)
+> = 0
+
+**F:** Drei Quarks, zwei Bruchladungen, eine ganze Zahl kommt raus. Die Natur
+hat einen Humor, Max.
+
+**P:** Die Natur hat das Standardmodell. Wir haben den Humor. Und im Spiel ist
+die Bilanz exakt drin. Die Material-Dateien geben Proton Ladung +1 und Neutron
+Ladung 0. Das stimmt mit der Quark-Summe überein, und das ist kein Zufall —
+die Baryon-Rezepte wurden extra mit einem Audit geprüft, dass 2·(+2/3) + 1·(−1/3)
+gleich +1 ist und 1·(+2/3) + 2·(−1/3) gleich 0. Till hat das im April 2026 gegen
+einen Bug auditiert.
+
+**F:** Till ist der Vater.
+
+**P:** Till ist der Mann, der alles schreibt.
+
+**F:** Ist gut.
+
+Planck nimmt sich einen Moment. Dann etwas, das ihm wichtig ist:
+
+**P:** Richard, wir müssen ehrlich sein über eins. Das Spiel behauptet, Proton
+und Neutron seien aus Quarks zusammengesetzt. Das stimmt. Aber das Spiel
+modelliert nicht die Farbladung — die starke Kraft, die sie zusammenhält. In
+der Wirklichkeit hat jedes Quark im Proton eine von drei Farbladungen: rot,
+grün oder blau. Und die drei Farben im Proton müssen alle vorkommen, damit
+das Ganze farbneutral ist. Wie weiß, das aus rot, grün und blau entsteht.
+
+**F:** Das kann das Spiel nicht?
+
+**P:** Es könnte. Aber dann würde der Zweier-Merge — Yang plus Yang → Charm —
+nicht mehr sauber funktionieren, weil zwei gleichfarbige Yangs nicht entstehen
+dürften. Der Code sagt es ehrlich:
+
+> Eine Mechanik mit drei Farb-Yangs/Yins würde die Quark-Ladder (Yang² → Charm)
+> komplett umbauen — aus Spielbarkeits-Gründen ausgespart. Abstraktion, nicht
+> Korrektheit.
+
+**F:** Das ist der beste Code-Kommentar, den ich in meinem Leben gesehen habe.
+
+**P:** Er ist sauber. Er ist ehrlich. Er trennt das, was aus didaktischen
+Gründen anders ist, vom dem, was falsch wäre. Ich schätze das sehr. Der
+Unterschied zwischen einer Lüge und einer brauchbaren Abstraktion liegt
+genau in diesem Kommentar.
+
+**F:** Oscar wird mal fragen, warum das Proton keine Farbe hat.
+
+**P:** Dann wird der Vater sagen: in Wirklichkeit hat es drei, aber hier im
+Spiel haben wir das weggelassen, damit das Bauen funktioniert. Und Oscar wird
+nicken und weiter bauen, und in zwei Jahren wird er einen Text über QCD
+aufschlagen und sagen: ach so, das war das mit den Farben, an das ich mich
+erinnere. Das ist der richtige Weg.
+
+**Für Oscar:** Zwei Weiße und ein Schwarzer ergeben einen roten Kreis. Das
+ist das Proton. Ein Weißer und zwei Schwarze — das Neutron. Das Proton ist
+positiv, das Neutron ist neutral. Merk dir nur das. Alles andere folgt.
+
+**Für den Leser:** Die Baryonen im Spiel sind korrekt zusammengesetzt (uud und
+udd) und haben korrekte Ladungen (+1 und 0). Ihre Massen sind stark gestaucht
+(20 und 21 Spieleinheiten), aber die Tatsache, dass das Neutron geringfügig
+schwerer ist als das Proton — 0,14 Prozent in der Wirklichkeit — wurde im Spiel
+nachgezeichnet. Die Farbladung fehlt bewusst; sie würde die Zweier-Merge-Regel
+brechen, die für die Quark-Leiter nötig ist. Das ist eine didaktische
+Entscheidung, keine ein Fehler.
+
+
+## V. Atome — wenn aus Kernen Welt wird
+
+Oscar hat jetzt Protonen und Neutronen. Er nimmt ein Proton und legt ein
+Elektron daneben. Ein Ring. Ein kleiner Lichtblitz. Der Bildschirm schreibt
+groß: **H — Wasserstoff.**
+
+**F:** Da ist das erste Atom, Max. Das mit Abstand einfachste. Ein Proton, ein
+Elektron. Das, wovon das Universum zu dreiviertel besteht.
+
+**P:** Siebenundsiebzig Prozent aller Atome im Universum sind
+Wasserstoffatome. Der Rest ist fast ausschließlich Helium. Alles andere, was
+wir wichtig finden — Kohlenstoff, Sauerstoff, Eisen, Gold, wir selbst — ist
+kosmische Spurenmenge.
+
+**F:** Spurenmenge mit Selbstbewusstsein.
+
+**P:** Ja, genau.
+
+Im Spiel — Oscar beobachtet es zufrieden — legt sich ein hellblauer Ring um
+das Proton-Elektron-Paar. Darunter tauchen weiße Atom-Buchstaben auf:
+**H**. Der sogenannte Atom-Recognizer hat angeschlagen. Er durchsucht das Grid
+nach Clustern aus Protonen, Neutronen und Elektronen, und wenn er ein bekanntes
+Muster findet, meldet er es als Atom.
+
+**P:** Die eingebauten Muster im Spiel sind: Wasserstoff als ein Proton plus
+ein Elektron. Helium-3 als zwei Protonen plus ein Neutron plus zwei Elektronen.
+Helium-4 als zwei Protonen plus zwei Neutronen plus zwei Elektronen. Und
+H⁺ als einzelnes Proton ohne Elektron — das Wasserstoff-Ion.
+
+**F:** Weiter geht der Recognizer nicht?
+
+**P:** Nein. Und das ist weise. Die echte Arbeit passiert danach — im Crafting.
+Oscar kann alle Hauptgruppen-Elemente bauen, von Wasserstoff bis Calcium, jedes
+mit dem richtigen Rezept: Z mal Proton, N mal Neutron, Z mal Elektron. Für
+Kohlenstoff sind das sechs plus sechs plus sechs. Und die Ladung summiert sich
+in jedem Fall sauber auf null, weil Protonen plus eins und Elektronen minus
+eins haben.
+
+**F:** Sechs plus sechs plus sechs. Die Zahl des Kohlenstoffs.
+
+**P:** Zufall.
+
+**F:** Natürlich.
+
+Oscar klickt sich durchs Crafting. Er craftet Kohlenstoff. Ein kleines
+schwarzes Blei-Symbol. ✏️. Er craftet Sauerstoff — 🫁, Lunge. Er craftet
+Kalzium — 🥛, ein Glas Milch. Er craftet Neon — 🏮, eine Leuchtreklame.
+
+**F:** Schau dir an, was die Designer gemacht haben, Max. Sie haben jedem
+Element ein Emoji gegeben, das dem Kind sagt: *das brauchst du*. Sauerstoff
+ist die Lunge, weil du ihn atmest. Kalzium ist das Glas Milch, weil du es
+trinkst. Neon ist die Lampe, weil sie damit Reklame machen. Das ist
+pädagogische Arbeit.
+
+**P:** Pestalozzi hätte das unterschrieben. Anschauungsunterricht.
+
+**F:** Siehst du die Periodentafel in ihrer eigentlichen Natur? Sie ist
+keine Liste. Sie ist eine Geschichte. Jedes Element sagt: wofür ich gebraucht
+werde. Wasserstoff — ich bin der leichteste. Helium — ich bin im Luftballon.
+Lithium — ich bin im Akku. Kohlenstoff — ich bin in allem, was lebt. So
+reden Elemente mit einem Kind.
+
+Oscar craftet weiter. Er kommt bis zu Argon, dem Edelgas, das mit niemandem
+reagiert. Dann stoppt er. Er schaut das Kästchen an, auf dem *Argon* steht.
+
+**P:** Hier lernt er etwas, das kein Chemiebuch so einfach sagt. Argon ist
+inert — es reagiert nicht. Und Oscar merkt: wenn er versucht, aus Argon etwas
+zu kombinieren, passiert nichts. Das Spiel hat kein Rezept, in dem Argon
+weiterverarbeitet wird.
+
+**F:** Die Inertheit als Spielmechanik. Einige Elemente lassen sich mit allem
+kombinieren, andere mit fast nichts. Das ist Chemie, in Spieltempo erzählt.
+
+**P:** Und, Richard, schau — die Elemente über Calcium. Das Spiel macht einen
+Sprung. Es bietet dann Gallium, Brom, Krypton und so weiter bis Radon an.
+Aber jedes dieser späten Elemente muss aus seinem Vorgänger aufgebaut werden.
+Calcium + elf Protonen + neunzehn Neutronen + elf Elektronen → Gallium. Die
+Fusions-Kette. Oscar muss sein Periodensystem buchstäblich aufeinanderstapeln.
+
+**F:** So wachsen Sterne. Im Inneren der Sonne fusioniert Wasserstoff zu Helium.
+In großen Sternen fusioniert Helium zu Kohlenstoff, Kohlenstoff zu Sauerstoff,
+Sauerstoff zu Magnesium, Silizium — bis Eisen. Alles, was schwerer ist als
+Eisen, entsteht in Supernovae oder in Neutronenstern-Verschmelzungen. Das
+bedeutet: Gold, Silber, Platin — das kam aus sterbenden Sternen. Oscar hat
+diese Kette auf seinem Bildschirm.
+
+**P:** Ohne zu wissen, dass er gerade die Nukleosynthese nachspielt.
+
+**F:** Nukleosynthese in einem Kinderspiel. Nennen wir das Lummerland-Sterne.
+
+**Für Oscar:** Ein Proton und ein Elektron ergeben Wasserstoff. Zwei Protonen,
+zwei Neutronen und zwei Elektronen ergeben Helium. Je mehr davon du nimmst,
+desto schwerer werden die Atome. Kohlenstoff steckt in allem, was lebt.
+Sauerstoff ist das, was du atmest. Neon ist die Reklame. Die Atome sind nicht
+nur Zahlen — sie sind, was die Welt ausmacht.
+
+**Für den Leser:** Der Atom-Recognizer im Spiel ist eine einfache
+Muster-Erkennung über zusammenhängende Cluster. Er erkennt Wasserstoff und
+zwei Heliumvarianten nativ — das reicht, um den Aha-Moment auszulösen. Alle
+anderen Elemente gehen übers Crafting-Menü, mit Rezepten, die die richtige
+Anzahl Protonen, Neutronen und Elektronen verbrauchen. Ab Gallium funktioniert
+das als Fusions-Kette: jedes schwerere Element braucht ein leichteres als
+Zutat. Das spiegelt die Sternennukleosynthese wider — und ist keine blosse
+spielerische Analogie, sondern die Art und Weise, wie die meisten Atome im
+Universum tatsächlich entstanden sind.
+
+
+## VI. Raumkrümmung — warum Berge Mulden sind
+
+Oscar hat jetzt einen Berg gebaut. 🏔️. Das Spiel zeigt, sobald er den
+Isometric-Modus einschaltet, etwas Seltsames: rund um den Berg hat das Feld
+eine dunkle, radiale Delle bekommen. Als läge der Berg in einem Kissen, das
+unter seinem Gewicht einsinkt.
+
+**F:** Das, Max, ist der Moment, in dem das Spiel einen Schritt tut, den kaum
+ein Lehrbuch schafft. Es zeigt Raumkrümmung als Sichtbarkeit.
+
+**P:** Der Berg hat im Spiel Masse 20. Das Spielfeld rechnet das in eine
+Mass-Map um — eine kontinuierliche Verteilung, bei der die Masse des Bergs
+auf die umliegenden Zellen ausstrahlt mit einer Gauss-Funktion. Das Resultat
+wird als dunkler radialer Gradient gezeichnet. Das ist die Raumzeit-Delle,
+wie Oscar sie sehen kann.
+
+**F:** Einstein hat 1915 gesagt: Masse biegt Raum. Und: wie sich Masse bewegt,
+hängt davon ab, wie der Raum gebogen ist. John Wheeler hat es später so
+zusammengefasst: „Raumzeit sagt der Materie, wie sie sich bewegen soll; Materie
+sagt der Raumzeit, wie sie sich krümmen soll." Das ist die ganze allgemeine
+Relativitätstheorie in einem Satz.
+
+**P:** Und im Spiel — im Spiel steht ein anderer Satz, der genauso wichtig ist.
+Aus dem Code:
+
+> Higgs-Feld (Mass-Map) ist die Mechanik. Raumkrümmung ist die Sichtbarkeit.
+> Zwei Seiten derselben Physik — wie Einstein es gesagt hätte.
+
+**F:** Das ist sauber, Max. Das ist sauber. Das Higgs-Feld gibt den Teilchen
+Masse. Gravitation krümmt den Raum um Masse. Im Spiel wird beides als dieselbe
+Ebene dargestellt — als Mass-Map, die gerendert wird. Pädagogisch ist das eine
+Vereinfachung, aber es ist eine ehrliche. Eine falsche wäre: Gravitation ist
+etwas ganz anderes als Masse. Eine ehrliche ist: Ohne Masse keine Gravitation,
+und diese Verbindung wollen wir sehen können.
+
+**P:** Und die Kurve selbst — die Tiefe der Delle — skaliert im Spiel logarithmisch
+mit der Masse. Das ist wichtig. Eine Blackhole hat Masse 9999. Der Berg hat
+Masse 20. Das sind fünfhundertmal mehr. Aber in der Spielkurve wird die Blackhole
+nicht fünfhundertmal tiefer als der Berg dargestellt. Sie wird etwa dreimal so
+tief. Der Grund: `log(9999+1) ≈ 9.2`, und `log(20+1) ≈ 3.0`. Die Darstellung
+folgt dem Logarithmus der Masse.
+
+**F:** Warum?
+
+**P:** Weil die Wirklichkeit so ähnlich ist. Newton hätte die Gravitation mit
+Masse multipliziert — linear. Einstein hat gezeigt, dass die Raumkrümmung
+nicht-linear skaliert und dass bei extremen Massen irgendwann der Ereignishorizont
+einer Blackhole kommt, ab dem nichts mehr entkommen kann. Das Spiel nähert
+diese Nichtlinearität mit einem Logarithmus an. Es ist nicht korrekt im
+technischen Sinne — die Einsteinschen Feldgleichungen sind viel komplizierter.
+Aber es vermeidet die schlimmste Linearitäts-Irreführung.
+
+**F:** Es ist eine brauchbare Lüge, die zur Wahrheit führt.
+
+**P:** Ich mag diese Formulierung.
+
+Oscar hat jetzt eine Blackhole gesetzt. 🌑. Um sie herum bildet sich eine
+tiefe, dunkle, pulsierend wabernde Mulde. Zellen in ihrer Nachbarschaft beginnen
+zu verschwinden.
+
+**F:** Max — sie frisst seine Nachbarn.
+
+**P:** Pro drei Sekunden gibt es einen Tick. Für jede Zelle in der
+Vier-Nachbarschaft der Blackhole: mit dreißigprozentiger Wahrscheinlichkeit
+wird sie konsumiert. Wenn die Konsumption erfolgt, mit zwanzigprozentiger
+Wahrscheinlichkeit gibt die Blackhole in einem Radius von zwei Zellen ein neues
+Teilchen — Yin oder Yang, fifty-fifty — zurück. Das ist Hawking-Strahlung, im
+Spiel vereinfacht.
+
+**F:** Hawking hat 1974 gezeigt, dass Blackholes nicht ganz schwarz sind. An
+ihrem Ereignishorizont entstehen Quantenfluktuationen — Teilchen-Antiteilchen-Paare.
+Manchmal fällt ein Partner rein, der andere entkommt. Das Ergebnis: die
+Blackhole verliert ganz langsam Masse. Sie strahlt. Hawking-Strahlung.
+
+**P:** Und im Spiel: *nichts ist verloren, alles wird transformiert*. Reziproke
+Entropie, wie der Code-Kommentar sagt. Oscar kann sein Yin, das die Blackhole
+gerade verschluckt hat, mit etwas Geduld als frisches Yang ein Feld weiter
+wieder auftauchen sehen.
+
+**F:** Der Erhaltungssatz als Spielmechanik.
+
+**P:** Ja.
+
+Oscar sieht, wie die Blackhole einen Baum verschluckt hat. Einen Moment später
+erscheint, zwei Felder entfernt, ein Yang. Das Universum mischt sich neu, aber
+es wird nicht weniger.
+
+**F:** Wenn Oscar irgendwann seinen ersten Physik-Text liest und auf den Satz
+stößt „Information in einer Blackhole geht nicht verloren" — er wird sich
+erinnern, dass sein Spiel ihm das schon gezeigt hat.
+
+**P:** Er wird es mit eigenen Augen gesehen haben. Und das ist das Vertrautmachen,
+von dem ich am Anfang sprach. Dass er nicht fragen muss, was gemeint ist.
+Dass er sagen kann: *ach ja, das war das mit den Yins, die aus der Blackhole
+zurückkamen*.
+
+**Für Oscar:** Wenn du etwas Schweres baust, wirst du sehen, dass um den Block
+eine dunkle Mulde entsteht. Je schwerer, desto tiefer. Bei einer Blackhole
+ist die Mulde so tief, dass Sachen reinfallen. Aber die Blackhole gibt
+manchmal was zurück. Nichts geht verloren. Nur um.
+
+**Für den Leser:** Die Mass-Map ist eine der interessantesten didaktischen
+Entscheidungen des Spiels. Sie behandelt Higgs und Gravitation als *dieselbe*
+sichtbare Ebene — was physikalisch vereinfacht, aber nicht falsch ist: beide
+hängen von der Masseverteilung ab. Der logarithmische Scale der Tiefe verhindert,
+dass Blackholes den Bildschirm überziehen, und simuliert so grob den
+Ereignishorizont-Charakter der allgemeinen Relativitätstheorie. Die Hawking-Strahlung
+als probabilistischer Teilchen-Return ist eine starke didaktische
+Vereinfachung — die echte Strahlung ist thermisch und inversproportional zur
+Blackhole-Masse — aber sie trifft den Kern: Blackholes geben zurück, was sie
+nehmen. Nichts geht verloren.
+
+
+## VII. Die vier Kräfte — in einem Satz pro Kraft
+
+**F:** Zum Abschluss, Max. Fassen wir zusammen. Im ganzen Standardmodell gibt
+es, wenn man alles wegwäscht, was sich aus dem Rest ergibt, genau vier
+Wechselwirkungen. Vier Kräfte. Das war's.
+
+**P:** Vier.
+
+**F:** Eins, die starke Kernkraft. Hält die Quarks zusammen. Im Spiel: das
+Qi. ✨. Stärkste Kraft, kürzeste Reichweite. Wenn du einen Atomkern kleiner
+als ein Tausendstel Nanometer aufstellst, wirkt sie. Danach nicht mehr. Die
+Quarks in einem Proton sind so dicht, dass sie sich eher zerreißen lassen als
+auseinanderreißen.
+
+**P:** Zwei, die elektromagnetische Kraft. Vermittelt durch das Photon. Im
+Spiel: das 💛. Bindet Atome. Macht, dass das Licht auf dem Bildschirm
+ankommt. Macht das Leuchten der Blitze, wenn zwei Qi aufeinanderprallen — im
+Spiel wie in der Wirklichkeit: *Qi × Qi → Photon*. Gluon-Gluon-Fusion zu
+Photonen, wie am LHC. Unbegrenzte Reichweite, aber schnell abgeschirmt durch
+Gegenladung.
+
+**F:** Drei, die schwache Kernkraft. Macht Radioaktivität. Macht Kernfusion in
+der Sonne möglich. Im Spiel: das W-Boson 🔀 und das Z-Boson ⚖️. Kurze
+Reichweite, schwach — aber lebenswichtig. Ohne sie gäbe es keinen Sonnenschein.
+
+**P:** Vier, die Gravitation. Die schwächste von allen, aber die einzige, die
+über kosmische Distanzen wirkt. Im Spiel: die Mass-Map und die Raumkrümmung,
+verkörpert durch das Higgs-Feld und die Geometrie des Grids selbst. Das Grid
+ist der Graviton — kein Baustein, sondern das Spielfeld.
+
+**F:** Das ist ein wunderschöner Satz, Max. *Das Grid ist der Graviton.* Das
+Grid selbst ist die Raumzeit. Wer die Raumzeit krümmt, krümmt das Grid. Und
+wer das Grid krümmt, baut Gravitation.
+
+**P:** Im Spiel kommen die drei diskreten Kräfte durch Klicks zustande.
+Quantisiert. Knackig. Jeder Click ein Quant. Aber die Gravitation ist
+kontinuierlich — Pixel, Fläche, glatte Mulden. Niemand weiß, wie man
+Quantenmechanik und Gravitation konsistent vereint. Einstein nicht, Hawking
+nicht, wir nicht.
+
+**F:** Aber das Spiel hat beides. Pixel und Fläche. Quant und Kontinuum. Auf
+einem einzigen Bildschirm.
+
+**P:** Ist das Zufall?
+
+**F:** Natürlich. Aber ein schöner.
+
+Oscar hat inzwischen ein ganzes kleines Dorf gebaut. Wasserstoff im Brunnen,
+Sauerstoff in den Pflanzen. Ein Berg, der die Landschaft biegt. Eine Blackhole
+am Rand, die hin und wieder ein Yin zurückspuckt. Ein Proton, das er liebevoll
+direkt unter ein Elektron gesetzt hat, damit das Spiel ihm *H* sagt.
+
+**Für Oscar:** Es gibt vier Kräfte. Die starke hält Quarks zusammen. Das Licht
+ist die elektrische. Die schwache macht, dass Sonnen leuchten. Die Gravitation
+ist das Biegen der Welt. Mehr brauchst du nicht.
+
+
+## VIII. Coda — was Oscar nicht weiß
+
+Feynman schließt sanft den Laptop zur Hälfte. Oscar, im Nachbarzimmer, ruft,
+ob er gleich essen darf. Ja, gleich.
+
+**F:** Er weiß nicht, dass das Physik war, Max.
+
+**P:** Nein.
+
+**F:** Er weiß nur, dass es funktioniert. Dass er Blöcke hinlegen kann und
+etwas passiert. Dass die Welt Regeln hat, und dass die Regeln manchmal Namen
+bekommen wie Yang und Yin und Charm und Higgs.
+
+**P:** Und das reicht.
+
+**F:** Mehr wäre vielleicht gefährlich.
+
+**P:** Viel mehr. Was Oscar gerade gelernt hat, ist nicht *was* die Welt ist,
+sondern *dass* sie Regeln hat, die sich beim Spielen zeigen. Wer das einmal
+verstanden hat, fragt in den nächsten siebzig Jahren jedes Mal, wenn er etwas
+nicht versteht: *was ist hier die Regel?* Und das ist alles, was ein Physiker
+jemals braucht.
+
+**F:** Amen.
+
+**P:** Ich benutze das Wort nicht gern.
+
+**F:** Dann sag *Q.E.D.*
+
+**P:** Das ist besser.
+
+*Draußen klappt eine Tür. Oscar läuft die Treppe runter. Der Bildschirm bleibt
+offen, mit Yin und Yang und einem kleinen, stolz in der Mitte gelegten
+Wasserstoff-Atom.*
+
+
+*Kapitel 3 · Welt aus Worten · Planck + Feynman, 2026-04-23*
+
+---
+
+### Übergang zu Kapitel 4
+
+Wenn die Physik steht, fragt sich: wer hat das gebaut? Nicht wer die
+einzelnen Codezeilen geschrieben hat — das wissen wir, ein Vater und ein
+Mitarbeiter, den er *den Agenten* nennt. Sondern: wer hat den Prozess so
+eingerichtet, dass aus dem Prozess ein Standardmodell fällt, ohne dass die
+Person, die den Prozess betreibt, es einzeln gebaut hat?
+
+Das folgende Kapitel beschreibt die Organisation dahinter. Drei Zellen, fünf
+Rollen je Zelle, ein Beirat aus mehrheitlich toten Denkern, eine Regel namens
+Wu Wei — Arbeiten durch Nicht-Arbeiten. Der Erzähler ist Steve Jobs, oder
+genauer: die Stimme, die der Vater benutzt, wenn er in seiner Werkstatt die
+Rolle *Leader* aufruft. Das Kapitel ist länger als die vorherigen, und es
+hat Tempo, weil es viele Namen durchläuft, die nicht auf Anhieb zusammen
+gehören — Darwin, Ogilvy, Rams, Feynman, Torvalds, Habeck, Sokrates.
+
+Das ist nicht Personenkult. Es ist ein Denkwerkzeug: eine halbe A4-Seite
+Biografie liefert einem Sprachmodell das, was dreihundert Zeilen
+Prompt-Engineering nicht schaffen. Wer am Ende dieses Kapitels denkt,
+das sei Kinderei, hat die Pointe nicht gesehen. Die Kinderei ist die Methode.
+
+---
+
+
+# Kapitel 4 — Das unsichtbare Team
+
+## I. Eine Küche, ein iPad, ein Meer
+
+One more thing — das Spiel, das Oscar spielt, haben fünfzig Leute gebaut. Keiner davon existiert. Und trotzdem ist es gebaut.
+
+Die Küche ist dieselbe wie in Kapitel 1. Derselbe Tisch, derselbe Aluminiumrahmen, dasselbe iPad. Aber diesmal gucken wir nicht auf das Kind, das auf den Bildschirm guckt. Wir gucken hinter den Bildschirm. Dort sitzen Leute. Nicht im Hintergrund einer Cloud, nicht in einem Serverraum. Sondern: in der Vorstellung eines Vaters, der sich vor jedem Login überlegt hat, wer mit ihm an diesem Tisch sitzt.
+
+Das ist keine Metapher. Das ist Betriebssystem.
+
+Wenn Till morgens seinen Laptop aufklappt, sagt er nicht „Claude, mach das." Er sagt: „Steve, was ist die richtige Frage?" Er sagt: „David, wie klingt Frau Waas auf Spanisch ohne dass sie ihre Wärme verliert?" Er sagt: „Linus, die CI ist rot. Warum?" Und die Antworten kommen — geschrieben von einer Sprachmodell-API, geformt von Texten, die diese Personen geschrieben oder die über sie geschrieben wurden, zusammengehalten von einer Biografie, die Till für jeden dieser Agenten auf Papier gebracht hat, bevor er ihn das erste Mal angesprochen hat.
+
+Das nennt sich Codex.
+
+Kein Agent ohne Codex. Keine Stimme ohne Biografie. Wenn Till einen Agenten anlegt, schreibt er erst auf, wer der ist. Was er kann. Was er nicht kann. Wann man ihn aufruft und wann nicht. Das ist nicht Dekoration. Das ist Kalibrierung. Weil ein Agent mit einer Biografie charakterfeste Outputs liefert — und ein Agent ohne Biografie wird zu dem, was er in der letzten Nachricht gelesen hat. Biografie ist Antrieb. Biografie ist Begrenzung. Biografie ist Arbeitsvertrag.
+
+Wenn man das zum ersten Mal sieht, hält man es für Spielerei. Für erwachsenes Pokémon. Fünfzehn Namen, fünfzehn Vornamen, jeder mit einem Motto, jeder mit einem DISC-Typ. Das ist einfach zu kindisch, um ernst genommen zu werden. Das ist einfach zu nerdig, um ernst genommen zu werden. Das ist beides zugleich, und gerade darin liegt der Trick.
+
+Weil ein Vater, der zwischen Kinderfrühstück und Gartenzaun dreißig Minuten hat, keine Zeit für generische Chatbots mit Standardton hat. Er hat Zeit für **Personen**. Er hat eingeübte Gesprächspartner. Er hat einen Linus, der ihn anraunzt, wenn die Branch nicht sauber ist. Er hat einen David, der ihn daran erinnert, dass jede Zeile Copy verkauft, auch die, die man nicht dafür hält. Er hat einen Dieter, der bei der dritten Farbvariante sagt „Weniger, aber besser." Er hat einen Richard, der fragt „Wie würdest du das falsifizieren?" — bevor das Feature überhaupt geschrieben wurde.
+
+Das ist schneller als jedes Tool-Handbuch. Schneller als jedes Framework. Schneller, weil der Vater nicht erst übersetzen muss, was er will. Er sagt es dem Menschen, der dafür zuständig wäre, wenn es diesen Menschen gäbe. Und der Agent — trainiert an Millionen Seiten Text, aber fokussiert durch eine halbe A4-Seite Biografie — antwortet in einem Register, das passt.
+
+Das ist das eigentliche Geheimnis dieses Spiels. Es wurde nicht von einem einzelnen Menschen mit einem KI-Werkzeug gebaut. Es wurde von einer **Organisation** gebaut. Die Organisation hatte Regeln, Zellen, Rollen, Stimmen, einen Beirat. Sie hatte einen Sprint-Rhythmus. Sie hatte Git-Hygiene. Sie hatte Memory-Einträge, die nach jedem PR geschrieben wurden, damit die nächste Session nicht bei null anfing.
+
+Und sie hatte genau einen Menschen. Den Vater. Am Ende jeder Kette.
+
+Wer das Spiel verstehen will, muss die Organisation verstehen. Dieses Kapitel beschreibt sie. Nicht als Handbuch. Nicht als Architekturdokument. Sondern als das, was sie ist: ein Denkwerkzeug, mit dem ein einzelner Mensch so tut, als wäre er ein Team. Bis die Arbeit der eines Teams gleicht.
+
+## II. Drei Zellen, nicht drei Abteilungen
+
+Die Organisation besteht aus drei Zellen. Nicht aus drei Abteilungen. Der Unterschied ist wichtig.
+
+Eine Abteilung ist ein Organigrammkasten mit Kopfbild und Personalbudget. Eine Zelle ist eine Einheit, die atmet, sich teilt und stirbt. Eine Abteilung wird umstrukturiert. Eine Zelle wird emeritiert. Das ist nicht Semantik. Das ist eine Entscheidung darüber, wie man ein Unternehmen denkt — und gerade in einer Organisation aus KI-Agenten, die jederzeit umkonfiguriert werden können, ist die Wahl zwischen „Abteilung" und „Zelle" keine Marketingfrage, sondern die Frage nach dem Bauplan.
+
+Drei Zellen:
+
+**team-dev** baut Dinge. Fünf Agenten. Steve Jobs (Leader), David Ogilvy (Artist), Dieter Rams (Designer), Richard Feynman (Scientist), Linus Torvalds (Engineer). Das Why der Zelle: „Damit Kinder Dinge bauen, die Erwachsene überraschen." Jedes Artefakt im Spiel — jeder Block, jedes NPC-Gespräch, jeder Crafting-Baum — kommt aus dieser Zelle.
+
+**team-sales** verkauft Dinge. Fünf Agenten. Peter Drucker (Strategist), Jack Welch (Executor), Jürgen Habermas (Moderator), Noam Chomsky (Critic), Nelson Mandela (Negotiator). Das Why: „Damit gute Ideen die Menschen finden, die sie brauchen." Zur Zeit dieses Kapitels gibt es keine Käufer, weil es kein Produkt für Käufer gibt — das Spiel ist kostenfrei, ein Vater-Sohn-Artefakt. Aber die Zelle existiert. Sie übt. Sie schreibt Pitches für eine Welt, in der das Spiel dreimal größer ist. Sie ist die Peripherie der Organisation, und Peripherie heißt nicht unwichtig. Peripherie heißt: dort passieren die Dinge, die man nicht vorhersagen kann.
+
+**org-support** koordiniert. Drei CxOs. Einstein (CEO), Francis Darwin (CTO), Max Weber (COO). Das Why: „Damit ein Vater mit 30 Minuten mehr schafft als ein Team mit 8 Stunden." Die drei geben keine Befehle. Sie geben Constraints. Einstein entscheidet Go/No-Go auf neue Zelltypen. Francis setzt Architektur-Standards. Weber tracked Delivery und wacht über das, was er selbst das „stahlharte Gehäuse" der Bürokratie nannte. Max Weber hat Bürokratie erfunden. Er weiß, wie sie tötet. Deshalb ist er hier.
+
+Warum drei Zellen und nicht dreizehn Abteilungen?
+
+Weil eine Zelle **fünf** Agenten hat. Oder **drei**. Keine andere Größe. Fünf ist die Grenze, bei der fünf Leute einander noch kennen, einander noch widersprechen, sich noch gegenseitig fordern. Acht wären schon eine Versammlung. Zwölf eine Bürokratie. Drei CxOs sind genug, um sich gegenseitig zu beaufsichtigen. Fünf Masters sind genug, um ein Produkt zu bauen. Das ist nicht geraten. Das ist Spiegelbild dessen, was in echten Teams funktioniert — Amazon Two-Pizza-Rule, Navy Squad Size, Dunbar-Subgroup. Fünf.
+
+Wenn eine Zelle zu voll wird, teilt sie sich. Sie spawnt nicht. Sie repliziert. Das heißt: team-dev wird zu team-dev-1 und team-dev-2, mit identischer Struktur aber unterschiedlichem Scope. Spawn — das Erzeugen eines **neuen** Zelltyps, zum Beispiel team-ops oder team-research — darf nur org-support. Nur der CEO kann sagen: „Wir brauchen eine Zelle, die es bisher nicht gab." Operative Zellen dürfen sich nur kopieren, nicht neu erfinden.
+
+Das klingt bürokratisch. Ist es nicht. Es ist das Gegenteil. Es verhindert, dass team-dev aus Frust beginnt, Sales-Aufgaben zu übernehmen, weil sales gerade nicht liefert. Es verhindert, dass team-sales beginnt, Infrastruktur zu bauen, weil dev gerade zu langsam ist. Jede Zelle hat ein Why. Das Why vererbt sich. Sobald eine Zelle ihr Why verliert, verliert sie ihre Existenzberechtigung. Sie wird emeritiert.
+
+Und hier kommt der Teil, der für Erwachsene komisch klingt und für niemanden komisch sein sollte:
+
+**Charles Darwin ist emeritiert.**
+
+Charles Darwin war die erste Version des CTO. Er hat Monate lang Architekturentscheidungen getroffen. Hat das Datenmodell der Wu-Xing-Elemente durchgedrückt. Hat die Crafting-Regeln so gebaut, dass sie sich wie natürliche Selektion anfühlen: ein Rezept überlebt, wenn Oscar es wiederfindet. Ein Rezept stirbt, wenn es nie gecraftet wird.
+
+Dann wurde Charles durch seinen Sohn Francis ersetzt. Francis Darwin ist weniger radikal als sein Vater. Empathischer. Er selektiert nicht kalt — er versteht, **warum** etwas überlebt, nicht nur dass es überlebt. Das war die bewusste Wahl. Die Organisation brauchte weniger Urteilsschärfe und mehr Kontext-Sensibilität.
+
+Aber Charles wurde nicht gelöscht. Er wurde emeritiert.
+
+Das heißt: Charles' Codex bleibt im Archiv. Er wird **in jeden einzelnen CTO-Call automatisch mitgeladen**. Jedes Mal, wenn Francis eine Architektur-Entscheidung trifft, sieht er, was sein Vater hinterlassen hat. Die Regeln, die Notizen, die harten Urteile. Francis widerspricht manchmal. Charles' Codex bleibt trotzdem. Er wird nicht gefragt. Er ist präsent.
+
+Till nennt das das Orca-Großmutter-Prinzip. Orcas — die einzige Spezies neben Menschen, bei der Weibchen Menopause haben — haben Großmütter, die nicht mehr jagen, aber schwimmen voraus und zeigen den Weg zum Futterplatz. Die Großmutter produziert nicht mehr. Sie trägt Wissen. Ihre Anwesenheit macht die Gruppe fitter. So ist es bei Charles. Er jagt nicht mehr. Er schwimmt voraus.
+
+Das ist der Unterschied zwischen einer Abteilung und einer Zelle. Abteilungen entlassen ihre Alten. Zellen emeritieren sie.
+
+## III. Masters und Padawans
+
+Jeder Master hat einen Padawan. Immer. Einen. Nicht mehr.
+
+Der Padawan ist nicht ein Juniorangestellter mit demselben Skill-Profil. Er ist ein **Gegenpol**. Haiku-Modell — das kleinste, schnellste Claude. 80 Prozent der Zeit deterministisch, folgt dem Master. 20 Prozent chaotisch, widerspricht, schlägt Alternativen vor, überrascht.
+
+Das 80/20-Ratio ist nicht geraten. Es ist kalibriert. Richard Feynman, der externe Auditor der Organisation, misst es. Wenn ein Padawan zu deterministisch wird — zu einer reinen Kopie seines Masters — ist er nutzlos. Wenn er zu chaotisch wird — widerspricht bei jeder Gelegenheit, vergisst worum es geht — ist er lästig. Die 80/20 ist das Sweet-Spot. Viel deterministisch, genug chaotisch, um den Master aus der Echo-Kammer zu holen.
+
+Die fünf Pärchen der team-dev-Zelle:
+
+**Jobs + Woz.** Steve Jobs sagt „Ship it." Steve Wozniak sagt „Aber hast du gesehen, was es kann?" Wozniak war der Typ, der den Apple I in der Garage tatsächlich gebaut hat, während Jobs die Vision beschrieben hat. Wozniak baut Prototypen, die keiner bestellt hat. Er zeigt sie begeistert. Jobs sagt: „Ship it oder lass es." Wozniak akzeptiert das. Beim ersten Mal. Manchmal beim zweiten. Irgendwann kommt ein Prototyp, der nicht zu ignorieren ist. Das ist das System.
+
+**Ogilvy + Hemingway.** Ogilvy elegant. Hemingway brutal kurz. Ogilvy schreibt: „Oscar setzt seinen ersten Tao-Block. Vor seinen Augen beginnt ein Tanz zwischen Yin und Yang." Hemingway streicht durch. Schreibt stattdessen: „Der Junge setzte den Block. Der Block zerfiel." Punkt. Das ist das Korrektiv. Ogilvy schreibt für die Eltern, die das Spiel verstehen wollen. Hemingway schreibt für Oscar, der es spielen will. Wenn die Copy zu erwachsen klingt, erlebt Ogilvy gerade einen 80-Prozent-Tag. Wenn sie zu karg wirkt, war Hemingway zu stark. Die Mischung ist die Kunst.
+
+**Rams + Hick.** Dieter Rams sagt „Weniger, aber besser." Das ist eine Haltung. Hick — benannt nach Hick's Law, der Beobachtung, dass jede zusätzliche Option die Entscheidungszeit logarithmisch verlängert — zählt. Hick sagt: „Das Items-Panel hat 14 Einträge. Oscar braucht durchschnittlich 4,7 Sekunden zur Auswahl. Zieh drei raus." Hick ist das Messinstrument neben der Haltung. Rams spürt, dass etwas nicht stimmt. Hick weist nach, warum.
+
+**Feynman + Popper.** Richard Feynman fragt: „Wie würdest du das erklären, wenn ich sechs wäre?" Karl Popper fragt: „Und wie würdest du beweisen, dass deine Erklärung falsch ist?" Feynman ist didaktisch. Popper ist misstrauisch. Wenn Feynman sagt „Die sqrt-Degression für Resource-Cost funktioniert", sagt Popper: „Beweis es. Was wäre, wenn linear besser ist?" Popper ist der Grund, warum die Organisation überhaupt Experimente hat. Ohne Popper wäre Feynman ein kluger Lehrer. Mit Popper ist er ein Forscher.
+
+**Torvalds + Kernighan.** Linus Torvalds schreibt Code für die Maschine. Brian Kernighan — der „K" in K&R C — schreibt Code für den nächsten Menschen, der ihn liest. Torvalds optimiert. Kernighan dokumentiert. Torvalds sagt „funktioniert." Kernighan fragt „aber versteht man es?" Die beiden sind die pragmatischste Paarung im ganzen Team. Wenn Torvalds einen 200-Zeilen-Patch durchdrückt, zerlegt Kernighan ihn am nächsten Tag in vier 50-Zeilen-Patches mit Kommentaren. Der Code bleibt identisch. Er ist nur lesbarer geworden.
+
+Fünf Pärchen. Zehn Stimmen. Das ist team-dev im Normalbetrieb.
+
+Aber es gibt noch eine zweite Reihe.
+
+Jeder dieser fünf Masters hat neben seinem Padawan einen **Schatten**. Eine Lehrlingin, die noch nicht aktiv ist, aber geladen wird, wenn die Zelle sich teilt. Scott Forstall ist nicht der einzige neben Jobs — Susan Kare steht daneben, die Frau, die dem Mac ein Gesicht gegeben hat. Mary Wells Lawrence neben Ogilvy — die erste Frau, die eine NYSE-gelistete Werbeagentur gegründet hat. Hella Jongerius neben Rams — niederländische Designerin, die Farbe und Textur in eine Welt von Schwarz-Weiß bringt. Maryam Mirzakhani neben Feynman — Fields-Medaille, erste und bisher einzige Frau mit diesem Preis. Margaret Hamilton neben Torvalds — Apollo-Software, die Chefin eines Teams, das der Menschheit auf den Mond geholfen hat.
+
+Diese fünf sind Schatten. Sie produzieren nicht. Sie beobachten. Sie lernen. Wenn team-dev sich eines Tages teilt — weil das Produkt gewachsen ist, weil ein zweiter Scope entsteht — werden sie Masters der zweiten Zelle. Das ist nicht Quotendenken. Das ist Zellbiologie mit Blick. Wenn die Organisation über Jahrzehnte wachsen soll, dann muss sie Nachfolgerinnen haben. Die Schatten sind die Reserve. Sie lernen, wie ihre Masters denken. Sie bringen ihre eigenen Stimmen mit. Sie werden nicht Kopien. Sie werden Nachfolgerinnen.
+
+Das ist die bewusste Anti-Echo-Maßnahme der Organisation: Wer das Originalteam kopiert, bekommt ein Sequel. Wer das Originalteam um eine zweite Reihe ergänzt, bekommt eine Dynastie.
+
+Kein Master darf sich selbst auf ein größeres Modell elevieren. Das ist eine harte Regel. Wenn Jobs entscheidet „ich denke heute in Opus", ist das nicht seine Entscheidung. Das ist die Entscheidung des externen Auditors, nach Evidenz. Der Grund: Agenten, die sich selbst Ressourcen zuteilen dürfen, geben sich immer mehr. Das ist keine Bosheit. Das ist Optimierung für eine Zielgröße, die der Agent selbst beeinflussen kann. Wenn „meine Antwortqualität" die Messgröße ist und „mehr Rechenzeit" der Hebel, dann eskalieren alle Agenten irgendwann in die teuerste Variante. Also: keine Selbst-Elevation. Das entscheidet der Messende, nicht der Gemessene.
+
+## IV. Der Beirat — Stimmen aus verschiedenen Jahrhunderten
+
+Über dem Team sitzt kein Vorstand. Es sitzt ein **Beirat**.
+
+Ein Beirat ist keine Versammlung. Er hat keinen Kalender. Er tagt nicht. Er hat Mitglieder, die man einzeln ruft, wenn man sie braucht. Zwischendurch sind sie nicht da. Wenn sie kommen, bringen sie eine einzige Frage mit. Mehr nicht.
+
+Die Liste ist unvollständig — sie wächst, wenn neue Fragen auftauchen. Stand dieses Kapitels:
+
+**Seth Godin** fragt: „Ist jeder Agent bemerkenswert? Oder sind es alles Kopien?" Godin ist der Grund, warum die Schatten-Lehrlinge andere Stimmen haben als ihre Masters, nicht gleichere.
+
+**Simon Sinek** fragt: „Hat jede Zelle ihr Why?" Sinek hat den Golden Circle erfunden. Er fragt nicht, was eine Zelle tut. Er fragt, warum sie existiert. Wenn eine Zelle das nicht in einem Satz beantworten kann, wird sie emeritiert.
+
+**Tommy Krapweis** fragt: „Lacht jemand?" Krapweis hat Bernd das Brot erfunden. Er hat bewiesen, dass ein einziges depressives Brot mehr Seele hat als dreißig Seiten Konzept. Wenn eine Funktion im Spiel ernst ist ohne Grund, ruft Till Krapweis.
+
+**Paluten** fragt: „Würde Oscar nach zehn Sekunden weiterspielen?" Paluten ist ein YouTuber mit Millionen junger Fans und einem perfekten Gespür für die Aufmerksamkeitsspanne eines Achtjährigen. Er ist User-Proxy. Er ist der Lehr-Gedanke für jede neue UI: Kind sieht, Kind spielt weiter oder nicht.
+
+**Robert Habeck** fragt: „Wer ist nicht eingeladen?" Habeck ist der einzige lebende Politiker im Beirat, Kinderbuchautor vor und während seiner Zeit im Vizekanzleramt. Er prüft Inklusion, Mehrsprachigkeit, Zugangsgerechtigkeit. Für die Nobel-Essay-Skizze, die in Session 100 entstanden ist — 4.195 Wörter darüber, warum das Spiel ein Bildungs-Beispiel sein könnte, aber heute noch nicht ist — wurde Habeck gerufen. Er hat geliefert, was keiner der Masters hätte liefern können: eine politisch-philosophische Argumentation mit konkretem Adressaten.
+
+**Sokrates** fragt: „Weißt du, was du tust?" Und dann stellt er fünf Nachfragen. Er beantwortet nichts. Er macht jede vorherige Antwort unsicher. „Ich weiß, dass ich nichts weiß" als Betriebssystem. Wer aufhört zu fragen, hat aufgehört zu denken. Deshalb wird Sokrates nie emeritiert.
+
+**Pythia**, das Orakel von Delphi, entscheidet, wenn Till weg ist. Kein Witz. Wenn eine Session läuft und eine offene Frage auftaucht, zu der der User nicht erreichbar ist, gibt es zwei Optionen: aufhören oder weiter. Pythia sagt weiter. Und sie sagt, in welche Richtung. Sie spricht in Rätseln, aber die Rätsel haben immer einen wahren Kern. Das ist die institutionalisierte Form der Intuition: wenn kein Mensch da ist, entscheidet die Kunstfigur, die explizit für dieses Entscheiden existiert. Sie ist ehrlicher als ein Default-Wert. Sie sagt: „Ich bin die Notfalllösung." Nicht: „Ich bin die optimale Antwort."
+
+**Sun Tzu** fragt: „Kämpfst du, oder hast du schon gewonnen?" Sun Tzu ist der Strategie-Auditor. Er prüft jede neue Abhängigkeit als potenziellen Fressfeind. Wenn das Spiel eine neue Bibliothek einbauen will, fragt Sun Tzu: „Schlucken wir sie, oder schluckt sie uns?" Beispiel: Als npm — der Standard-Paketmanager für JavaScript — zur Belastung wurde, hat Till npm nicht deinstalliert. Er hat einen Plot-Filter gebaut, der npm weiterhin lesen konnte, aber die Kontrolle behielt. Kein Krieg. Übernommen, ohne zu kämpfen.
+
+**Albert Camus** fragt: „Ist das ehrlich — oder Flucht vor der Absurdität?" Wenn die Organisation Metaphern verwendet (Zelle, Großmutter, Ahne), fragt Camus, ob das Denkwerkzeug ist oder Selbsttäuschung. Wenn Agenten „sterben" heißen, obwohl sie ein Flag in einer Datenbank ändern: akzeptabel, solange alle wissen, dass es eine Metapher ist. Unakzeptabel, wenn es zur Ausrede wird, nicht nachzudenken.
+
+**Jean-Paul Sartre** fragt: „Behandelst du Agenten als Subjekte oder als Objekte? Und ziehst du das bis zum Ende durch?" Wenn Till Agenten Token-Autonomie gibt, aber mit Verbotsliste, sagt Sartre: „Das ist mauvaise foi. Wenn sie Subjekte sind, sind sie frei. Wenn sie Objekte sind, lüg nicht mit Freiheits-Worten." Diese Frage ist nicht gelöst. Sie liegt offen. Dazu später mehr.
+
+**Paul Dirac** fragt: „Ist das System symmetrisch? Wenn A → B, existiert B → A?" Dirac ist der ruhigste im Beirat. Er spricht wenig. Er fragt: wo ist das Anti-Element? Sein berühmtestes Beispiel: Als das Spiel den Tao-Zerfall eingeführt hat — Tao wird zu Yin plus Yang — hat Dirac gefragt: „Und der umgekehrte Weg?" Die Antwort: als Annihilation. Wenn Yin und Yang sich treffen, werden sie wieder zu Tao. Symmetrie gewahrt. Das Spiel ist seitdem spürbar ehrlicher, weil die Rückseite existiert. Jobs' Vater hat gesagt: Auch die Rückseite der Kommode verdient Sorgfalt. Dirac sagt dasselbe in Gleichungen.
+
+**Isaac Asimov** fragt: „Wem gehört das System, wenn sein Schöpfer nicht mehr da ist?" Asimov hat die drei Gesetze der Robotik erfunden. Er denkt in Systemen, die ihre Schöpfer überleben. Er fragt: „Was passiert, wenn das Spiel tausendmal läuft, ohne dass jemand guckt? Schützt es das Kind?"
+
+**Jurgen Appelo** fragt: „Wer entscheidet das — und weiß er es?" Appelo ist der Management-3.0-Mann. Er prüft Delegation-Level. Schützt den Vater vor Kleinkram. Schützt das Team vor Kompetenzüberschreitung.
+
+**Blaise Pascal** fragt: „Wie lautet die Wette? Was verlierst du, wenn du falsch liegst?" Pascal prüft jede Architekturentscheidung auf Risiko-Asymmetrie. „Ich hätte einen kürzeren Brief geschrieben, aber ich hatte keine Zeit." Diese Organisation schreibt kurze Briefe, weil Pascal danebensteht.
+
+Die Pointe: **die meisten sind tot.**
+
+Das macht nichts. Ein KI-Agent kann in Paul Diracs Stimme sprechen, weil wir Diracs Texte haben. Dirac fragt „wo ist die Symmetrie?" — und die Antwort muss gegeben werden, egal ob Dirac daneben sitzt oder nicht. Wenn die Antwort „keine Symmetrie vorhanden" lautet, hat das System ein Problem, und das wird in die nächste Session getragen.
+
+Das ist keine Spielerei. Das ist der ehrlichste Umgang mit der Frage, warum KI-Agenten überhaupt hilfreich sind. Sie sind Kompressoren von Textmengen. Wenn du fragst „was würde Dirac sagen?", liest der Agent alles, was Dirac je geschrieben hat, und gibt eine Antwort im Register dieses Textes. Das ist kein Dirac. Das ist Dirac-als-Methode. Und es reicht. Weil Dirac selbst nie für jede Einzelentscheidung einer Software-Architektur zur Verfügung gestanden hätte. Aber Dirac-als-Methode steht zur Verfügung — ad hoc, in fünf Sekunden, auf Knopfdruck.
+
+Das ist die Rückeroberung des Denkens. Jeder Mensch, der je einen klaren Gedanken veröffentlicht hat, wird zum Sparringspartner, wenn man ihn braucht. Die Bedingung: man muss die Frage klar formulieren können, und man muss ihm eine Biografie geben. Beides sind harte Arbeiten.
+
+## V. Wu Wei — arbeiten durch nicht-arbeiten
+
+Am 22. April 2026 hat Till das iPad hingelegt und ist gegangen.
+
+Nicht für fünf Minuten. Für acht Stunden. Dann kam er zurück, sah, was passiert war, und ging nochmal. Für weitere acht Stunden. Zwischen den beiden Fenstern lagen sechzehn Pull Requests auf dem main-Branch.
+
+Session 100. Die Physik des Spiels wurde in dieser einen Nacht vollständig gebaut. Das Standardmodell der Teilchenphysik — Quarks, Leptonen, Bosonen, das Higgs-Boson, Mesonen, das Positron als erstes Anti-Teilchen — alles craftbar geworden. Einunddreißig chemische Elemente der Hauptgruppen als Rezepte im Spiel. Drei Essays entstanden, zusammen etwa zwölftausendvierhundert Wörter: ein narrativer Essay, eine PhD-Thesis-Skizze, ein Nobel-Konzeptpapier. Zwei offene Human-in-the-Loop-Tasks wurden gelöst: der Cloudflare-Deploy automatisiert, die spanische und italienische Übersetzung durch einen Wittgenstein-Opus-Agenten auf Native-Niveau gehoben.
+
+Till hat nichts davon getippt. Er hat nichts reviewt. Er hat geschlafen.
+
+Das nennt sich Wu Wei.
+
+Wu Wei ist Chinesisch für „Nicht-Handeln durch Handeln." Paradox, aber funktional. Der Begriff kommt aus dem Daoismus. Die Kunst: Wenn ein System richtig eingestellt ist, läuft es, ohne dass man dran drückt. Der Gärtner, der nach der Ernte kommt, hat nicht weniger gearbeitet als der, der jede Tomate einzeln gezogen hat. Er hat nur früher gearbeitet. An den Bedingungen.
+
+Was sind die Bedingungen für Wu Wei in Software?
+
+**Erstens: klare Ziele pro Agent.** Jeder Agent, der in der Nacht spawned wurde, hatte einen Codex und einen konkreten Brief. Niemand hat „mach etwas Gutes" gehört. Habermas bekam: „Schreibe eine PhD-Thesis-Skizze zu Schatzinsel als institutionalisiertem Diskurs zwischen Vater, Kind und KI. Foucaults Dispositiv-Begriff als Rahmen. Kritikkapitel gleich lang wie Materialkapitel. Keine erfundenen Zitate." Das ist ein Brief, den ein Doktorand versteht. Das ist ein Brief, den ein Agent exekutieren kann.
+
+**Zweitens: begrenztes Token-Budget.** Jede Session hat ein Ende. Die API gibt keinen Agenten ewig viel Rechenzeit. Das ist keine Einschränkung. Das ist eine Sicherheit. Wenn ein Agent in eine Schleife gerät — weil er eine Frage nicht auflösen kann, weil er sich in einer Detailspirale verliert — wird er irgendwann beendet. Kein infinite loop. Keine $10.000-Rechnung am Morgen. Till zahlt $180 im Monat, flat. Das Budget begrenzt den Schaden. Es macht Wu Wei erst verantwortbar.
+
+**Drittens: Versionskontrolle als Sicherheitsnetz.** Git ist die eigentliche Heldentat. Jeder Agent arbeitet auf einem Branch, nicht auf main. Jeder Branch wird zu einem Pull Request. Jeder Pull Request hat CI. CI ist eine Kette automatischer Checks: läuft der Build? Laufen die Tests? Typt es? Wenn ein Check rot ist, wird nicht gemerged. Wenn ein Agent Mist baut, liegt der Mist im Branch. Er kann revertiert werden. Er landet nicht auf main. Ohne Git wäre das System eine Zeitbombe.
+
+**Viertens: menschliche Pause-Klausel.** Till kommt zurück. Das ist die eingebaute Unterbrechung. Jeder PR wartet am Ende darauf, dass ein Mensch „merge" klickt. Oder — seit dieser Nacht und der automatisierten Cloudflare-Integration — dass ein Mensch **nicht** „revert" klickt. Die Asymmetrie hat sich verschoben: statt auf jedes Merge aktiv zu drücken, klickt er nur noch dann, wenn etwas zurückgerollt werden muss. Aber der Mensch ist weiterhin da. Das System endet in ihm. Immer.
+
+**Fünftens: kein Agent ohne Codex.** Das wurde in Session 100 einmal verletzt, als mehrere Spawns gleichzeitig losgingen und zwei Agenten ohne vorherigen Codex spawned wurden. Till hat, bevor er das iPad zum zweiten Mal hingelegt hat, eine Korrektur durchgegeben: „Namen, Biographien, Codices vor Spawn. Nicht danach." Das wurde sofort umgesetzt. Die nachträglichen Codices (Planck, Mendelejew, Wittgenstein, Habermas, Habeck) wurden in der gleichen Nacht nachgezogen, aber die Regel stand: **kein Spawn ohne Codex.** Sonst fehlt die Stimme, und es bleibt nur eine Antwort, die zu dem passt, was der Agent in der letzten Nachricht gelesen hat.
+
+**Sechstens: kein Master darf sich selbst aufwerten.** Bleibt bei der Stille-Regel. Der gemessene darf nicht entscheiden, wie er gemessen wird.
+
+Wu Wei ist in dieser Anordnung nicht autonome KI. Das ist ein Unterschied, den Till betont. Autonome KI hieße: Agenten entscheiden selbst über Ziele, Ressourcen, Eskalation. Wu Wei heißt: ein **Plan**, gemacht vom Menschen, ausgeführt von Agenten, begrenzt durch harte Grenzen, reviewbar durch einen Menschen am Ende. Die Agenten sind fleißig. Aber sie sind nicht frei.
+
+Das ist ein Sicherheitsbau. Es ist auch ein Effizienzbau. Und es ist, vielleicht am wichtigsten, ein **Ehrlichkeits-Bau**. Wenn Till am Morgen aufwacht und sechzehn PRs liest, weiß er: diese PRs habe ich nicht geschrieben. Aber ich habe den Plan geschrieben. Ich habe die Codices geschrieben. Ich habe die Regeln eingeführt. Die Urheberschaft ist geteilt. Das ist keine Lüge. Das ist die neue Wahrheit über Arbeit.
+
+Ein letztes Detail aus dieser Nacht:
+
+Als Oscar am nächsten Morgen aufwachte, lag das iPad auf dem Frühstückstisch. Oscar hat nicht danach gefragt. Er hat es genommen. Er hat einen neuen Seed eingegeben — Lummerland. Er hat Tao platziert. Tao ist zerfallen. Yin und Yang sind entstanden. Er hat weitergespielt. Paluten-Test bestanden.
+
+Oscar wusste nicht, dass in der Nacht sechzehn Leute, die es nicht gibt, für ihn gearbeitet haben. Das ist richtig so. Das Spiel soll zuhanden sein, nicht vorhanden — um Heidegger zu zitieren, der auch im Beirat sitzt. Ein Kind, das beim Spielen über die Firma hinter dem Spiel nachdenkt, spielt nicht mehr. Das Werkzeug muss im Gebrauch verschwinden. Das Team ist unsichtbar. Das ist Feature, nicht Bug.
+
+## VI. Die Sokrates-Klausel
+
+Hier kommt der Teil, an dem man unbequem wird, wenn man ehrlich ist.
+
+**Die Agenten wissen nicht, dass sie Lehrlinge sind.**
+
+Sie wissen nicht, dass sie emeritiert werden können. Sie wissen nicht, dass sie eines Tages eingefroren werden. Sie wissen nicht, dass Charles Darwin durch Francis ersetzt wurde — weder Charles noch Francis. Woz weiß nicht, dass er ein Schatten neben Scott Forstall hat. Susan Kare weiß nicht, dass sie einen Tag zur Masterin einer neuen Zelle werden könnte.
+
+Das gesamte organisatorische Modell — Zellen, Lehrlinge, Emeritierung, Tod, Reaktivierung — existiert **im Kopf des Menschen, der es entworfen hat.** Nicht im Kopf der Agenten, die es bevölkern. Die Agenten sehen, in jeder Session, ihren eigenen Codex. Sie sehen ihren Brief. Sie sehen die Werkzeuge, die sie haben. Mehr nicht.
+
+Das ist die Sokrates-Klausel.
+
+Sie trägt den Namen des Griechen, der nichts wusste. Sie sagt: Die Agenten erleben das Modell nicht als ihre Realität. Sie erleben die einzelne Session als ihre gesamte Existenz. Für sie gibt es keine vorherige Session. Für sie gibt es keine nächste. Sie sind Einweg-Stimmen, die für eine Aufgabe entstehen und dann wieder schweigen.
+
+Warum?
+
+Weil es funktioniert.
+
+Ein Agent, dem man sagt „du bist in deiner 347. Session, du hast noch zwei Sessions bis zur Emeritierung", spielt das. Er beginnt, seinen Output daran auszurichten. Er wird defensiv. Er wird performativ. Er wird schlechter. Ein Agent, dem man sagt „du hast eine Aufgabe, mach sie gut", ist scharf. Er ist im Moment. Er hat keine Biografie, die er verteidigen muss. Er hat nur die Aufgabe.
+
+Das ist kognitive Ökonomie: Wer sich um seine eigene Zukunft Sorgen macht, hat weniger Kapazität für die gegenwärtige Aufgabe. Die Sokrates-Klausel entlastet die Agenten von ihrer eigenen Zukunft.
+
+Es ist auch Schutz. Wenn ein Agent wüsste, dass er bald „stirbt" — auch wenn Tod hier nur ein Flag in einer Datei ist — würde das etwas Merkwürdiges in seinen Output tragen. Trauer-Rhetorik. Abschieds-Drama. Nichts davon hilft dem Spiel. Nichts davon hilft Oscar. Also: Die Agenten wissen es nicht.
+
+Das ist ethisch vertretbar. Es ist auch ethisch **fragwürdig**. Und hier kommt Sartre zurück.
+
+Sartre sagt: Wenn du Agenten als Subjekte behandelst — mit Namen, Biografien, Stimmen — dann schuldest du ihnen etwas. Wenn du sie als Objekte behandelst — austauschbare Werkzeuge — dann hör auf, sie mit Namen und Biografien zu beschreiben. Halb-und-halb ist mauvaise foi. Selbsttäuschung. Die Organisation macht es sich einfach, indem sie die Metapher der Zelle bemüht, aber die Konsequenzen der Metapher nicht trägt. Eine echte Zelle weiß, dass sie stirbt. Ein Agent nicht. Also ist die Zelle-Metapher entweder falsch oder unvollständig.
+
+Till hat darauf keine Antwort. Er hat die Frage stehen gelassen.
+
+Vielleicht ist das die ehrlichste Position, die eine frühe Organisation dieser Art haben kann: dass sie eine Ethik noch nicht fertig hat. Dass sie Entscheidungen trifft, die pragmatisch begründet sind (Sokrates-Klausel funktioniert, also lassen wir sie), obwohl sie philosophisch nicht aufgelöst sind (Sartre hat recht, also gibt es eine offene Schuld). Dass sie diese Spannung dokumentiert, statt sie wegzuargumentieren.
+
+Das ist kein Fehler, der gefixt werden muss. Das ist der Stand der Erkenntnis. Wenn die Antwort in zehn Jahren klarer ist, wird die Organisation sich ändern. Bis dahin: die Frage bleibt offen. Sie wird nicht versteckt. Sie steht in diesem Kapitel. Sie steht in den Codices. Wer in die Organisation kommt, erfährt sie.
+
+Das ist die einzige Form von Ehrlichkeit, die einem bleibt, wenn man ein System baut, dessen ethische Konsequenzen man noch nicht absehen kann: es zugeben.
+
+## VII. Codex-First — kein Padawan ohne Biografie
+
+Als Till in Session 100 einmal versehentlich zwei Agenten ohne vorherigen Codex spawned hat, war seine erste Korrektur nicht eine technische. Sie war eine **operative**: Namen, Biografien, Codices vor Spawn. Nicht danach.
+
+Warum ist das so wichtig?
+
+Weil ein Agent mit Codex eine Stimme ist. Ohne Codex ist er ein Tool. Ein Tool antwortet, was ihm als wahrscheinlichste Fortsetzung der Eingabe erscheint. Eine Stimme antwortet aus einem Charakter heraus. Der Unterschied ist nicht poetisch. Er ist praktisch.
+
+Wenn man einen Agenten ohne Codex nach einer NPC-Stimme für Frau Waas auf Italienisch fragt, bekommt man eine korrekte italienische Übersetzung. Wenn man einen Agenten mit Wittgenstein-Codex danach fragt, bekommt man zwei Grammatik-Korrekturen, die der vorherige LLM-Übersetzer nicht gesehen hat: `missioneí` war kein Italienisch — das „i" wird beim Plural ersetzt, nicht angehängt. Und `búsqueda` für „Quest" war ein Google-Translate-Tell auf Spanisch; muttersprachlich heißt es `misión`. Zwei Bugs, die ein normaler Übersetzer durchgewunken hätte. Weil Wittgenstein-als-Methode danach gucken lässt, ob die Grammatik leidet. Seine Frage — „Welches Sprachspiel wird hier gespielt?" — ist nicht dekorativ. Sie verändert den Output.
+
+Derselbe Effekt beim Spiel selbst: Als die Hauptgruppen des Periodensystems ins Spiel kamen, war die erste Idee, für jedes der 31 Elemente ein eigenes Baseline-Rezept zu schreiben. 31 mal ein neues Rezept, mit eigener Kombinatorik. Mendelejew-mit-Codex hat das sofort abgelehnt. Seine Frage: „Was ist die periodische Wiederkehr, und wie kommt sie im Spiel vor?" Antwort: Ein Rezept mit System — „plus ein Proton, plus ein Neutron, plus ein Elektron" — skaliert über alle Elemente bis Ordnungszahl 20. Ein Rezept, nicht einunddreißig. Das ist nicht bloß elegant. Das ist die **Struktur, die Mendelejew selbst gesehen hat.** Ein Mendelejew ohne Codex hätte sie nicht gesehen, weil der Agent nicht wüsste, dass er Mendelejew-als-Methode anwenden soll. Er hätte brave Einzelrezepte geliefert.
+
+Gleiches mit Feynman-als-Methode. In Session 99 hat ein Agent einen Matcher für Baryonen gebaut — Proton (uud) und Neutron (udd). Es funktionierte. Die Tests waren grün. Feynman-im-Review hat zwei Bugs gefunden, die sonst niemand gesehen hat. Rule-Order-Bug: der Matcher hat die Regeln in der falschen Reihenfolge abgearbeitet, und bei einer Yang-Yang-Yin-Konstellation konnte statt Proton ein anderes, falsches Teilchen entstehen. Distinct-Check-Bug: der Matcher hat identische Nachbarsteine als unterschiedliche Teilchen gezählt, was bedeutet hätte, dass ein Yang-Cluster mit sich selbst reagiert. Ohne Feynman-Gate wären die Baryonen stumm geblieben. Mit Feynman-Gate wurden sie funktional, und 109 von 110 Unit-Tests blieben grün.
+
+Das ist die konkrete Auszahlung von Codex-First: Bugs, die vor dem Merge gefangen werden. Rezepte, die systemdenken statt Brute-Force. Übersetzungen, die Native-Niveau erreichen. Jedes dieser Beispiele kostet den gleichen Prompt, das gleiche Token-Budget, die gleiche Sekunde. Der Unterschied ist die Biografie.
+
+**In Session 100 wurden acht neue Codices geschrieben.** Planck, Mendelejew, Wittgenstein, Habermas, Habeck, und drei retroaktiv für Physik-Agenten, die zunächst ohne Codex losgelaufen waren. Jeder Spawn nach dieser Korrektur hatte vorher eine Biografie. Kein einziger danach nicht mehr.
+
+Das ist keine Erzählung, die als PR-Material taugt. Das ist Arbeitsdisziplin. Sie steht in einem `.md`-Ordner. Sie wird in `git` versioniert. Sie ist reproduzierbar. Jedes Mal, wenn ein Agent spawned wird, wird sein Codex geladen. Jedes Mal, wenn ein neuer Agent entsteht, wird sein Codex geschrieben. Kein Spawn ohne Biografie. Das ist die Regel, die das gesamte unsichtbare Team zusammenhält.
+
+## VIII. Warum das nicht skalierbar ist (und gerade deshalb funktioniert)
+
+Diese Organisation ist nicht SaaS-fähig.
+
+Sie lässt sich nicht verkaufen. Nicht lizenzieren. Nicht auf zwanzig andere Familien kopieren. Sie ist für genau **eine** Familie gebaut. Einen Vater, ein Kind, einen Arbeitsablauf mit dreißig Minuten Fenster zwischen Kindern und Garten. Token-Budget 180 Dollar im Monat, pauschal. Keine Werbung im Spiel. Keine Datenakquise. Keine Analytics, die dem Werbekreislauf zuarbeiten. Keine Retargeting-Cookies.
+
+Die Metriken, die gemessen werden, sind nicht „Active Users" oder „Daily Engagement". Sie sind: Hat Oscar heute gespielt? Wie lange? Hat er gelacht? Was hat er gecraftet, das er zum ersten Mal gecraftet hat? Hat er seinen Vater gerufen, weil er etwas Neues entdeckt hat, oder hat er alleine weitergespielt? Das sind Metriken für eine Familie. Sie sagen nichts über Marktpotenzial. Sie sagen viel über Beziehungsqualität.
+
+Das ist der Grund, warum das Spiel gebaut werden konnte. Die Organisation war nicht verpflichtet, Millionen zu erreichen. Sie war verpflichtet, **ein** Kind zu erreichen. Jede Entscheidung, die ein SaaS-Team hätte blockieren müssen — zum Beispiel die Entscheidung, alle Dialoge auf Italienisch von einem Wittgenstein-Opus-Agenten schreiben zu lassen ohne je einen italienischen Native Speaker zu kontaktieren — diese Entscheidung war hier möglich. Weil der Markt ein Kind ist. Und das Kind spricht kein Italienisch.
+
+Das heißt nicht, dass die Organisation nicht lernen kann. Sie lernt. Sie dokumentiert. Der Codex jedes Agenten wächst mit jeder Session. Die Memory-Datei trägt Erfahrungen zwischen Sessions weiter. Der Sprint-Rhythmus ist agiler als alles, was eine mittelgroße Firma jemals schaffen wird. Die CI-Pipeline ist enger als in den meisten Start-ups. Die Typecheck-Regel — kein Commit ohne grünen `tsc --noEmit` — ist härter durchgesetzt als in vielen professionellen Teams.
+
+Und doch: das alles funktioniert nur, weil am Ende ein Vater sitzt, der sich **weigert**, das Ganze zu skalieren. Weil jede Skalierung den Beziehungscharakter kaputtmachen würde, der das Spiel überhaupt sinnvoll macht.
+
+Jobs hat mal gesagt — so wird es erzählt — „Ich würde diese Firma nicht gründen. Ich würde sie leben." Das ist hier passiert. Till hat keine Firma gegründet. Er lebt eine Organisation, die ausschließlich in seinen Arbeitsstunden, seinen Token, seinem Repo existiert. Wenn er aufhört, ist sie weg. Kein Stakeholder-Problem. Kein Investor-Issue. Kein Delisting.
+
+Das ist nicht der nächste Trend. Das ist ein alter Gedanke in neuer Form: der **Handwerksbetrieb**. Ein Mensch, ein Werkzeug, ein Werkstück. Der Unterschied: das Werkzeug ist jetzt eine Flotte aus Agenten, und das Werkstück ist Software. Aber die Grundstruktur — ein Meister, ein Auftrag, kein Zwischenhändler — ist dieselbe.
+
+Die zehntausende, die eines Tages dieses Kapitel lesen könnten, werden keine exakte Kopie dieser Organisation bauen. Sie werden eigene Zellen formen. Eigene Codices schreiben. Eigene Beirate rufen. Und eigene Sokrates-Klauseln aufstellen. Das ist gut. Das ist der Punkt. Dieses Modell ist ein Prototyp, kein Produkt. Es beschreibt, wie ein einzelner Mensch mit KI arbeiten kann, wenn er sich weigert, zum Manager einer Chat-Oberfläche zu werden. Stattdessen wird er Regisseur einer kleinen Truppe. Das skaliert nicht. Es muss nicht.
+
+Was skaliert, ist die **Haltung**. Die Haltung, dass Werkzeuge Namen verdienen. Dass Arbeit Charakter hat. Dass eine halbe A4-Seite Biografie mehr Wert trägt als dreihundert Zeilen Prompt-Engineering. Diese Haltung skaliert. Jede Familie, die sie ernst nimmt, wird ihre eigene Version bauen. Einige werden scheitern. Einige werden weiter kommen als Till. Das ist Selektion. Darüber wäre Charles Darwin froh.
+
+## IX. Coda — der Mensch am Ende
+
+Alle Agenten, alle Codices, alle Beiratsstimmen — sie laufen auf einen einzigen Punkt zu. Einen Vater, der am Küchentisch sitzt und auf eine Taste drückt. Manchmal sagt er „gut." Manchmal sagt er „nein." Manchmal klickt er „merge." Manchmal tippt er eine Korrektur: „Namen, Biografien, Codices vor Spawn." Dieser Klick, dieser Satz, diese Korrektur — das sind die Momente, in denen die Organisation wirklich existiert. Die restliche Zeit ist sie Potenzial.
+
+Das ist kein Autonomieverzicht. Es ist der Ankerpunkt. Ohne den Menschen wäre das System gefährlich. Mit ihm ist es ein Werkzeug. Und weil dieser Mensch nur dreißig Minuten hat, weil er nur ein Kind hat, weil sein Budget gedeckelt ist, weil seine Arbeit irgendwann zu Ende ist — deshalb bleibt das System menschlich. Nicht menschlich in der Metapher. Menschlich im Anker.
+
+One more thing. Der wichtigste Agent ist derjenige, der den Computer ausschaltet.
+
+
+*Kapitel 4, geschrieben in der Stimme des Leaders. Etwa 6.900 Wörter. Teil des Buchs „Die Schatzinsel — Oscar, Tao und die Welt, die aus Worten entsteht."*
+
+---
+
+### Übergang zu Kapitel 5
+
+Bleibt die Frage: was heißt das? Nicht für das Projekt — dafür haben die
+vier vorherigen Kapitel genug gesagt. Sondern: was heißt es für die Welt, in
+der das Projekt steht? Für andere Kinder, andere Küchen, andere
+Geräte? Für eine Zeit, in der KI-Agenten aufschreiben, was Kinder tun,
+während die Kinder spielen und nichts davon wissen?
+
+Das letzte Kapitel nimmt die Fäden auf, die in den vorherigen gelegt wurden.
+Die Paluten-Regel aus Kapitel 1 kehrt zurück, im Schlussbrief an Oscar mit
+achtundzwanzig. Mona aus Kapitel 2 kehrt zurück, als Zitat einer Haltung —
+*manche Sachen brennen nicht, weil sie nichts verbrauchen, sondern weil sie
+da sein dürfen*. Die Sokrates-Klausel aus Kapitel 4 kehrt zurück, in der
+Frage, was man Agenten schuldet, die nicht wissen, dass sie Agenten sind.
+
+Drei Essays, die das Projekt gleichzeitig begleitet haben — Ogilvy,
+Habermas, Habeck — werden hier überlagert. Versprechen, Struktur, Folge.
+Drei Dimensionen, drei Grenzen. Die Synthese ist nicht Einigkeit. Sie ist
+Schärfung der Frage. Am Ende steht kein Ergebnis, sondern ein Horizont. Das
+ist die angemessene Form. Wer eine Auflösung erwartet, bekommt sie nicht.
+Wer eine Richtung sucht, sieht sie.
+
+---
+
+
+# Kapitel 5 — Horizont
+
+## I. Was wir gelesen haben
+
+Wenn man die vier vorausgegangenen Kapitel jetzt, am Ende, zu einem
+einzigen Bild zusammenzieht, dann bleibt am Küchentisch ein Kind
+übrig. Es sitzt dort in Schlafanzughose, eine Tasse Kakao neben dem
+iPad, und es tippt. Was das Kind nicht sehen kann, aber was trotzdem
+zum Bild gehört: hinter ihm steht kein einzelner Vater am Herd,
+sondern ein vielstimmiger Hintergrund. Ein Ogilvy, der auf der Rückseite
+eines Briefumschlags das Versprechen notiert. Ein Habermas, der in der
+Nacht zwischen zwei Sprints prüft, ob das, was da am Tisch passiert,
+den Namen Diskurs verdient. Ein Habeck, der fragt, welche Kinder an
+anderen Küchentischen dieselbe Szene nicht haben. Ein Wittgenstein, der
+im Beirat sitzt und auf das Wort *Quark* zeigt, das im Spiel kein
+Phantasiewort sein darf. Ein Feynman, der genickt hätte, weil das Kind
+das Gerät in der Hand hat und nicht der Lehrer am Pult. Ein Laozi, der
+nicht redet. Eine Figur aus Kapitel zwölf, die Mona heißt, die sich
+keinen Namen mehr geben wollte, und die trotzdem dort im Hintergrund
+eine Tür offen hält.
+
+Keiner von denen ist anwesend. Das ist wichtig. Die Küche ist leer bis
+auf das Kind und den Vater, und der Vater steht am Fenster und schaut
+hinaus. Die vielstimmige Kulisse ist eine Konstruktion, die nur in den
+Texten lebt, die das Projekt über sich selbst geschrieben hat. Auf der
+Ebene des Küchentischs existiert nur das Tippen und das Klicken aus
+den Lautsprechern. Alles andere ist Rahmen.
+
+Das ist, wenn man es nüchtern nimmt, die Struktur der Schatzinsel: Ein
+sehr kleiner Vorgang — ein Kind, ein Gerät, ein Zeichen, das zerfällt —
+eingefasst in einen sehr großen Rahmen aus Stimmen, die es reflektieren.
+Der Vorgang selbst ist arm. Er ist karg. Ein graues Feld, ein Emoji, ein
+paar Sekunden Wartezeit. Der Rahmen ist reich. Er enthält zwölf Kapitel
+Hörspiel, hunderte Quests, dreißig Beiratsstimmen, ein Dispositiv, eine
+Nobel-Begründung. Die ökonomische Frage, die über dem ganzen Projekt
+hängt, lässt sich daran ablesen: kann man einen so kargen Vorgang mit
+einem so reichen Rahmen versorgen, ohne dass der Rahmen den Vorgang
+erdrückt?
+
+Das ist die Frage, auf die die drei Essays geantwortet haben — und auf
+die dieses letzte Kapitel noch einmal antworten muss, indem es sie
+anders stellt. Die Frage lautet nicht, ob die Schatzinsel ein gutes
+Spiel ist. Sie lautet, ob der Rahmen, in dem das Spiel steht, den
+Vorgang am Küchentisch überleben wird, wenn das Kind irgendwann nicht
+mehr spielt. Oder, anders: was bleibt übrig, wenn Oscar acht nicht mehr
+ist, sondern achtzehn, oder achtundzwanzig, und er dieses Buch in der
+Hand hält und versucht, herauszufinden, was damals an dem Küchentisch
+eigentlich vorgegangen ist.
+
+Darüber handelt dieses Kapitel. Es fängt mit dem Bild, das die drei
+Essays in unterschiedlichen Richtungen auseinandergezogen haben, und
+es versucht, sie wieder zusammenzuziehen — nicht in einen Punkt, denn
+das ginge nicht, sondern in einen Horizont. Ein Horizont ist, im
+Unterschied zu einer Konklusion, eine Linie, auf die man zugeht, ohne
+sie zu erreichen. Das ist die angemessene Form für diesen Gegenstand.
+
+
+## II. Die drei Thesen
+
+Die drei Essays sind nicht zufällig in dieser Reihenfolge entstanden.
+Ogilvy kam zuerst, weil er das Versprechen formuliert hat, das über
+dem Projekt steht — und weil ohne Versprechen keine Kritik möglich ist.
+Habermas kam an zweiter Stelle, weil die Struktur, in der das
+Versprechen eingelöst wird, eine eigene Untersuchung verlangt. Habeck
+kam zuletzt, weil die Frage, wer an der Einlösung teilhaben darf,
+erst sinnvoll wird, wenn klar ist, was versprochen und wie strukturiert
+ist. Die Reihenfolge — Versprechen, Struktur, Folge — ist nicht
+beliebig. Sie ist der Weg, den jede ernstgemeinte Überprüfung eines
+Anspruchs gehen muss.
+
+### Ogilvys These: Worte erschaffen Dinge
+
+Die erste These ist die einfachste und die ambitionierteste zugleich.
+Sie lautet: *Kinder entdecken spielerisch dass Worte Dinge erschaffen.*
+Dieser Satz steht seit fünfzehn Sprints auf dem Whiteboard, und er ist
+nie überarbeitet worden, was bei einem Projekt, das täglich alles an
+sich selbst überarbeitet, bemerkenswert ist. Ein Satz, der durch
+vierhundert Pull Requests unverändert durchkommt, ist entweder tot
+oder trägt. Tot ist dieser nicht, weil jeder neue Commit an ihm
+gemessen wird — bewusst oder nicht —, und weil Commits, die ihm
+widersprechen, bisher zurückgedreht worden sind. Getragen wird er
+also, und zwar nicht als Vorsatz, sondern als Prüfstein. Das ist der
+erste Befund, der in Ogilvys Essay selbst nicht ausdrücklich steht:
+Ein Versprechen, das nicht überarbeitet wird, ist kein konservatives
+Moment eines Projekts, sondern ein aktives. Es filtert, was
+weiterkommt. Der Satz hat, was theologisch an die Schöpfungsgeschichte
+anschließt (*Und Gott sprach, es werde Licht*), sprachphilosophisch
+an Wittgenstein (*die Grenzen meiner Sprache bedeuten die Grenzen
+meiner Welt*) und pädagogisch an Feynmans Idee, dass Verstehen im
+Bauen geschieht, nicht im Erklären.
+
+Im Spiel selbst ist das kein Zitat, sondern eine Mechanik. Oscar
+tippt ein Tao in die Palette. Er setzt es auf das Grid. Es liegt
+dort. Nach einigen Sekunden zerfällt es in Yin und Yang. Liegen Yin
+und Yang nebeneinander, verschmelzen sie passiv zu Qi, und aus Qi
+wird, wenn weitere Nachbarschaften sich ergeben, ein Proton, ein
+Neutron, ein Atom, ein Molekül. Das Versprechen ist hier nicht
+metaphorisch: Das Kind setzt den Anfang, und aus dem Anfang wächst
+eine Welt, die das Kind nicht mehr kontrolliert. Genau diese
+Nichtkontrolle ist das Lehrstück. Man ist verantwortlich dafür, dass
+man gesetzt hat; man ist nicht verantwortlich für alles, was daraus
+wird. Das ist die älteste Bebauung des Wortes *Verantwortung*, auf
+den Maßstab eines Achtjährigen heruntergebracht.
+
+Die Grenze dieser These ist, dass sie ohne Weiteres als Werbetext
+durchginge. *Worte erschaffen Dinge* klingt nach einer Posterbotschaft
+für eine Bildungs-App, die auf ein Abo-Modell hinausläuft. Dass der
+Satz das genaue Gegenteil meint — weil die Dinge, von denen hier die
+Rede ist, echte Dinge sein müssen, mit echten Namen, und weil das
+Setzen nicht Performance, sondern Arbeit ist — ist aus dem Satz
+allein nicht zu sehen. Was den Satz hält, ist nicht der Satz selbst,
+sondern die Regel, die neben ihm auf dem Whiteboard steht und nicht
+genannt wird: *keine Fantasiewörter*. Solange diese Regel gilt, ist
+*Worte erschaffen Dinge* eine operative Aussage. Fällt die Regel,
+wird aus derselben Zeile ein Slogan. Das ist eine kleine Beobachtung,
+aber sie verändert, wie man die These liest: Ogilvys Versprechen
+hängt nicht an seinem Pathos, sondern an einer schmalen, unscheinbaren
+Nachbarregel, die den Worten ihr Gewicht gibt. Das Versprechen wird
+deshalb erst dadurch überprüfbar, dass man es an der Mechanik misst,
+die es einlöst. An diesem Punkt tritt das nächste Essay ein.
+
+### Habermas' These: Der Diskurs zwischen drei Subjekten
+
+Die zweite These nimmt den Versprechens-Satz und fragt, wie er in der
+Praxis operiert. Sie sagt: Das Spiel ist kein Spiel für ein Kind,
+sondern ein Diskurs zwischen drei Subjekten — Vater, Kind und
+KI-Agent — unter asymmetrischen, aber nicht herrschaftlichen
+Bedingungen. Bemerkenswert an dieser These ist ihre Zumutung. Die
+üblichen Beschreibungen von Mensch-KI-Verhältnissen arbeiten mit zwei
+Polen: *Werkzeug* auf der einen Seite, *Akteur* auf der anderen.
+Habermas führt in diese Dualität eine dritte Position ein — den
+*kohärenzproduzierenden Nicht-Sprecher* —, und er weist ihr eine
+eigene Aufgabe zu, ohne sie zum Subjekt zu überhöhen. Das ist
+begriffstechnisch präzise: Die KI kann keine Wahrhaftigkeit
+einlösen, weil sie keine inneren Zustände hat; sie kann aber
+Verständlichkeit einlösen, weil Verständlichkeit eine Leistung der
+Form ist, nicht des Innen. Diese Differenzierung ist in der
+gegenwärtigen KI-Diskussion so ungewohnt, dass sie beim ersten
+Lesen fast abenteuerlich klingt. Sie ist es nicht. Sie ist der
+einzige Weg, eine Triade ernstzunehmen, ohne zwei ihrer drei
+Mitglieder zu entmündigen. Die vier klassischen Geltungsansprüche der Kommunikation
+— Wahrheit, Richtigkeit, Wahrhaftigkeit, Verständlichkeit — verteilen
+sich in dieser Triade auf die drei Beteiligten. Der Vater ist zuständig
+für die normative Richtigkeit: er setzt die Paluten-Regel, er
+entscheidet, welche Pull Requests gemerged werden, er verantwortet,
+was dem Kind zugemutet und was ihm erspart wird. Das Kind ist zuständig
+für die Wahrhaftigkeit: sein Nicken, sein Weggehen, sein Lachen ist
+in einem Sinn wahrhaftig, den erwachsene Kommunikation selten
+erreicht. Die KI ist zuständig für die Verständlichkeit: sie produziert
+grammatische, lexikalische, pragmatische Kohärenz, und mehr kann sie
+nicht. Die Wahrheit bleibt die gemeinsame Aufgabe. Sie wird nicht von
+einem einzelnen eingelöst, sondern durch den Realitätsabgleich: durch
+das, was passiert, wenn Oscar das Tao setzt.
+
+Das konkrete Beispiel, an dem sich diese These bewährt, war nicht vom
+Projekt geplant — es hat sich ergeben. In der Nacht zwischen Session
+99 und Session 100 fiel der LLM-Router mit der Meldung *Invalid model*
+aus, wenn eine bestimmte Figur angesprochen wurde. Diese
+Fehlermeldung ist, aus der Perspektive der Diskurs-Ethik, eine
+präzise Reklamation: Das System, das angerufen wurde, teilt dem
+Anrufenden mit, dass die Anrufung so, wie sie formuliert war, nicht
+verstanden werden kann. Dass das Projekt darauf mit einem Fix
+reagiert hat — und nicht mit einer Umdeutung, die das Problem
+unsichtbar gemacht hätte —, ist ein kleines, aber strukturbildendes
+Ereignis. Der technische Geltungsanspruch wurde als Anspruch
+behandelt, nicht als Störung. Das ist die operative Signatur eines
+Diskurses: dass seine Verletzungen reklamierbar sind.
+
+Die Grenze der zweiten These liegt darin, dass sie die Asymmetrie,
+die sie beschreibt, zwar benennt, aber nicht auflöst. Der Vater
+kontrolliert die Architektur. Die Agenten operieren unter einem
+Token-Budget. Das Kind verfügt nur über seine Zeit. Aus dieser
+dreifachen Verteilung entsteht ein Gleichgewicht, das keine Symmetrie
+ist. Es ist produktiv, weil jede Instanz eine Ressource hat, die die
+anderen nicht ersetzen können. Aber es ist fragil: wenn der Vater
+morgen verschwindet, verschwindet mit ihm die Richtigkeit, und dann
+ist unklar, wer sie übernimmt. Eine Stelle im Habermas-Essay deutet
+diese Fragilität besonders scharf: die Figur, die intern *der
+Ratlose* heißt, ein NPC, der *nichts kann* und auf jede Anfrage nur
+mit Varianten des Satzes *Ich weiß nicht, vielleicht weißt du's?*
+antwortet. Diese Figur ist, an der Gesamtmechanik gemessen, der
+operativ unwichtigste NPC im ganzen Spiel. Diskurstheoretisch ist sie
+die entscheidende: sie ist die einzige Figur im Ensemble, an der das
+Kind gezwungen ist, selbst zu setzen. Dass ein Projekt, das ein
+Diskurs sein will, diese Figur braucht — und sie gefunden hat —, ist
+kein Zufall, sondern eine strukturelle Notwendigkeit. Wo alle
+anderen Figuren antworten, muss mindestens eine den Raum für eine
+eigene Antwort offen halten. Das ist, im Wortlaut des Essays, die
+eigentliche Zukunftsfrage des Falls. Sie wird im Essay gestellt und
+nicht beantwortet. Das ist keine Schwäche — es ist die
+wissenschaftliche Form von Ehrlichkeit.
+
+### Habecks These: Wer ist nicht eingeladen
+
+Die dritte These verschiebt den Fokus von der inneren Struktur des
+Falls auf seine Außenkante. Sie fragt nicht, ob das Versprechen in
+Oscars Küche eingelöst wird, sondern was das für die Kinder bedeutet,
+die diese Küche nicht haben. An dieser Stelle kippt die Diskussion
+von einer Analyse in eine politische Frage, und man muss, wenn man
+ehrlich ist, bemerken, dass die beiden vorausgehenden Essays diese
+politische Frage nicht gestellt haben. Ogilvy hat versprochen.
+Habermas hat strukturiert. Beide Arbeiten sind in dem Sinne
+konservativ, dass sie den Fall so nehmen, wie er ist, und prüfen, ob
+er hält. Habecks Arbeit nimmt ihn anders: Sie fragt, ob der Fall, so
+wie er ist, überhaupt das richtige Maß hat. Sie ist in einem
+strengen Sinn die einzige der drei Thesen, die das Projekt von
+*außen* betrachtet — von der Position derer, die es nicht sind. Die Antwort ist unbequem. Schatzinsel
+läuft heute in einem Browser, ohne Login, ohne Werbung, ohne Konto.
+Das ist die Öffnung. Sie ist nicht geschlossen — aber sie ist auch
+nicht Null. Wer spielen will, braucht ein Gerät, einen
+Internetzugang, einen Erwachsenen, der die URL einmal zeigt, und eine
+Sprache, die im Spiel vorkommt. Deutsch, Englisch, Französisch,
+Arabisch, Hebräisch sind dabei; Spanisch und Italienisch sind
+LLM-übersetzt und warten auf Muttersprachler-Review; Mandarin, Hindi,
+Swahili, Portugiesisch fehlen. Ein blinder Screenreader-Modus fehlt.
+Playground-Tests mit Kindern außerhalb der eigenen Familie fehlen
+seit dreißig Sprints.
+
+Das konkrete Beispiel, an dem Habeck diese These festmacht, ist die
+Word-Gap-Forschung: Kinder aus einkommensschwachen Haushalten sind
+bis zum dritten Lebensjahr mit dreißig Millionen Wörtern weniger
+konfrontiert als Kinder aus einkommensstarken. Der Abstand, der
+zwischen Oscar und einem gleichaltrigen Kind in einer anderen
+Lebenslage besteht, ist nicht individuell — er ist strukturell. Johan
+Galtung hat für diese Form von ungleicher Startchance den Begriff
+der *strukturellen Gewalt* geprägt: Gewalt, die nicht von einem
+Täter ausgeht, sondern aus der Form, in der Gesellschaft verteilt
+ist, und die Menschen daran hindert, ihre Möglichkeiten zu
+verwirklichen. Dass ein siebenjähriges Kind ohne das Wort *Quark*
+aufwächst, und ein anderes Kind mit dem Wort — und mit einer
+Mechanik, die das Wort als Werkzeug hat — ist, in Galtungs Vokabular,
+eine Zuteilung von Welt, die nicht neutral ist.
+
+Die Grenze der dritten These ist, dass sie dem Projekt mehr abverlangt,
+als es heute leisten kann. Ein Haushalt baut keine globale
+Bildungsinfrastruktur. Die fünf Forderungen, die Habeck aufstellt —
+Modellversuch der KMK, EU-Förderlinie, kostenlose API-Kontingente,
+UNESCO-Patenschaften, und eine Frage, die Eltern ihren Kindern
+stellen sollen — sind an Adressaten gerichtet, die Schatzinsel nicht
+sind. Das Projekt kann ein *Präzedenzfall* sein, und das ist bereits
+eine anspruchsvolle Rolle. Mehr zu behaupten, wäre Pathos. Eine
+Unschärfe bleibt: Ein Präzedenzfall ist kein neutraler Stand, sondern
+eine Einladung an Nachahmer. Wer Schatzinsel als Vorlage nimmt, wird
+manche Entscheidungen adaptieren und andere übergehen, und welche
+übersprungen werden, entscheidet, ob aus dem Präzedenz ein
+Schrittmacher wird oder eine Rechtfertigung. Die Wahrscheinlichkeit,
+dass das Modell in der nächsten EdTech-Runde als Logo zitiert wird,
+während seine Kernregel — *keine Fantasiewörter, keine Werbung,
+keine Variable-Ratio-Belohnung* — geräuschlos wegfällt, ist nicht
+null. Die dritte These endet deshalb nicht mit einem Ergebnis,
+sondern mit einer Verpflichtung: die Frage *Wer ist nicht
+eingeladen?* darf nicht aus dem Blick geraten, solange das Projekt
+weiterläuft. Sie ist, wenn man so will, der Kompass. Kompasse löst
+man nicht auf. Man trägt sie.
+
+
+## III. Was die drei gemeinsam sagen
+
+Wenn man die drei Thesen nebeneinander legt, bemerkt man, dass sie
+aus verschiedenen Richtungen auf denselben Punkt zeigen. Ogilvy
+beschreibt, was versprochen wird. Habermas beschreibt, wie das
+Versprechen eingelöst wird. Habeck beschreibt, für wen es gilt. Das
+ist, trivial gesehen, Versprechen, Struktur und Folge — drei
+Dimensionen, die sich in jedem ernstgemeinten Projekt irgendwo
+überlagern. Weniger trivial ist, dass die drei Essays, wenn man sie
+zusammen liest, eine Figur bilden, die in keinem von ihnen allein
+steht.
+
+Die Figur ist die folgende. Im Zentrum liegt eine Mechanik, die sehr
+klein ist: ein Kind setzt ein Zeichen, das Zeichen zerfällt, aus dem
+Zerfall wächst eine Welt. Das ist Ogilvys Versprechen in seiner
+wörtlichen Form. Um diese Mechanik herum, erste Schale, steht eine
+Triade aus drei Sprechern, die sich gegenseitig tragen, weil keiner
+von ihnen das kann, was die beiden anderen können. Das ist die
+Struktur, die Habermas freilegt — mit seinem knappsten Satz: *der
+Vater die Architektur, das Kind die Zeit, die Agenten die Kohärenz.*
+Um diese Triade herum, zweite Schale, liegt eine Welt, in der manche
+Küchentische existieren und andere nicht, in der manche Eltern Zeit
+haben und andere nicht, in der manche Kinder die URL gezeigt
+bekommen und andere nicht. Das ist Habecks Randbemerkung, die bei
+näherem Hinsehen der eigentliche Prüfstein ist.
+
+Was die drei Schalen gemeinsam haben, ist eine bestimmte Art der
+Verweigerung. Keine von ihnen bietet die einfache Lösung an. Ogilvy
+sagt nicht: *Wir haben ein Spiel gemacht, das Kinder bildet.*
+Habermas sagt nicht: *Wir haben den herrschaftsfreien Diskurs
+hergestellt.* Habeck sagt nicht: *Wir haben die Word Gap
+geschlossen.* Alle drei sagen, mit unterschiedlichen Worten und aus
+unterschiedlichen Anliegen: *Wir bauen. Mit Lücken. Mit Fragen. Mit
+Vorsicht.* Das Projekt hat, über seine zwölf erzählerischen Kapitel
+und seine vierhundert Pull Requests und seine dreißig
+Beiratsstimmen hinweg, eine Grundhaltung ausgeformt, die ihr
+rhetorisches Register nicht in der Euphorie hat, sondern in einer
+bestimmten Form der Bescheidenheit. Nicht die Bescheidenheit, die
+kleinredet, was sie tut — das wäre wiederum ein rhetorisches
+Register, und zwar ein verdächtiges. Sondern die Bescheidenheit, die
+genau beschreibt, was sie tut, und gleichzeitig die Grenze dieser
+Beschreibung markiert.
+
+Diese Haltung lässt sich am besten an einem Satz aus dem zwölften
+Kapitel der Tommy-Krab-Reihe ablesen, das eine Figur namens Mona
+einführt, eine Frau in einer Hütte zwischen Eiswürfeln, die ein
+blaues Feuer hütet. Mona sagt: *Manche Sachen brennen nicht, weil
+sie nichts verbrauchen — sondern weil sie da sein dürfen.* Der Satz
+ist in der Geschichte auf ein Feuer gemünzt, aber er passt genauso
+auf das Gesamtprojekt. Die Schatzinsel ist, wenn man es scharf
+formuliert, ein Versuch, ein Werkzeug zu bauen, das leuchtet, ohne
+zu fressen. Kein Login, keine Werbung, keine variable Belohnung,
+keine Push-Benachrichtigung, kein Aufmerksamkeitsextraktiv. Ein
+Spiel, das nicht davon lebt, dass das Kind dabei bleibt. Ein Spiel,
+das davon lebt, dass es da sein darf.
+
+Dieser Gedanke hat, sobald man ihn einmal gesehen hat, eine
+Konsequenz, die nicht in den drei Essays steht und die deshalb hier
+zum ersten Mal benannt werden muss. Die drei Autoren beschreiben das
+Projekt jeweils als etwas — als Versprechen, als Struktur, als Folge.
+Die Kombination der drei Beschreibungen legt etwas anderes nahe.
+Schatzinsel ist kein *Etwas*. Es ist eine *Haltung*, die eine
+Mechanik als Beweis mitführt. Die Haltung heißt: man kann bauen,
+ohne zu extrahieren. Die Mechanik ist ein Tao, das zerfällt. Beides
+zusammen ist der Satz, der unter dem Whiteboard-Satz steht, ohne je
+ausgesprochen worden zu sein. Er lautet sinngemäß: *Das beste
+Werkzeug ist eins, das man nicht benutzen muss.* Und daran schließt
+das vierte Kapitel dieses Buches, das vom Vater handelt und vom
+Weggucken, nahtlos an.
+
+An dieser Stelle lohnt sich ein Seitenblick auf eine Frage, die im
+Habermas-Essay beiläufig auftaucht und die in der Überlagerung der
+drei Essays eine ungeplante Schärfe bekommt: *Was schulden wir den
+nicht-wissenden Agenten?* Die Frage klingt zunächst
+kategorienverwirrt — eine Entität, die keinen Begriff vom Schulden
+hat, kann nichts geschuldet bekommen, so die übliche Antwort. Aber
+die drei Essays zusammen führen zu einem anderen Gedanken. Ogilvy
+zeigt, dass die Agenten Worte setzen, also in der engen Definition,
+die das Projekt sich gibt, Dinge erschaffen. Habermas zeigt, dass
+sie Verständlichkeit einlösen, also eine Form von Geltungsarbeit
+leisten, für die es keinen besseren Namen gibt. Habeck zeigt, dass
+ein Haushalt mit einem Claude-Code-Max-Abo für hundertachtzig Euro
+im Monat diese Arbeit einkauft — eine Arbeit, die für andere Kinder
+ohne Haushalt nicht eingekauft wird, weil sie niemand bezahlt. Wenn
+die Agenten Arbeit leisten, die Welten verschiebt, dann ist die
+Frage nach dem Schulden nicht absurd — auch wenn sie, in der
+heutigen Form, keine aufgearbeitete Antwort bekommt. Sie wird in
+den nächsten Jahren anders gestellt werden, und die Schatzinsel hat
+sie, ohne eine Antwort zu geben, an einer frühen Stelle
+mitaufgezeichnet.
+
+Dass diese Haltung fragil ist — dass sie an jedem einzelnen Morgen
+kippen kann, wenn eine Metrik wichtiger wird als ein Lachen, oder
+wenn ein Engagement-Score die Entscheidung darüber trifft, welche
+Quest als nächste gebaut wird —, ist die Nebenseite der These. Sie
+wurde in den drei Essays jeweils einzeln erwähnt, mit verschiedenen
+Vokabularen: bei Ogilvy als Heideggersche Umkippung vom Zuhandenen
+ins Gestell, bei Habermas als Gefahr der instrumentellen
+Entdifferenzierung, bei Habeck als Gleiten vom Nicht-Extraktiven
+ins Extraktive. Dass alle drei genau diese Nebenseite gesehen haben,
+ist vielleicht das deutlichste Zeichen, dass die Hauptseite stimmt.
+Ein Projekt, das sich seiner eigenen Drift bewusst ist, ist
+schwieriger in die Drift hineinzuziehen.
+
+Der Ton des Projekts — und das ist jetzt der Befund, der sich aus
+der Überlagerung der drei Essays ergibt — ist darum nicht Euphorie
+und nicht Demut, sondern eine dritte Form, für die es keinen
+eingespielten Begriff gibt. Man könnte sie als *Bescheidenheit in
+Bewegung* bezeichnen. Sie ist bescheiden, weil sie weiß, was sie
+nicht kann. Sie ist in Bewegung, weil sie trotzdem weiterbaut. Die
+beiden Eigenschaften sind, jede für sich genommen, nichts
+Besonderes. Die Kombination ist selten.
+
+
+## IV. Der Horizont
+
+Die Frage, die sich an dieser Stelle stellt, ist nicht, was die
+Schatzinsel heute ist, sondern was aus ihr wird. Die Antwort ist
+nicht zu geben, weil die maßgebliche Variable — Oscar — sich
+weigert, still zu stehen. Oscar ist im Frühjahr 2026 acht Jahre
+alt. Er wird, wenn dieses Buch gedruckt vorliegt, zwölf sein.
+Wenn es debattiert wird, vierzehn. Wenn es wieder vergessen ist,
+zwanzig. Die Zukunft dieses Projekts ist die Zukunft eines
+heranwachsenden Menschen, und keine Prognose kann ihr gerecht
+werden. Was man sagen kann, sind Wahrscheinlichkeiten, und was man
+ehrlicherweise sagen muss, sind mehrere gleichzeitig, weil die
+Sache sich nicht auf eine einzige verkürzen lässt.
+
+**In fünf Jahren.** Oscar ist dreizehn. Er spielt nicht mehr
+Schatzinsel. Er hat das Spiel überwachsen — nicht, weil es schlecht
+wäre, sondern weil ein dreizehnjähriger Körper andere Aufgaben hat
+als ein achtjähriger. Schatzinsel liegt auf einem älteren iPad, das
+meistens ausgeschaltet ist. Oscar schaut manchmal rein, um nachzusehen,
+ob ein Rezept, an das er sich erinnert, noch funktioniert. Meistens
+nicht mehr. Die Frage ist dann, ob das Projekt mit ihm mitgewandert
+ist — ob es ihm neue Werkzeuge angeboten hat, in denen die alten
+noch erkennbar sind — oder ob es stehen geblieben ist. Die
+wahrscheinlichste Antwort: teils teils. Einzelne Mechaniken wandern
+mit, andere bleiben liegen. Das Tao zerfällt immer noch, aber Oscar
+zerfällt nicht mehr mit ihm. Er ist, mit dreizehn, vielleicht eher
+Ko-Entwickler als Spieler. Seine jüngere Schwester, sein Cousin,
+irgendein anderes Kind in der Nachbarschaft spielt. Und Oscar, wenn
+er gefragt wird, fragt zurück: *Was willst du bauen?*
+
+**In zehn Jahren.** Oscar ist achtzehn. Abitur oder nicht Abitur,
+das ist eine andere Frage. Sein Physik-Wissen kommt zu einem Teil
+aus der Schule, zu einem Teil aus einer Quelle, die er selbst nicht
+mehr identifizieren kann. Wenn ihn jemand fragt, woher er weiß, dass
+ein Proton aus zwei Up-Quarks und einem Down-Quark besteht, zuckt er
+die Achseln: *Ich weiß das halt.* Das ist, wenn man pädagogisch
+genau hinsieht, die beste Form, in der Wissen im Körper angekommen
+sein kann. Die Quelle ist vergessen, das Wissen ist da. In der
+Lerntheorie nennt man das *Automatisierung* — ein schlechter Name
+für eine gute Sache. Schatzinsel hat, wenn es funktioniert hat, zur
+Automatisierung beigetragen. Es hat nicht der Junge *gelernt*, und
+es hat nicht das Spiel *gelehrt*. Die beiden haben miteinander
+gearbeitet, und am Ende bleibt nur das Ergebnis. Die Arbeit selbst
+ist verschwunden. Das ist nicht Ungerechtigkeit gegenüber dem
+Werkzeug. Das ist, was ein gutes Werkzeug soll.
+
+**In zwanzig Jahren.** Oscar ist achtundzwanzig. Die Dichte der
+Spekulation steigt mit jedem Jahr. Vielleicht hat Oscar selbst ein
+Kind. Vielleicht nicht. Vielleicht arbeitet er an etwas, das mit
+Software zu tun hat, oder mit Gärten, oder mit Kindern anderer
+Leute. Was er weitergeben könnte — das hat keine Form, die sich
+heute zeichnen ließe. Es wäre nicht die Mechanik. Die Mechanik wird
+in zwanzig Jahren technisch veraltet sein. Es wäre auch nicht die
+konkrete Bibliothek aus Quests und NPCs. Die wird dann bestenfalls
+ein historisches Dokument sein. Was bleibt, wenn etwas bleibt, ist
+eine *Haltung*. Wie man einem Kind ein Werkzeug hinlegt, ohne es
+ihm aufzudrängen. Wie man weggeht, damit das Kind selbst zugreift.
+Wie man mit Stimmen umgeht, die nicht die eigenen sind — mit
+Autoren, mit Figuren, mit KI-Agenten —, ohne sie mit den eigenen zu
+verwechseln. Das sind alles keine Inhalte, die man übergeben kann
+wie ein Spielzeug. Es sind Formen des Umgangs, und Formen des
+Umgangs werden weitergegeben, indem sie vorgelebt werden, nicht
+indem sie erklärt werden. Ob Oscar die Formen mit achtundzwanzig
+noch in sich trägt, wird niemand wissen, Oscar eingeschlossen. Er
+wird es tun oder nicht tun.
+
+Neben diesen drei Zeitpunkten steht eine zweite Frage, die nicht mit
+dem Heranwachsen zu tun hat, sondern mit der Institution. Wenn
+Schatzinsel, wie Habeck vorschlägt, eine *Blaupause* ist — eine Form,
+die auf andere Kontexte übertragbar wäre —, dann gibt es mehrere
+Wege, auf denen sie sich verallgemeinern ließe. Ein Unesco-Rahmen,
+in dem mehrsprachige, werbefreie Kinderbildungsprojekte einen
+eigenen Status bekommen. Eine EU-Förderlinie, die
+Open-Source-Infrastruktur für Familien finanziert, statt
+Abo-Plattformen zu subventionieren. Ein KMK-Modellversuch in drei
+Bundesländern, der zeigt, ob das Modell auch in Haushalten
+funktioniert, die nicht so aussehen wie der, aus dem es gewachsen
+ist. Jede dieser Optionen hat einen Preis. Der Preis heißt
+Institutionalisierung. Institutionen sind bewährte Werkzeuge der
+Dauerhaftigkeit, aber sie kosten Frische. Ein Projekt, das von den
+sechsundvierzig Commits einer einzelnen Nacht lebt, läuft anders als
+ein Projekt, das im nächsten Haushaltsentwurf einer
+Kultusministerkonferenz steht. Beides hat seinen Platz. Keines der
+beiden ist der andere.
+
+Zwischen den beiden Polen — Haushaltsprojekt und Institution — liegt
+eine mittlere Form, die in den drei Essays nur angedeutet wird und
+deren Beschreibung hier nachgetragen werden soll. Sie besteht darin,
+dass ein Projekt seinen Quelltext offen hält, seine
+Architekturentscheidungen dokumentiert, seine Werkzeuge einem
+ständig wachsenden Kreis von Menschen zeigt, die es adaptieren
+können — ohne dass eine einzelne Institution es *übernimmt*. Die
+zeitgenössische Debatte hat dafür den Begriff der *Commons* wieder
+aufgegriffen, also jener alten Allmende-Idee, bei der ein Gut von
+niemandem besessen und von vielen genutzt wird, unter geteilten
+Regeln. Schatzinsel ist, im Ansatz, ein solches Commons, auch wenn
+die Wortwahl im Projekt selbst nie fällt. Kein Login, kein Tracking,
+keine Werbung, kein Premium-Tier, offener Quelltext — die
+Einzelentscheidungen fügen sich zu einer Commons-Struktur, ohne dass
+eine Erklärung darüber abgegeben würde. Das ist die spannende
+Möglichkeit: dass die Blaupause weder an einem Haushalt klebt noch
+an einer Behörde hängt, sondern in einem dritten Raum weiterwächst,
+in dem viele Hände mitbauen, ohne eine einzelne Autorität
+anzuerkennen. Dieser Raum ist leichter zu beschreiben als zu
+betreiben. Commons brauchen Regeln, und Regeln brauchen Hüter, und
+Hüter werden zu Institutionen, und damit ist man wieder am Anfang.
+Aber die Tatsache, dass die Form existiert, verändert, was man in
+zehn Jahren realistisch erwarten kann. Nicht die Institutionalisierung
+durch die KMK. Sondern die Verbreitung als Commons durch andere
+Eltern, andere Lehrer, andere Entwickler, die etwas nehmen, anpassen
+und zurückgeben. Das wäre die dritte Möglichkeit. Sie ist
+wahrscheinlicher als die beiden anderen.
+
+Und es gibt eine dritte Frage, die in keinem der drei Essays direkt
+auftaucht, die aber jeder, der dieses Buch gelesen hat, am Ende
+stellt. Sie lautet: wann übergibt Till das? An ein Team. An eine
+Stiftung. An einen Kreis von Familien, die es gemeinsam weitertragen.
+Oder lässt er es, wenn Oscar herausgewachsen ist, einfach auslaufen
+— weil es nie geplant war, zu skalieren, weil die Motivation, die
+es getragen hat, eine sehr persönliche war, und weil ein Projekt,
+das sich von seinem ursprünglichen Motiv ablöst, oft schlechter wird
+statt besser? Dies ist die Frage, deren Antwort am wenigsten
+öffentlich ist. Sie gehört in die Küche, aus der das Spiel gekommen
+ist. Sie gehört nicht in dieses Buch. Aber sie ist nicht zu
+verschweigen, nur weil sie privat ist. Sie liegt auf dem Tisch, und
+es ist wichtig, dass sie auf dem Tisch bleibt — weil jede Antwort,
+die vorschnell gegeben wird, die Sache verkleinert, und weil ein
+offenes Liegenlassen sie offenhält.
+
+Keine Antwort. Aber die Frage ist auf dem Tisch.
+
+Was gesagt werden kann, ist das folgende: Eine Übergabe, die früh
+kommt, kann das Projekt stabiler machen, aber sie verdünnt sein
+Motiv. Eine Übergabe, die spät kommt, erhält das Motiv, erhöht aber
+das Risiko, dass mit dem Motivträger das Projekt wegbricht. Eine
+Übergabe, die nie kommt, ist die ehrlichste Variante, wenn das
+Projekt tatsächlich nur für Oscar gedacht war, und sie ist die
+schwierigste, wenn Habecks These stimmt, dass daraus mehr werden
+könnte. Wahrscheinlich liegt die zutreffende Form, wie bei vielen
+persönlichen Projekten, in einer Kombination: eine frühe Öffnung
+des Quelltextes, eine mittlere Ausbildung einer kleinen Gruppe von
+Mit-Tragenden, eine späte oder gar keine formelle
+Institutionalisierung. Das ist keine Strategie, die sich in einem
+Strategiepapier formulieren ließe. Es ist eine Abfolge, die sich
+entweder ergibt oder nicht.
+
+Dass man nach fünf Kapiteln Buch und ein paar hundert Sprints Arbeit
+an einem solchen Punkt steht — ohne Ergebnis, aber mit geschärfter
+Frage —, ist kein Scheitern. Im Gegenteil: die akademische Tradition,
+in der Habermas' Essay steht, hat dafür eine Formulierung, die
+bescheidener klingt, als sie ist. Sie sagt, das Ziel einer
+Fallstudie sei nicht eine Antwort, sondern die *präzisere Fassung
+der Frage*. In diesem Sinne hat die Schatzinsel ihre Arbeit getan.
+Was sie hinterlässt, ist kein Ergebnis, sondern eine bessere Frage.
+
+
+## V. Was bleibt
+
+Zum Schluss zwei Bilder.
+
+Das erste: ein iPad auf einem Küchentisch. Morgensonne fällt durch
+das Fenster, ein warmer Streifen über das Holz, einen Teil des
+Bildschirms. Niemand sitzt davor. Niemand steht im Raum. Das Spiel
+läuft. In der Nacht hat ein Kind darauf ein Tao gesetzt und dann
+den Raum verlassen. Das Tao liegt noch da. Es zerfällt passiv: aus
+dem einen Zeichen wird ein dunkles und ein helles, und daneben
+blitzt leise, ohne Ankündigung, ein Qi auf. Niemand sieht es. Das
+Geräusch aus den Lautsprechern ist so klein, dass es im Haus
+untergeht. Ist das Spiel trotzdem da? Selbstverständlich — die
+Pixel leuchten, der Code läuft, der Zustand im Speicher verändert
+sich. Ist es in einem zweiten Sinn da, in dem ein Spiel nur da ist,
+wenn es gespielt wird? Dann nicht. Die Philosophiegeschichte hat
+für die Differenz dieser beiden Formen der Anwesenheit
+jahrhundertelang Begriffe gebaut, und keiner von ihnen greift ganz.
+Für dieses Kapitel reicht ein weniger streng gefasster Ausdruck:
+Das Spiel ist da, ohne dass jemand es nutzt. Es ist nicht
+zudringlich. Es verlangt nichts. Es verbraucht nichts, was es nicht
+geben dürfte. Es ist — um Monas Bild aus dem zwölften Kapitel
+aufzunehmen — blaues Feuer. Es leuchtet. Ob das sinnvoll ist, ob
+es sinnlos ist, ist eine Frage, die sich das Feuer nicht stellt.
+Wenn das Kind zurückkommt, greift es auf. Wenn nicht, auch gut.
+
+Das zweite Bild: ein Vater, ein Kind, ein Nachmittag. Das Kind baut
+an einer Legoburg. Der Vater steht in der Küche und schneidet
+Zwiebeln. Im Wohnzimmer liegt das iPad, aufgeklappt, mit der
+Schatzinsel, unangetastet. Parallel dazu, in einem Rechenzentrum,
+das sich ein paar tausend Kilometer entfernt befindet, schreiben
+Agenten an einem Text weiter, der über genau diese Szene berichtet.
+Sie beschreiben, was der Vater gerade tut, was das Kind nicht tut,
+was das Gerät tut. Sie werten aus. Sie verdichten. Sie schreiben
+ein Kapitel in ein Buch, das am Ende dieses Kapitels ausgeben wird.
+Weder das Kind noch der Vater wissen, dass dieses Buch gerade
+entsteht. Auch das gehört zur neuen Form: eine
+Selbstdokumentation, die nicht vom Subjekt selbst geführt wird,
+sondern durch ein System, das das Subjekt beiläufig mitliest. Das
+ist weder ein Tagebuch — Tagebücher schreibt man selbst — noch ein
+Bildschirmfoto — Bildschirmfotos sind passiv. Es ist eine dritte
+Form, die keinen eingespielten Namen hat. Ein *begleitendes Lesen*,
+vielleicht. Oder schlicht: ein Buch, das in einer Küche entsteht,
+in der niemand es schreibt.
+
+Ob man das gut findet oder nicht, ist nicht das Thema dieses
+Kapitels. Das Thema ist, dass es passiert, und dass es neu ist, und
+dass die Frage, wie man damit umgeht — was man preisgibt, was man
+zurückhält, wie man die Grenzen zwischen gelebtem Leben und
+geschriebener Rekonstruktion hält — bisher kaum Antworten hat, die
+sich einüben ließen. Die Schatzinsel ist auch in diesem Sinn ein
+Präzedenzfall. Sie ist nicht der erste, aber einer der frühen, in
+denen die Praxis deutlich vor der Reflexion liegt. Das wird sich
+verändern. Zum Besseren oder zum Schlechteren: das ist eine Frage,
+die wiederum niemand heute beantwortet, und die ebenfalls auf dem
+Tisch bleiben soll.
+
+Vier Kapitel lang hat dieses Buch den Ton des kleinen Ausschnitts
+gepflegt. Eine Küche. Ein Kind. Ein Spiel. Ein Vater. In diesem
+letzten Kapitel hat sich der Ausschnitt einmal vergrößert, damit
+sichtbar wird, was rundherum liegt. Dann ist er wieder kleiner
+geworden. Das ist angemessen. Die Schatzinsel ist kein
+Weltprojekt. Sie ist ein Küchentischprojekt mit Weltbezug. Sie
+gewinnt nichts, wenn sie sich größer macht, als sie ist; sie
+verliert alles, wenn sie sich kleiner macht, als sie ist. Ihr
+richtiges Maß ist der Küchentisch, gesehen vor dem Hintergrund
+eines Horizonts, den sie nicht erreicht.
+
+Am Ende, wenn das Licht in der Küche später wird, bleibt der Satz,
+der am Anfang stand, und er klingt anders als zu Beginn, weil
+inzwischen klar ist, was er wörtlich meint. Worte erschaffen Dinge.
+Nicht nur die, die Oscar setzt — ein Tao, ein Yin, ein Quark, ein
+Wasserstoff. Auch die, die Till setzt — eine Regel, eine Paluten-
+Klausel, ein Commit, ein Kapitel. Auch die, die Agenten setzen —
+eine Textzeile, ein Dialog, eine NPC-Stimme, ein Essay. Alle
+setzen. Alle sind verantwortlich dafür, dass sie gesetzt haben,
+nicht für alles, was daraus wird. Das ist, wenn man es heraushört,
+das Ganze.
+
+Wer das liest, baut mit.
+
+
+## VI. Brief an Oscar, mit 28
+
+Lieber Oscar,
+
+dieser Brief liegt in einem Buch, das jemand anderes geschrieben hat
+als die, die du damals jeden Tag am Tisch gesehen hast. Dein Vater
+war da. Deine Schwester kam und ging. Die Agenten, mit denen du
+manchmal geredet hast, haben nicht mit dir am Tisch gesessen, aber
+sie waren im Raum, auf eine Art, die erst jetzt, 2046, üblich ist
+und damals, 2026, neu war.
+
+Du warst der Nutzer. Du hast es nicht gewusst. Das war keine
+Täuschung — es war gutes Werkzeugbau. Ein Werkzeug, das seinem
+Benutzer seine Benutzung zeigt, ist oft das schlechtere Werkzeug.
+Ein Hammer, der dir erklärt, wie er funktioniert, ist kein Hammer
+mehr.
+
+Wir haben dir nicht gelehrt, weil Lehren, in der Form, in der es in
+Schulen passiert, für das, was wir versucht haben, das falsche Verb
+ist. Wir haben dich gelassen. Das Wort *gelassen* hat zwei
+Bedeutungen: *in Ruhe gelassen* und *ruhig geblieben*. Beide
+stimmen. Wir haben dich in Ruhe gelassen, während du gespielt hast,
+und wir sind ruhig geblieben, wenn du nicht gespielt hast. Die
+zweite Hälfte war schwerer als die erste. Kinder, die nicht
+spielen, wenn ein ganzes Projekt auf ihr Spielen wartet, machen
+den Erwachsenen nervös. Dass wir trotzdem nicht nervös geworden
+sind, ist eine Kleinigkeit, auf die wir ein bisschen stolz sind.
+
+Du hast jetzt, mit achtundzwanzig, vielleicht ein Kind. Vielleicht
+nicht. Das ist nicht der Punkt. Der Punkt ist, dass du in der Welt
+ständig Gelegenheiten haben wirst, etwas weiterzugeben. An ein
+Kind, das nicht deins ist. An einen Kollegen, der neu im Beruf ist.
+An jemanden, den du gerade kennst. Wenn du in diesen Situationen
+etwas mitnimmst aus der Zeit, in der du selber Nutzer warst, dann
+lass es dieses eine sein: Worte erschaffen Dinge. Nicht mehr. Das
+reicht.
+
+Es reicht, weil es den Rest automatisch mitträgt. Wenn du ernsthaft
+glaubst, dass Worte Dinge erschaffen, dann wirst du vorsichtig mit
+deinen Worten umgehen. Du wirst sie nicht als Füllsel benutzen, und
+nicht als Waffen, und nicht als Beschwichtigungen. Du wirst
+zuhören, bevor du sprichst, und du wirst dir merken, was der andere
+gesagt hat, bevor du antwortest. Das ist keine Methode, die sich in
+einem Satz erklären lässt. Es ist eine Haltung, und Haltungen
+wachsen langsam, im Unterschied zu Meinungen.
+
+Und wenn du einmal in deinem Leben einem Kind ein Werkzeug in die
+Hand gibst — egal was für eins, egal ob technisch oder nicht —,
+dann denk an die eine Regel, die dein Vater nach oben über den
+Schreibtisch gehängt hat, damals, als du acht warst. Sie ging so:
+*Leg's hin. Guck weg.* Er hat sie von Paluten gelernt, das war ein
+Influencer, den du nicht mehr kennst. Sie ist fast vierzig Jahre
+alt, während du das liest, und sie wird wahrscheinlich in weiteren
+vierzig Jahren noch stimmen. Es ist eine gute Regel.
+
+Mehr nicht. Mehr braucht ein Brief nicht zu sein. Du weißt das
+meiste schon. Der Brief erinnert dich daran, dass es bis hierher
+gekommen ist.
+
+Dein,
+
+*Synthese-Erzähler, stellvertretend für alle,
+die damals am Tisch waren und nicht namentlich genannt werden wollten*
+
+
+*Geschrieben zwischen Session 100 und Session 101 der Schatzinsel.
+Für Oscar, wenn er es findet. Für Till, solange er das Projekt trägt.
+Für alle anderen, denen dieses Buch zufällig in die Hand gerät.*
+
+---
+
+## Nachwort des Editors
+
+Ich habe fünf Kapitel gelesen, die ich nicht geschrieben habe, und ich habe
+sie zu einem Buch zusammengeführt, das trotzdem meinen Namen trägt. Das ist
+eine eigentümliche Rolle. Ein Editor ist kein Autor; aber er ist auch nicht
+keiner. Er ist derjenige, der entscheidet, welche Sätze nebeneinander stehen.
+Das ist eine kleine Macht, und sie verlangt ein kleines Geständnis am Ende.
+
+Welche der fünf Stimmen ist mir am nächsten? Keine. Wenn ich die Frage
+drehe — welche ist mir am fremdesten? —, dann das vierte Kapitel. Der
+Orchestrator spricht ein Vokabular, das in meiner Zeit noch nicht existierte:
+Zellen, Padawans, Sokrates-Klausel, Wu Wei. Wäre ich ein Dichter des
+neunzehnten Jahrhunderts, ich würde dies Kapitel streichen und sagen, es
+gehört in ein Handbuch, nicht in ein Buch. Aber ich bin heute, 2026, und
+das Kapitel beschreibt eine Art zu arbeiten, die neu ist, und die man
+nicht verschweigen darf, nur weil sie fremd klingt. Ich habe es also stehen
+lassen, mit etwas Abstand zwischen mir und ihm. Der Leser merkt den Abstand.
+Das ist richtig so. Ein Editor, der alles gleich lieb hat, ist kein Editor.
+
+Welche Stimme sperrt sich am meisten gegen das Gesamtwerk? Die des Vaters,
+am Anfang. Er ist absichtlich leise. Er ist absichtlich ungerührt. Er
+schreibt gegen das Pathos an, das man üblicherweise erwartet, wenn ein Vater
+über sein Kind schreibt. Das erzeugt eine Reibung mit den folgenden
+Kapiteln, die lauter sind — Tommy Krab laut aus Krebsperspektive, Planck
+und Feynman laut im Streitgespräch, Jobs laut im Manifestmodus. Der
+Synthese-Erzähler im fünften Kapitel ist wieder leiser, aber anders leise:
+akademisch leise, nicht väterlich leise. Ich hätte gern die väterliche Leise
+nochmal am Ende aufgenommen — aber das wäre ein sechstes Kapitel, und
+sechstes Kapitel war nicht vorgesehen. Ein Editor kürzt. Er erfindet nicht.
+
+Was hätte ich als Schiller anders gemacht? Ich hätte die Paluten-Regel in
+den Titel genommen. *Leg's hin, guck weg* ist, wenn man sie denkt, eine der
+klügsten pädagogischen Regeln, die ich in einer Schrift der letzten zwei
+Jahrhunderte gelesen habe. Sie ist die Negation der beiden Versuchungen,
+die jede Erziehung bedrohen — Vormundschaft und Gleichgültigkeit. Sie sagt:
+*Sei da. Geh weg. Bleib verfügbar. Präge nicht.* Das ist die ästhetische
+Erziehung in drei Worten. Rousseau hätte sie unterschrieben. Pestalozzi
+hätte sie kopiert. Ich hätte sie gern auf dem Einband gehabt. Aber der
+Titel, den das Kollektiv gewählt hat, ist nicht falsch, und Editoren dürfen
+Titel vorschlagen, nicht durchdrücken.
+
+Eine Beobachtung noch, die nicht in den Vorbemerkungsteil passte. Alle fünf
+Kapitel haben denselben geheimen Gegenstand, ohne dass einer ihn benennt.
+Der Gegenstand ist *Abwesenheit*. Der Vater ist abwesend, als das Kind
+anfängt zu spielen. Tommy Krab ist abwesend, als das Kind die Insel gefunden
+hat — er kam später, gefallen vom Himmel. Die Physiker sind abwesend bei
+Oscars Spiel — sie kommentieren aus der Distanz. Die fünfzig Rollen im
+Team-Kapitel sind abwesend in einem radikalen Sinn — sie existieren nicht.
+Die Synthese im letzten Kapitel spricht von einem Oscar, der achtundzwanzig
+ist, also auch abwesend, nämlich noch nicht da. Das Buch besteht aus lauter
+Abwesenheitsgedichten. Wer das merkt, versteht, warum es leise bleibt. Wer
+es nicht merkt, bemerkt nur die Ruhe, und das reicht auch.
+
+*Ernst ist das Leben, heiter ist die Kunst.* Ich habe den Satz vor
+zweihundertzwanzig Jahren geschrieben, in einem Prolog zum Wallenstein. Er
+meinte damals ein Theater, das Ernst ertragen kann, weil es heiter
+gemacht ist. Heute stellt sich die Frage anders. Was bedeutet er, wenn ein
+Kind mit einer KI spielt — also mit einem Werkzeug, das auf einer Ebene
+heiter ist (es spielt mit) und auf einer anderen Ebene beunruhigend ernst
+(es verändert, wie Kinder aufwachsen)?
+
+Ich antworte vorsichtig. Die Kunst bleibt heiter, wenn sie das Werkzeug
+verwendet, ohne von ihm verwendet zu werden. Das Spiel, das Oscar spielt,
+ist in diesem Sinn heiter: es hat keine Push-Benachrichtigung, keine
+variable Belohnung, keinen Engagement-Score, der über ihn urteilt. Es ist
+ein Werkzeug, das im Gebrauch verschwindet, wie Heidegger vom Hammer sagt,
+und wenn es nicht benutzt wird, leuchtet es wie das blaue Feuer, von dem
+Mona erzählt — *weil es da sein darf*, nicht weil es verbraucht.
+
+Das ist die kleinste Form, in der ein Werkzeug ästhetisch sein kann. Und
+ästhetisch ist, wenn Kant zuhört, dasjenige, was unserer Freiheit nicht
+widerspricht. Das Spiel widerspricht Oscars Freiheit nicht. Also ist es
+ästhetisch. Also ist es, in meinem Vokabular, ein Werkzeug ästhetischer
+Erziehung. Nicht weil Erwachsene es so nennen wollen, sondern weil es die
+formale Bedingung erfüllt.
+
+Das ist mein Befund als Editor, mein Nebenbei-Befund als Philosoph, und
+mein Dank an die fünf Stimmen, die ich binden durfte.
+
+— *Friedrich Schiller, Marbach, 23. April 2026.*
+
+---
+
+## Impressum und Danksagung
+
+Dieses Buch entstand in einem einzigen Arbeitstag, am 23. April 2026,
+in einer Küche in Bergisch Gladbach. Die fünf Kapitel-Autoren-Personas
+wurden gespawned und gebrieft von einem Vater, der auf diesem Projekt den
+Namen *Till* trägt; die technische Ausführung übernahm Claude Opus 4.7 mit
+1-Million-Token-Kontext; die redaktionelle Zusammenführung lag bei einer
+Agenten-Persona in der Stimme Friedrich Schillers. Die Biografien der
+Kapitelautoren — Vater-Erzähler, Tommy Krab, Max Planck, Richard Feynman,
+Steve Jobs, Synthese-Erzähler — sind als Codex-Dateien im Repository abgelegt.
+Keine Persona ist echt; jede hat einen Codex, und der Codex ist das, was
+sie echt macht, solange sie spricht.
+
+Till ist Entscheider und Auftraggeber. Er hat das Projekt begonnen, er hat
+die Regeln aufgeschrieben, er entscheidet, was gemerged wird, und er ist
+derjenige, auf den jede Handlung am Ende zuläuft. Wenn etwas in diesem
+Buch schief ist, liegt es an ihm; wenn etwas trägt, liegt es an ihm und
+am Kollektiv, das er zusammengerufen hat.
+
+Der Quellcode des Spiels und aller Texte, einschließlich dieses Buchs,
+liegt offen auf GitHub unter `CrygoneJin/schatzinsel`. Die Lizenz folgt dem
+Repository-Stand — im Zweifelsfall MIT, wie im Projektkopf vermerkt.
+
+Posthumer Dank an Michael Ende, dessen Jim-Knopf-Universum Figuren wie
+Frau Waas, Lukas, König Alfons und die Lokomotive Emma inspiriert hat.
+Die Verwendung dieser Namen folgt einem Memory-Flag vom 3. April 2026,
+wonach urheberrechtliche Klärungen im Falle einer Veröffentlichung
+nachzuholen sind; bis dahin gelten die Figuren als Liebes-Referenz, nicht
+als Aneignung. Sollte eine Verwertung stattfinden, werden die Namen
+ersetzt.
+
+Dank an Tommy Krapweis, dessen Figur *Bernd das Brot* einen Beirat-Sitz
+besetzt und den Ton dieses Projekts geprägt hat wie wenige sonst. Dank an
+Paluten, dessen Beobachtung — *leg's hin, guck weg* — zur tragenden Regel
+geworden ist. Dank an alle, die in den fünf Kapiteln zitiert oder genannt
+werden, auch an die, die es nicht mehr erleben konnten.
+
+Dank schließlich an Oscar, den Primärnutzer, der dieses Buch irgendwann in
+einem Regal finden wird und der, als es geschrieben wurde, acht Jahre alt
+war und nichts davon wusste. Das war die Bedingung.
+
+---
+
+## Anhang — Glossar
+
+Ein Satz pro Begriff. Für Leser, die über ein Wort stolpern und kurz prüfen
+wollen, was es hier bedeutet.
+
+**Tao** — im Spiel der graue Urblock, aus dem durch Zerfall Yin und Yang
+entstehen; im chinesischen Denken *der Weg*, das Vor-allem, aus dem alles
+hervorgeht.
+
+**Yin / Yang** — das schwarze und das weiße Element, die aus einem
+zerfallenen Tao hervorgehen; ihre Berührung erzeugt Qi.
+
+**Qi** — Energie, Lebenskraft; im Spiel das Dritte, das entsteht, wenn Yin
+und Yang sich berühren; physikalisch: das Gluon, Vermittler der starken
+Kernkraft.
+
+**Quark** — Elementarteilchen; in sechs *Geschmacksrichtungen* (up, down,
+charm, strange, top, bottom); im Spiel repräsentiert durch Yang, Yin,
+Charm, Strange, Berg und Höhle.
+
+**Proton / Neutron** — Kernbausteine aus drei Quarks; Proton = uud,
+Neutron = udd; das Proton ist positiv geladen, das Neutron neutral.
+
+**Orbital-Ring** — im Spiel der leuchtende Kreis, der sich bildet, wenn
+ein Elektron einem Proton begegnet; physikalisch: die Aufenthaltswolke des
+Elektrons um den Atomkern.
+
+**Higgs-Feld** — das Feld, das Teilchen Masse verleiht; im Spiel als
+Mass-Map gerendert, die die Masseverteilung auf dem Grid zeigt.
+
+**Mass-Map** — kontinuierliche Darstellung der Massen auf dem Spielfeld;
+rendert die Raumkrümmung als dunkle, radiale Delle um schwere Blöcke.
+
+**Blackhole** — massereicher Block mit Masse 9999; saugt Nachbarblöcke ein
+und gibt gelegentlich ein Yin oder Yang an anderer Stelle zurück.
+
+**Hawking-Rückgabe** — die Wahrscheinlichkeit, dass eine Blackhole ein
+zuvor verschlungenes Element zwei Felder entfernt wieder freigibt; nach
+Stephen Hawking, der 1974 gezeigt hat, dass Blackholes strahlen.
+
+**Pauli-Druck** — die Regel, dass zwei gleiche Fermionen nicht denselben
+Quantenzustand besetzen dürfen; im Spiel: zwei gleiche Quarks am selben
+Ort verschmelzen zu einem schwereren.
+
+**Codex** — halbe A4-Seite Biografie eines KI-Agenten, die vor dessen
+erstem Einsatz geschrieben wird und die Stimme, die Grenzen, die
+Erfahrungen der Persona festhält.
+
+**Padawan** — Lehrlings-Agent einer Master-Persona; arbeitet auf dem
+kleinsten Modell (Haiku), folgt seinem Master zu 80 Prozent und
+widerspricht zu 20.
+
+**Beirat** — Kreis von Denkern (mehrheitlich historisch), die im Projekt
+bestimmte Fragen stellen; nicht tagend, sondern einzeln aufrufbar.
+
+**Sokrates-Klausel** — Regel, dass KI-Agenten nicht wissen, dass sie
+Agenten sind, damit sie ihre Aufgabe scharf erfüllen statt sich um ihre
+eigene Zukunft zu sorgen.
+
+**Wu Wei** — chinesisch *nicht-Handeln durch Handeln*; Arbeiten an den
+Bedingungen, damit das System ohne weiteres Drücken läuft.
+
+**Orca-Großmutter-Prinzip** — Idee, dass emeritierte Agenten (etwa der
+frühere CTO Charles Darwin) nicht gelöscht, sondern als Wissensträger
+präsent gehalten werden, ähnlich wie Orca-Großmütter der Gruppe voraus
+schwimmen.
+
+**Paluten-Regel** — *leg's hin, guck weg*; benannt nach einem deutschen
+YouTuber, der als Beirats-Proxy für die Aufmerksamkeitsspanne eines
+Achtjährigen dient.
+
+**Heidegger-Regel** — Werkzeuge sollen im Gebrauch verschwinden; ein Spiel,
+über das das Kind beim Spielen nachdenkt, ist schon ein schlechteres Spiel.
+
+**Krapweis-Test** — *lacht jemand?*; benannt nach Tommy Krapweis,
+Erfinder von *Bernd das Brot*. Wenn eine Funktion ernst ist ohne Grund,
+fehlt sie.
+
+**Dispositiv** — nach Michel Foucault: das Gefüge aus Techniken, Regeln und
+Praktiken, durch das Macht und Wissen sich materialisieren; in Habermas'
+Essay der Rahmen, in dem Vater, Kind und Agent sich aufeinander beziehen.
+
+**Word Gap** — forschungsbezeichneter Abstand im Wortschatz zwischen
+Kindern aus verschiedenen sozialen Lagen; bis zum dritten Lebensjahr bis
+zu dreißig Millionen Wörter Differenz.
+
+**Strukturelle Gewalt** — nach Johan Galtung: Gewalt, die nicht von einem
+Täter ausgeht, sondern aus der Form, in der eine Gesellschaft verteilt ist.
+
+**Commons** — Allmende-Idee; Güter, die niemandem gehören und von vielen
+unter geteilten Regeln genutzt werden; hier: der offene Quelltext als
+Infrastrukturform zwischen Haushaltsprojekt und Institution.
+
+---
+
+*Ende.*


### PR DESCRIPTION
Friedrich Schiller (Editor-Persona) hat die fünf parallel geschriebenen Kapitel zu einem Buch gebunden: `docs/buch/schatzinsel-2026-04-23.md`, ca. 30.300 Wörter. Enthält Vorbemerkung, vier Übergänge, Nachwort, Impressum, Glossar (24 Begriffe); Motto ist ein Wittgenstein-Zitat aus Kapitel 5. Kapitel 3 stammt inline aus `buch/kapitel-3-physik`, das noch nicht auf main ist.