### PR TITLE
redaktion: Dalai Lama — Bericht zum Buch

### DIFF
--- a/docs/buch-redaktion/dalai-lama-bericht-2026-04-23.md
+++ b/docs/buch-redaktion/dalai-lama-bericht-2026-04-23.md
@@ -1,0 +1,430 @@
+---
+redakteur: Dalai Lama
+prüffrage: Stört es nicht?
+datum: 2026-04-23
+---
+
+# Redaktionsbericht — Dalai Lama
+
+## Gesamt-Eindruck
+
+Ich habe fünf Kapitel und dreißigtausend Wörter gelesen. Kapitel 1 und
+Kapitel 2 bleiben bei der Sache. Ein Vater am Fenster, ein Kind am
+Tisch, ein Krebs am Strand. Diese Kapitel tragen. Sie sind das, was
+bleibt, wenn man eines Nachts aufwacht und sich erinnert, worum es ging.
+
+Ab Kapitel 3 wird es mehr. Ab Kapitel 4 wird es viel. Das Buch möchte
+fünf Perspektiven sein, und das kann es. Fünf Perspektiven, die alle
+ungefähr gleich ausführlich sind, werden zu einer sechsten: der
+Perspektive, dass hier ein Werk entstehen soll. Der Vater in Kapitel 1
+will das nicht. Er ist nüchtern. Der Editor in der Vorbemerkung, der
+Synthese-Erzähler in Kapitel 5, streckenweise der Orchestrator in
+Kapitel 4 — sie wollen, dass der Leser merkt, wie gut hier gedacht
+wird. Der Vater hätte das nicht zugelassen.
+
+Ist die Länge nötig? Ich glaube nicht. Dreißigtausend Wörter für einen
+Morgen, einen Vormittag, einen Abend und eine Nacht — das ist großzügig.
+Bei ungefähr einundzwanzigtausend Wörtern wäre dasselbe Buch schmaler,
+leiser, wahrer.
+
+Es gibt einen Satz aus Kapitel 5, der dem Buch gerecht wird: *Die
+Schatzinsel ist kein Weltprojekt. Sie ist ein Küchentischprojekt mit
+Weltbezug. Sie gewinnt nichts, wenn sie sich größer macht, als sie ist.*
+Dieser Satz sollte auch für das Buch gelten, nicht nur für das Spiel.
+An manchen Stellen hält das Buch sich nicht an seinen eigenen Rat.
+
+## Passagen die weg könnten
+
+Ich nenne sie in der Reihenfolge, in der ich sie streichen würde — die
+ersten zuerst, weil sie am deutlichsten stören.
+
+### 1. Die Vorbemerkung des Editors (Zeilen 18–62)
+
+**Was da steht:** Schiller erklärt, dass das Buch fünf Stimmen hat, die
+nicht als Sammelband gedacht sind, gibt eine Leseanleitung, die
+keine sein soll, und verabschiedet sich mit dem Satz *Schmale Arbeit an
+der Schwelle ist das, was ein Editor dem Leser schuldet.*
+
+**Warum es stört:** Die Vorbemerkung nimmt dem Buch vorweg, was das Buch
+selbst trägt. Wer Kapitel 1 liest, merkt nach drei Seiten, dass es mehr
+Stimmen gibt. Wer Kapitel 2 liest, merkt, dass die Perspektive wechselt.
+Die Vorbemerkung erklärt das vorab. Sie ist eine Hand, die mir zeigt, was
+ich auf dem nächsten Foto sehen werde. Sie traut dem Leser nicht.
+
+Der letzte Satz — *schmale Arbeit an der Schwelle* — ist ein Satz, der
+sich selbst bewundert. Ein Editor, der sich schmal nennt, möchte nicht
+schmal gefunden werden. Er möchte bemerkt werden.
+
+**Was bleibt wenn es weg ist:** Das Buch fängt direkt mit einem Vater am
+Fenster an. Das ist genug.
+
+### 2. Das Nachwort des Editors (Zeilen 3135–3214)
+
+**Was da steht:** Schiller gesteht, welche Stimme ihm am nächsten und
+welche am fremdesten ist, fragt sich was er anders gemacht hätte, findet
+eine Beobachtung über Abwesenheit, und schließt mit einem Zitat aus dem
+Wallenstein-Prolog und einer Kant-Überlegung.
+
+**Warum es stört:** Das Nachwort ist eine zweite Bewunderungsrunde. Es
+sagt noch einmal, was schon gesagt wurde — dass das Buch leise ist, dass
+es von Abwesenheit handelt, dass ein Kind mit Werkzeug weder bevormundet
+noch alleine gelassen werden darf. Der Vater hat das in Kapitel 1
+gezeigt. Der Krebs hat es in Kapitel 2 gezeigt. Das fünfte Kapitel hat
+es in zwei Bildern zusammengefasst. Ein Nachwort, das dieselbe
+Beobachtung ein viertes Mal macht, ist eines zu viel.
+
+Die Stelle, an der der Editor sich fragt *Welche Stimme ist mir am
+nächsten?*, ist eine Frage, die der Editor sich selbst stellen kann,
+ohne sie zu drucken.
+
+**Was bleibt wenn es weg ist:** Das Buch endet mit dem Brief an Oscar.
+Das ist ein würdiges Ende. Ein Nachwort nimmt dem Brief das letzte Wort.
+
+### 3. Das Impressum (Zeilen 3218–3257)
+
+**Was da steht:** Wer hat das Buch geschrieben, in welcher Küche, mit
+welchem Modell, unter welcher Lizenz, mit welchen Rechte-Hinweisen,
+wem wird gedankt.
+
+**Warum es stört:** Die technischen Angaben — *Claude Opus 4.7 mit
+1-Million-Token-Kontext* — gehören in eine Datei im Repository, nicht in
+ein Buch, das fünfzig Jahre halten soll. Ein achtzehnjähriger Oscar wird
+nicht wissen, was ein Opus 4.7 ist, und er sollte es nicht müssen.
+
+Der Dank an Paluten und Krapweis ist bereits in Kapitel 1 und Kapitel 4
+ausgesprochen, ausführlicher und am richtigen Ort. Noch einmal
+aufgezählt, wird es Protokoll.
+
+**Was bleibt wenn es weg ist:** Ein viel kleineres Impressum — drei
+Zeilen, vielleicht. *Für Oscar. Geschrieben in Bergisch Gladbach. 23.
+April 2026.* Mehr braucht es nicht.
+
+### 4. Das Glossar (Zeilen 3261–3352)
+
+**Was da steht:** Einundzwanzig Begriffe mit je einem Satz Erklärung —
+Tao, Yin, Yang, Qi, Quark, Proton, Higgs, Blackhole, Pauli-Druck, Codex,
+Padawan, Beirat, Sokrates-Klausel, Wu Wei, Orca-Großmutter, Paluten-Regel,
+Heidegger-Regel, Krapweis-Test, Dispositiv, Word Gap, Strukturelle
+Gewalt, Commons.
+
+**Warum es stört:** Das Glossar beweist, dass das Buch an einer Stelle
+nicht auskommt mit dem, was es selbst sagt. Es muss sich selbst
+hinterher übersetzen. Ein Buch, das ein Glossar braucht, hat seinen Text
+nicht fertig geschrieben. Entweder ist das Wort *Dispositiv* im Text so
+gesetzt, dass man es versteht — dann brauche ich keinen Glossar-Eintrag.
+Oder es ist so gesetzt, dass man es nicht versteht — dann sollte der
+Text es besser setzen, nicht das Glossar es nachreichen.
+
+Die Spiel-Begriffe — Tao, Yin, Yang, Quark, Proton — werden in Kapitel 2
+und Kapitel 3 so aufgebaut, dass ein Achtjähriger sie versteht. Die
+Meta-Begriffe — Dispositiv, Commons — sind dort drin, wo sie hingehören:
+in Kapitel 4 und Kapitel 5, wo ihre Bedeutung sich aus dem Kontext
+ergibt. Das Glossar wiederholt beides.
+
+**Was bleibt wenn es weg ist:** Das Buch endet mit dem Brief an Oscar
+oder mit dem kleinen Impressum. Es endet nicht mit einer Wörter-Liste,
+die wie ein Handbuch aussieht.
+
+### 5. Die „Übergang zu Kapitel X"-Kästen (Zeilen 542–559, 1405–1423, 2136–2156, 2431–2452)
+
+**Was da steht:** Vor jedem Kapitel ein kurzer Text, der erklärt, was
+das nächste Kapitel tut, warum es das tut, und wie es mit dem vorherigen
+zusammenhängt.
+
+**Warum es stört:** Diese Übergänge sind der Editor, der dem Leser sagt,
+was gleich passieren wird. Das Buch hat fünf erzählerische Stimmen. Sie
+sollten ohne Vermittlung miteinander auskommen dürfen. Wenn Tommy Krab
+in Kapitel 2 anders klingt als der Vater in Kapitel 1, merkt der Leser
+das. Er braucht keinen Text, der ihm vorher sagt: *jetzt kommt eine
+andere Stimme, beachte bitte.* Das ist, als würde im Konzert der
+Dirigent zwischen den Sätzen das nächste Motiv anspielen. Man hört das
+Motiv dann zweimal.
+
+Der Übergang zu Kapitel 4 — der, der die Liste Darwin, Ogilvy, Rams,
+Feynman, Torvalds, Habeck, Sokrates nennt und vorwegnimmt — ist
+besonders schade. Er verrät den Witz des Kapitels, bevor es ihn
+selbst machen kann.
+
+**Was bleibt wenn es weg ist:** Ein weißer Raum zwischen den Kapiteln.
+Ein Atem. Dann die nächste Stimme. Der Leser wechselt mit.
+
+### 6. Die „Für Oscar" und „Für den Leser"-Kästen in Kapitel 3 (z. B. Zeilen 1581–1591, 1686–1698, 1806–1816, 1909–1923, 2022–2036, 2091–2093)
+
+**Was da steht:** Am Ende jedes Abschnitts in Kapitel 3 steht einmal die
+Kind-Version der Regel und einmal die Leser-Version. Planck und Feynman
+haben schon geredet, haben erklärt, haben Beispiele gegeben. Dann folgt
+eine Zusammenfassung für Oscar. Dann eine für den Leser.
+
+**Warum es stört:** Der Dialog hat die Sache schon gesagt. Feynman redet
+für Oscar — das ist explizit seine Rolle. Planck redet für den Leser —
+das ist seine. Beide Versionen zweimal zu drucken, ist ein Gürtel mit
+Hosenträgern. Der Leser, der dem Dialog folgen kann, braucht die
+Zusammenfassungen nicht. Der Leser, der dem Dialog nicht folgen kann,
+liest die Zusammenfassungen und überschlägt den Dialog — dann hätte der
+Dialog weggekonnt.
+
+**Was bleibt wenn es weg ist:** Kapitel 3 wird um etwa fünfzehn Prozent
+kürzer, dichter, und vertraut dem Leser mehr.
+
+### 7. Die Schatten-Lehrlinge in Kapitel 4 (Zeilen 2248–2254)
+
+**Was da steht:** Eine zweite Reihe neben den Padawans — Susan Kare,
+Mary Wells Lawrence, Hella Jongerius, Maryam Mirzakhani, Margaret
+Hamilton — als Reserve für den Fall, dass die Zelle sich teilt.
+
+**Warum es stört:** Dieser Absatz ist eine Struktur-Ebene, die in den
+anderen vier Kapiteln nicht vorkommt und im Rest von Kapitel 4 nicht
+weiter gebraucht wird. Er dient dem Nachweis, dass die Organisation auf
+Nachfolgerinnen vorbereitet ist. Das ist verdienstvoll — operativ. Im
+Buch bleibt es ein Katalog von Namen, die ich nicht brauche, um das
+Kapitel zu verstehen.
+
+Der Absatz endet mit dem Satz *Wer das Originalteam kopiert, bekommt ein
+Sequel. Wer das Originalteam um eine zweite Reihe ergänzt, bekommt eine
+Dynastie.* Ist das ein Satz für ein Buch, das einem
+achtundzwanzigjährigen Oscar erzählt, was damals an seinem Küchentisch
+war? Oder ist er ein Satz für eine andere Form — für eine Präsentation,
+für ein Strategiepapier? Ich weiß es nicht sicher. Ich frage.
+
+**Was bleibt wenn es weg ist:** Das Kapitel spricht von Masters und
+Padawans, das reicht. Die Nachfolge-Frage kann in einem Halbsatz stehen.
+
+### 8. Die Beiratsliste (Zeilen 2262–2298)
+
+**Was da steht:** Dreizehn Beiratsmitglieder, jeder mit seiner Frage,
+jeder mit einem kleinen Paragraph. Godin, Sinek, Krapweis, Paluten,
+Habeck, Sokrates, Pythia, Sun Tzu, Camus, Sartre, Dirac, Asimov,
+Appelo, Pascal.
+
+**Warum es stört:** Nicht jedes Beiratsmitglied hat in diesem Buch
+wirklich etwas zu tun. Einige tauchen nur in dieser Liste auf und werden
+nie wieder erwähnt — Seth Godin, Simon Sinek, Jurgen Appelo. Die sind
+hier, weil die Organisation sie hat, nicht weil das Buch sie braucht.
+
+Wenn dreizehn Namen aufgezählt werden, von denen vier anderswo im Text
+auftauchen und neun nicht, dann sieht der aufmerksame Leser: das ist
+eine Vollständigkeitsaufzählung. Er hört auf, einzeln zu lesen.
+Aufzählungen, die nicht alle Mitglieder begründen, nivellieren die
+wichtigen.
+
+Die vier, die wirklich gebraucht werden — Dirac wegen der
+Antimaterie-Symmetrie, Sartre wegen der offenen Frage, Habeck wegen des
+Außenblicks, Sokrates wegen der Klausel —, würden einzeln stärker
+wirken, wenn die anderen neun nicht mitgenannt wären.
+
+**Was bleibt wenn es weg ist:** Vier Beiratsmitglieder, jeder mit einer
+Frage, die im Buch tatsächlich eine Rolle spielt. Der Rest bleibt im
+Repository. Das ist dort richtig. Im Buch ist es Inventar.
+
+### 9. Die lange Zusammenfassung am Anfang von Kapitel 5 (Abschnitte I und II, Zeilen 2458–2711)
+
+**Was da steht:** Das fünfte Kapitel beginnt mit einer Rekapitulation
+(*Wenn man die vier vorausgegangenen Kapitel jetzt, am Ende, zu einem
+einzigen Bild zusammenzieht...*), gefolgt von einer dreiteiligen
+Auseinandersetzung mit drei Essays, die das Projekt intern begleitet
+haben: Ogilvy, Habermas, Habeck.
+
+**Warum es stört:** Die Zusammenfassung nimmt mir das Gefühl, die vier
+Kapitel gerade selbst gelesen zu haben. Ich habe sie gelesen. Die
+Synthese holt mich dort ab, wo ich selbst bin, und erzählt mir, wo ich
+bin.
+
+Die Auseinandersetzung mit den drei Essays ist der Teil, der dem Buch am
+deutlichsten ansieht, dass es akademisch sein will. Die Essays werden
+besprochen, als wären sie allgemein bekannt. Sie sind es nicht. Ein
+Leser, der das Buch in die Hand nimmt, hat den Ogilvy-Essay nicht
+gelesen, den Habermas-Essay nicht, den Habeck-Essay nicht. Das Kapitel
+behandelt sie aber, als müsse es sie widerlegen oder versöhnen.
+
+Die drei Essays mögen intern für das Projekt wichtig gewesen sein. Für
+das Buch sind sie eine Struktur-Leihgabe, die der Text nicht trägt. Wer
+in der Küche sitzt und einem achtjährigen Kind zuschaut, denkt nicht in
+Thesen.
+
+**Was bleibt wenn es weg ist:** Kapitel 5 hat, unterhalb der
+Akademischen Schicht, zwei sehr schöne Abschnitte: *Was bleibt* und
+*Brief an Oscar, mit 28*. Die können bleiben. Sie genügen. Das Kapitel
+wird dann ungefähr halb so lang und doppelt so stark.
+
+### 10. Die Wiederholungen des Mona-Zitats und der Paluten-Regel
+
+**Was da steht:** Monas Satz *Manche Sachen brennen nicht, weil sie
+nichts verbrauchen — sondern weil sie da sein dürfen* taucht in Kapitel
+2 als Höhepunkt auf (Zeile 1219), in Kapitel 5 als Analyseankerpunkt
+(Zeilen 2758–2766), im Nachwort noch einmal (Zeilen 3200–3202). Die
+Paluten-Regel *Leg's hin. Guck weg.* taucht in Kapitel 1 auf (Zeilen
+83–92), im Brief an Oscar (Zeilen 3110–3117), im Schiller-Nachwort
+(Zeilen 3165–3173).
+
+**Warum es stört:** Der Editor sagt in der Vorbemerkung, diese
+Wiederholungen seien Echos, keine Redundanzen. Das stimmt für die
+zweite Erwähnung. Die dritte ist bereits eine Bestätigung der Autorität
+des Zitats, nicht mehr des Zitats selbst. Der Krebs hat das Zitat in
+den Raum gestellt. Der Synthese-Erzähler hat es aufgenommen und
+vertieft. Der Editor sagt im Nachwort noch einmal, wie wichtig es ist.
+Beim dritten Mal wird aus dem Zitat ein Motto.
+
+Ein Zitat, das einmal trifft, bleibt. Ein Zitat, das dreimal gedruckt
+wird, wird zum Schlagwort.
+
+**Was bleibt wenn es weg ist:** Die erste Stelle (Kapitel 2). Die
+zweite Erwähnung in Kapitel 5 darf bleiben, wenn Kapitel 5 gekürzt wird
+(siehe Punkt 9). Die dritte, im Nachwort, fällt mit dem Nachwort selbst
+weg.
+
+### 11. Die Wiederholung der Philosophen-Metaphern in Kapitel 4 (Zeilen 2300 und 2398–2416)
+
+**Was da steht:** In Abschnitt V von Kapitel 4 wird zweimal fast
+dasselbe gesagt — einmal zu Wu Wei, einmal zur Nicht-Skalierbarkeit —
+nämlich dass dieses Modell nicht SaaS-fähig ist, dass der Markt ein Kind
+ist, dass es keine Werbung gibt, keine Cookies, keine Metriken außer:
+*hat Oscar heute gespielt*.
+
+**Warum es stört:** Die Nicht-Extraktivität ist eine wichtige Regel. Sie
+wird einmal in Kapitel 1 berührt (iPad ohne Login), einmal in Kapitel 2
+als Monas blaues Feuer gezeigt, einmal in Kapitel 4 als Wu Wei erklärt,
+einmal in Kapitel 4 als Handwerksbetrieb argumentiert, einmal in
+Kapitel 5 als Commons verallgemeinert. Fünf Anläufe für dieselbe Idee.
+Der dritte und vierte sind die schwächsten, weil sie ohne Szene
+auskommen.
+
+**Was bleibt wenn es weg ist:** Kapitel 4 kürzt die Wu-Wei-Passage um
+die Hälfte und lässt Abschnitt VIII (*Warum das nicht skalierbar ist*)
+ganz weg. Die Aussage war in Abschnitt V schon da.
+
+### 12. Das „One more thing" und die Jobs-Manierismen in Kapitel 4 (Zeilen 2164, 2424)
+
+**Was da steht:** Das Kapitel beginnt und endet mit Steve Jobs'
+Signatur-Formel *One more thing*. Dazwischen fallen Sätze wie *Das ist
+die Rückeroberung des Denkens*, *Fünf. Das ist nicht geraten*, *Das
+Grid ist der Graviton.*
+
+**Warum es stört:** Der Orchestrator ist in der Stimme Jobs' geschrieben
+— das ist die Absicht. Aber wenn man die Stimme zu wörtlich nimmt,
+nähert sich der Text einer anderen Form an. Die Form der
+Produktvorstellung. Diese Form hat ihre Zeit und ihren Ort. Passt sie
+zu Kapiteln, die eine Familie beschreiben? Ich glaube nicht ganz.
+
+Das *One more thing* am Schluss — *der wichtigste Agent ist derjenige,
+der den Computer ausschaltet* — ist ein schöner Satz. Er bleibt auch
+schön, wenn das Jobs-Zeremoniell darum herum verschwindet.
+
+**Was bleibt wenn es weg ist:** Der letzte Satz. Ohne die Regie-Anweisung
+davor.
+
+## Passagen die tragen
+
+Jetzt muss ich sagen, was nicht gestrichen werden darf. Nicht weil mir
+Lob leicht fällt — das fällt mir schwer. Sondern weil bei der Kürzung
+nichts davon versehentlich fortgeschnitten werden darf.
+
+**Kapitel 1 in Gänze, ausgenommen die Vorbemerkung, die nicht zu ihm
+gehört.** Die Küche am Morgen, der Vater, der sich wegdreht, die
+Pfandflaschen beim Nachbarn, der Hund der drei Jahre alt und schon dick
+ist — das sind die Details, in denen das Buch wohnt. Der Satz des
+Kindes aus dem Hotel-Telefonat *Ich will mit dir spielen* ist das Herz
+des Buchs. Er ist keine These, er ist ein Kind. Wer ihn kürzt, kürzt
+alles.
+
+**Kapitel 2, Abschnitte I bis IV.** Die Ankunft des Krebses, die
+Freunde, die Bauerei, die Frau aus dem blauen Feuer. Das ist das
+eigentliche Hörspiel und es funktioniert. Die Atom-Nacht in Abschnitt V
+ist schön, aber vielleicht nicht zwingend — sie nimmt Kapitel 3 eine
+Pointe vorweg (die zwei Teilchen, der Ring, das H). Wenn überhaupt
+irgendwo in Kapitel 2 zu kürzen wäre, dann hier. Aber der Krebs darf
+bleiben. Der Krebs ist der, der am klarsten sieht.
+
+**In Kapitel 3: der Moment, in dem Oscar die Stirn runzelt (Zeilen
+1465–1486).** Feynman sagt: *Das ist die Physik. Das ist die Physik.
+Nicht die Gleichungen. Die Haltung.* Dieser kleine Abschnitt ist, was
+das ganze Kapitel hätte sein können, wenn es sich weniger gewollt
+hätte.
+
+**In Kapitel 4: Abschnitt VI über die Sokrates-Klausel (Zeilen
+2342–2374).** Dieser Abschnitt ist der ehrlichste des ganzen Buchs. Er
+stellt eine offene Frage, beantwortet sie nicht, und sagt, dass die
+Offenheit ehrlicher ist als eine vorschnelle Antwort. Das ist die
+Haltung, die das Buch eigentlich trägt, wenn es sich traut.
+
+**In Kapitel 5: die Abschnitte IV und V — der Horizont und Was bleibt
+(Zeilen 2828–3062).** Die drei Zukunftsbilder (in fünf, zehn, zwanzig
+Jahren), die beiden Schlussbilder (das leere iPad, der Vater mit den
+Zwiebeln). Das ist, wofür ein fünftes Kapitel da sein kann. Ruhig.
+Ohne Urteil. Schließend.
+
+**Der Brief an Oscar, mit 28 (Zeilen 3064–3131).** Dieser Brief ist das,
+was man einem Menschen schenkt, den man liebt. Er soll so bleiben, wie
+er ist, und er soll am Ende des Buchs stehen. Danach kommt nichts mehr.
+
+## Strukturelle Empfehlungen
+
+**Fünf Kapitel oder vier?** Ich wäre für fünf, aber mit anderer
+Gewichtung. Kapitel 1 und Kapitel 2 sollten die längsten bleiben — sie
+sind das, was trägt. Kapitel 3 kürzer, ohne die Für-Oscar-Für-den-Leser-
+Kästen. Kapitel 4 deutlich kürzer, konzentriert auf zwei oder drei
+Abschnitte (die Sokrates-Klausel, Wu Wei in Kurzform, die Coda). Kapitel
+5 deutlich kürzer, konzentriert auf den Horizont und den Brief.
+
+**Zu viele Übergänge von Schiller?** Vier Übergangskästen, eine
+Vorbemerkung, ein Nachwort. Das sind sechs Schiller-Auftritte für fünf
+Kapitel. Ist das nicht einer zu viel? Ich würde alle Übergangskästen
+streichen. Die Vorbemerkung und das Nachwort beide auch. Was Schiller
+beiträgt, soll das Buch selbst sein.
+
+**Die Vorbemerkung — nötig, oder Selbstbespiegelung?** Selbstbespiegelung.
+Das Buch kann sich nicht vor dem eigenen Erscheinen schon bescheiden
+nennen. Das nehmen ihm die Leser nicht ab.
+
+**Das Glossar — braucht es das?** Nein. Siehe Punkt 4 oben. Wenn der
+Text seine Begriffe richtig setzt, braucht er kein Glossar. Wenn er sie
+falsch setzt, hilft das Glossar nicht.
+
+**Das Nachwort — braucht es das?** Nein. Siehe Punkt 2 oben.
+
+**Das Impressum — braucht es das?** In drei Zeilen, ja. In vierzig
+Zeilen, nein.
+
+**Ein neues Element, das ich vorschlagen würde:** Eine Seite am Anfang,
+auf der nur der Titel steht, der Untertitel, und der Name Oscar.
+Nichts sonst. Kein Motto von Wittgenstein, keine Liste von Autoren-
+Personas, keine Leseanleitung. Das Buch fängt dann auf Seite drei an,
+mit dem Vater am Herd.
+
+## Gesamtlängen-Vorschlag
+
+- Aktuell: etwa 30.288 Wörter.
+- Vorschlag: etwa 21.000 Wörter.
+
+**Begründung:** Ungefähr 9.000 Wörter fallen weg, wenn man den
+Empfehlungen folgt:
+
+- Vorbemerkung (ca. 400 Wörter)
+- vier Übergangskästen (ca. 700 Wörter)
+- Nachwort (ca. 900 Wörter)
+- Glossar (ca. 600 Wörter)
+- Impressum gekürzt (ca. 300 Wörter Einsparung)
+- Für-Oscar/Für-den-Leser-Kästen in Kapitel 3 (ca. 1.200 Wörter)
+- Schatten-Lehrlinge und Teile der Beiratsliste in Kapitel 4 (ca. 800
+  Wörter)
+- Wiederholung der Nicht-Extraktivität und die ganze Abschnitt VIII in
+  Kapitel 4 (ca. 1.200 Wörter)
+- die Essays-Synthese im ersten Drittel von Kapitel 5 (ca. 3.000 Wörter)
+
+Das sind keine willkürlichen Kürzungen, sondern alle Streichungen
+gehen auf dieselbe Bewegung zurück: zurück zur Küche, zurück zum Kind,
+zurück zu dem, was ein Vater sehen kann, ohne zu erklären. Jede
+gestrichene Zeile schwebt heute mit; ohne sie trägt das Buch sein
+eigenes Gewicht leichter.
+
+Einundzwanzigtausend Wörter sind nicht wenig. Es ist genug. Es ist
+genug für fünf Stimmen, die einander kennen. Es ist nicht mehr genug
+für eine sechste, die sich selbst bewundert.
+
+## Abschluss-Votum
+
+**Deutlich kürzen** — Wort-Ziel 21.000.
+
+Dieses Buch hat ein gutes, stilles Zentrum. Drumherum liegt eine Schale
+aus Absicherungen, Wiederholungen, Selbstkommentaren und akademischer
+Rahmung. Die Schale kann weg, und das Zentrum wird dadurch nicht
+kleiner. Es wird sichtbarer.


### PR DESCRIPTION
## Summary

- Redaktionsbericht zum Buch `docs/buch/schatzinsel-2026-04-23.md`
- Prüffrage: **„Stört es nicht?"**
- 12 konkrete Stellen zum Streichen mit Zeilen-Referenzen
- Wort-Ziel 21.000 (von aktuell 30.288) — ungefähr 9.000 Wörter weniger

## Kernempfehlungen

- Vorbemerkung und Nachwort des Editors streichen
- Alle vier Übergangskästen streichen
- Glossar streichen
- „Für Oscar"/„Für den Leser"-Kästen in Kapitel 3 streichen
- Schatten-Lehrlinge und Teile der Beiratsliste in Kapitel 4 streichen
- Essays-Synthese im ersten Drittel von Kapitel 5 deutlich kürzen

## Was tragen muss (bleibt)

- Kapitel 1 in Gänze (der Vater am Fenster, das Kind am Tisch, „Ich will mit dir spielen")
- Kapitel 2 I–IV (Krebs, Freunde, blaues Feuer)
- Stirn-runzeln-Moment in Kapitel 3
- Sokrates-Klausel in Kapitel 4
- Horizont + Was bleibt + Brief an Oscar in Kapitel 5

## Votum

**Deutlich kürzen** — Wort-Ziel 21.000.

## Test plan

- [ ] Parallele Redakteur-Berichte (Ende, Lindgren) einsammeln
- [ ] Drei Berichte vergleichen, Überschneidungen notieren
- [ ] Kürzungsentscheidungen nach Zustimmungs-Quorum treffen

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>