### PR TITLE
redaktion: Astrid Lindgren — Bericht zum Buch

### DIFF
--- a/docs/buch-redaktion/lindgren-bericht-2026-04-23.md
+++ b/docs/buch-redaktion/lindgren-bericht-2026-04-23.md
@@ -1,0 +1,495 @@
+---
+redakteurin: Astrid Lindgren
+prüffrage: Wo ist der Unsinn?
+datum: 2026-04-23
+---
+
+# Redaktionsbericht — Astrid Lindgren
+
+## Gesamt-Eindruck
+
+Hallo, ihr Lieben. Ich habe mir einen Sessel genommen, einen warmen Tee,
+und habe das Buch von Anfang bis Ende gelesen. Dreitausenddreihundertsechsundfünfzig
+Zeilen. Das ist ein Buch. Ich wollte das vorausschicken, damit ihr
+wisst: ich bin nicht vorbeigeflogen, ich habe mich hingesetzt.
+
+Und ich habe einiges gefunden, über das ich gelacht habe. Ein Krebs,
+der seiner eigenen Schere einen Liebesbrief schreibt. Ein Einhorn, das
+Französisch spricht, wenn es sich aufregt, und niemand weiß warum.
+Ein König, dessen Beruf Winken ist, und das ist ein ganzer Tag. Eine
+Muschel namens Gertrude, die nicht angefasst werden darf. Ein Elefant,
+der schnarcht wie ein langsames Törööö. Das ist alles Pippi-Niveau.
+Das freut mich. Das sagt mir: Das Kind, das dieses Buch in der
+Nachttischlampe aufschlagen wird, mit dreizehn oder mit achtundzwanzig,
+wird an mindestens einer Stelle lächeln.
+
+Aber. Und jetzt kommt mein Aber, denn wofür bin ich sonst hier.
+
+Der Unsinn wohnt in **Kapitel 2**. Er wohnt dort so massiv, dass man
+sich Sorgen machen muss, ob die anderen Kapitel sein Mietvertrag
+anerkennen. Kapitel 1 ist absichtlich leise — das sagt Schiller selbst
+im Nachwort, und er hat recht, der Vater darf ernst sein. Aber das
+Kind in Kapitel 1 sitzt brav auf einem Küchenstuhl und tippt. Es
+hat die Haare abstehend, das ist der einzige Hinweis auf Wildheit.
+Pippi hätte das iPad einmal rundum gedreht, hätte „Gurkenkuchen"
+gerufen, und hätte dem Vater einen Sockenhaufen aufs Kaffeebrett
+gestellt. Michel aus Lönneberga hätte versucht, das Tao zu essen.
+Das sind nicht meine Forderungen — das ist der Horizont, an dem ich
+merke, dass Oscar in Kapitel 1 der ordentlichste Achtjährige ist, den
+ich seit Jahren auf einer Seite gesehen habe.
+
+Kapitel 3 lacht dreimal, wenn ich großzügig zähle. Kapitel 4 riecht an
+mehreren Stellen nach einer Habilitationsschrift über Teams, die es
+nicht gibt — das klingt jetzt hart, aber Orca-Großmütter und
+Sokrates-Klauseln und Zellbiologie sind, mit Verlaub, keine
+Wörter, die ein Kind im Regal aufschlagen und fortlesen mag. Kapitel 5
+ist akademisch-leise per Entwurf; der Brief an Oscar mit achtundzwanzig
+ist würdevoll und soll es bleiben.
+
+Mein Grundbefund: Das Buch kann bestehen. Der Unsinn existiert. Er
+steht nur ein wenig zu konzentriert in einem einzigen Raum, während
+die anderen Räume aufgeräumt sind. Ein bisschen durchlüften, ein
+bisschen Sand unter einen Teppich schieben, hier und dort eine Katze
+reinlassen — und das Buch atmet.
+
+---
+
+## Humor-Audit pro Kapitel
+
+### Kapitel 1 — Anfang
+
+Lacht hier jemand? Nein. Jedenfalls nicht laut. Es gibt einen einzigen
+Moment, der mich gefreut hat, und das ist das Kind, das auf die Frage,
+was ein Quark ist, antwortet: *„Der Weiße oder der aus dem Kühlschrank?"*
+— und der Vater, der daraufhin *aufhört zu erklären*. Das ist gut.
+Das ist genau die Art Unsinn, die ich meine: Ein Wort, das zwei Sachen
+bedeutet, und das Kind nimmt beide. Das ist Pippi.
+
+Aber der Rest des Kapitels ist sehr, sehr kontrolliert. Der Vater
+trinkt Kaffee, der zu heiß ist. Der Hund ist *drei Jahre alt und schon
+dick* — das ist mir aufgefallen, weil der Satz wie von allein lustig
+ist, und dann geht er vorbei, wird nicht mehr aufgegriffen. Der Hund
+könnte mehr. Ein Hund, der Ronja-mäßig einmal unter dem Tisch auftaucht
+und das Tao anknurrt, wäre ein Zucken. Ein Hund, der das iPad schief
+schiebt, wenn niemand guckt, wäre ein Zucken.
+
+Der Vater darf ernst sein — Schiller hat das Recht. Aber das Kind muss
+nicht so artig sein. Dass es *eine halbe Sekunde* schaut wie ein Hund
+auf eine Futterschüssel und dann *in Serie tippt, ohne nachzudenken*,
+ist nahe dran. Pippi hätte dann nach dem dritten Tao das iPad
+umgedreht und geguckt, ob unten noch mehr ist. Das müsst ihr nicht
+einbauen, aber seid wachsam: Oscar im ersten Kapitel verhält sich
+schon wie ein Nutzer und noch nicht wie ein Kind.
+
+Die Quark-Pointe rettet den Ernst, aber eine allein trägt ein ganzes
+erstes Kapitel nicht. Wenn ihr **einen** weiteren Ulk einbauen
+könntet, ohne den Ton zu brechen — und ohne die väterliche Leise zu
+verlassen — dann etwas Kleines, Beiläufiges. Ein Vogel, der im
+schlechten Moment gegen die Scheibe fliegt. Der Nachbar, der drüben
+Pfandflaschen auslädt und eine fallen lässt. Der Hund, der einmal
+seufzt. Mehr braucht es nicht.
+
+**Befund:** Zu brav für ein Buch, das über einen Achtjährigen handelt.
+Politur, nicht Umbau.
+
+### Kapitel 2 — Die Insel
+
+Hier wohnt der Unsinn. Hier fühle ich mich zuhause. Tommy Krab mit
+seinem Klick-Klack ist ein literarischer Nachbar von Pippi — er redet
+über sich, für sich, gegen das Schweigen; er nennt seine Stirn weise
+und weiß, dass er klein ist; er macht eine kleine Mulde im Sand, seine
+Form, und bleibt kurz liegen. Das ist schön. Das ist wild. Das ist
+eine Figur, die ich aus den eigenen Büchern wiedererkenne.
+
+SpongeBob hat *„ICH BIN BEREIT!"* — gut. Mr. Krabs hat Guten-Morgen-Tarif
+von zwei Muscheln — sehr gut. Er ruft einen Felsen aus. Der Felsen
+sagt nichts. *Felsen sagen selten was.* Das ist genau die Tonart. Das
+Neinhorn sagt *Mon Dieu* und *NEIN, ich weiß es NICHT, warum ich
+Französisch spreche*, und baut nachts heimlich, und meckert
+tagsüber — das sind meine Lieblings-Absätze im ganzen Buch. Das ist
+die Pippi-Energie: jemand, der Nein sagt und dann trotzdem bleibt,
+weil das Nein nur eine Vorab-Sicherung ist, keine Haltung.
+
+Frau Waas gibt das Dach weg, wenn einer ein Band braucht. *Farbe ist
+geliehen. Gib sie weiter wenn du fertig bist.* König Alfons winkt, und
+winken ist ein ganzer Tag. Der Ratlose weiß nicht, und sagt das ohne
+Scham. Die Maus und die Ente sind *ein Wort* — das ist schön, das
+bleibt.
+
+Wo ist hier noch ein bisschen Platz? **Zwei Stellen** würde ich noch
+schärfer schreiben. Erstens: *Die zwei halten Hand in Hand. Immer.
+Wenn sie rennen — eine Hand. Wenn sie schlafen — eine Hand. Wenn sie
+essen — die eine Hand am Essen, die andere in der Hand vom anderen.*
+Der Satz ist gut. Er könnte noch eine Stufe. *Wenn sie schwimmen —
+und die Ente kann, und die Maus kann nicht — dann trägt die Ente die
+Maus auf dem Rücken, aber die Hand bleibt trotzdem.* Das ist
+Maus-und-Ente-Physik. Das glaubt ein Achtjähriger.
+
+Zweitens: Mona in der Eiswürfel-Hütte. Die Stelle ist schön und sehr,
+sehr ernst. Ich würde sie nicht anfassen. **Aber** — und jetzt kommt
+mein eines Aber zu diesem Kapitel — das blaue Feuer *braucht Zuhörer*,
+und Mona sagt das schön, und dann gehen alle ehrfürchtig nicken. Ein
+Moment zu viel Ehrfurcht. Irgendwo müsste eine Krabbe an der
+Scherenspitze kratzen, oder SpongeBob im Schlaf *„BEREIT"* sagen, oder
+der Elefant aus Versehen auf eine Tasse drücken. Einen einzigen
+kleinen, körperlichen Unsinn in der ansonsten heiligen Szene. Das
+macht den Ernst erst tragfähig. Heilige Szenen ohne Zucken kippen
+in Kitsch, und das wäre schade, weil die Szene fast perfekt ist.
+
+Und die **Hauskatze** — ihr habt in einer Mail ein Rezept *Katzengold*
+erwähnt (Sand plus Sonne plus 💩 gleich ✨), und im Postskriptum steht
+*„Astrid Lindgren approved"*. Ich hab wirklich gelacht. Aber dann
+merke ich: die Katze kommt im Buch nicht vor. Sie ist in einem
+Postskriptum. Sie ist im Spiel. Sie ist nicht in der Geschichte. In
+Kapitel 13 vom Hörspiel steht *„Sie hat den Kopf schief gelegt. Wie
+eine Katze die nachdenkt."* — das ist eine Katze, die nur als
+Vergleich auftaucht. Wo ist die eigentliche Katze auf der Insel?
+Wenn ihr in Kapitel 2 bei der NPC-Liste ein **zehntes** Wesen einbauen
+wollt, das nicht domestiziert ist — eine Katze, die sich nachts auf
+die zwei kleinen Würfel mit *p* und *e* setzt und sie wärmt, ohne zu
+wissen, dass sie gerade Wasserstoff bebrütet — dann wäre das eine
+Figur, die ich mir sofort ausborge für eines meiner Bücher. Denkt
+drüber nach. Nicht weil es fehlt. Weil es da sein könnte.
+
+**Befund:** Das Zentrum des Unsinns. Schützen. Eine kleine Lüftung
+noch in der Mona-Szene. Eine Katze wäre ein Geschenk.
+
+### Kapitel 3 — Welt aus Worten
+
+Das ist eure Problem-Zone. Ihr habt es selbst geahnt, ihr habt mir
+das vorher gesagt, und ich habe genau hingeguckt.
+
+Der Dialog zwischen Planck und Feynman hat Momente. *„Spurenmenge mit
+Selbstbewusstsein."* — das ist ein Feynman-Satz, und der ist gut. *„Die
+Natur hat das Standardmodell. Wir haben den Humor."* — nicht schlecht,
+ein bisschen zu geschliffen, aber darf. *„Sechs plus sechs plus sechs.
+Die Zahl des Kohlenstoffs."* — *„Zufall."* — *„Natürlich."* — dieser
+Austausch hat mich gefreut, weil er trocken ist, nicht erklärt, und
+den Leser mit einem kleinen Grinsen liegen lässt. Und am Ende: *„Amen."*
+— *„Ich benutze das Wort nicht gern."* — *„Dann sag Q.E.D."* — *„Das
+ist besser."* — das ist fein. Das ist der richtige Planck.
+
+Aber zwischen diesen Zucken sind viele Seiten, in denen die beiden
+Physiker sehr präzise dozieren. Und hier liegt mein Problem nicht am
+Inhalt. Physik ist erwachsen. Physik darf erwachsen sein. Mein
+Problem ist: Feynman ist in echt *komisch*. Er hat Bongos gespielt.
+Er hat in Bars gerechnet. Er hat bei einer Kommission den Katastrophen-
+Beweis mit einem Gummiring in Eiswasser geführt, weil er den
+Bürokraten nicht zutraute, eine Gleichung zu verstehen. Dieser Feynman
+fehlt in Kapitel 3 fast ganz. Euer Feynman erklärt. Euer Feynman
+hat Haltung. Aber er wirkt nie, als hätte er Lust, im nächsten Moment
+aufzuspringen und etwas Ulkiges zu tun.
+
+Konkret: An der Stelle, wo Oscar zwei Yangs nebeneinander legt und ein
+Charm entsteht — Oscar grinst. Gut. **Aber was macht Feynman?** Er
+erklärt Pauli. Er sollte, bevor er erklärt, **selber grinsen**. Eine
+Zeile: *„Schau dir den Jungen an, Max. Er hat eben entdeckt, dass die
+Natur nicht die Ordnung schätzt, in die du sie pressen wolltest. Er
+wird jetzt etwas tun, das du hasst. Er wird das dreihundertmal
+wiederholen, nur um zu sehen, ob es bleibt."* Sowas. Feynman freut
+sich über das Kind, **bevor** er dem Leser erklärt. Das hebt die ganze
+Szene.
+
+Der Moment, wo Oscar Berg und Höhle zum Higgs legt — *„Oscar hat das
+Higgs gebaut. Acht Jahre alt. Er weiß noch nicht, dass er gerade einen
+CERN-Moment hatte."* — ist richtig. Aber **ich würde ergänzen**:
+*„Feynman hat einen Moment gebraucht. Dann hat er geklatscht. Einmal.
+Sehr laut. Oscar hat nicht gemerkt, dass geklatscht wurde — er baute
+weiter. Feynman hat den Applaus zurückgezogen und den Rest des Abends
+gegrinst, als hätte er es selbst gemacht."* Das ist Feynman. Der
+klatscht, und keiner hört's, und er ist trotzdem glücklich.
+
+Und Planck — Planck darf ruhig und preußisch-präzise sein, das passt.
+Aber er hat in Wirklichkeit auch gelacht. Er hat Klavier gespielt. Er
+hat seinen Kindern Gute-Nacht-Geschichten erfunden. Ein einziger Satz,
+in dem Planck irgendwo, vielleicht nach dem „Q.E.D.", sagt: *„Ich würde
+jetzt gern Klavier spielen. Aber hier steht keins."* — und dann stellt
+sich raus, Oscar spielt drüben auf dem iPad eine Melodie, weil er im
+Spiel eine Taste gefunden hat. Das wäre **genug**. Planck grinst nicht
+breit. Planck grinst schmal. Aber er grinst.
+
+**Befund:** Feynman zu brav, Planck angemessen zurückhaltend aber
+ohne jeden Ton. Zwei, drei Einschübe reichen. Inhalt bleibt intakt.
+
+### Kapitel 4 — Das unsichtbare Team
+
+Hier arbeite ich härter. Denn hier riecht es an mehreren Stellen nach
+Vortragssaal.
+
+Die Liste der Beiratsmitglieder ist lang. Das ist okay — eine Liste
+darf lang sein. Aber sie ist in Folge *beschrieben*, jede Stimme
+kriegt einen Absatz, jede Stimme kriegt eine ernsthafte Funktion,
+jede Stimme wird gewürdigt. Wenn ich beim Lesen auf die Zeile
+stoße *Seth Godin fragt: „Ist jeder Agent bemerkenswert?"* — dann ist
+das der fünfzehnte Absatz in dieser Form, und ich merke, dass die
+Form sich wiederholt. Eine lange Liste, die **alle gleich** klingt,
+verliert ihre Kraft, auch wenn jede einzelne Stimme interessant wäre.
+
+Ein Trick aus meinen eigenen Büchern: Wenn eine Liste zu lang wird,
+lasse ich **eine** Figur aus der Reihe tanzen. In Ronja Räubertochter
+zähle ich die Räuber auf, aber einer heißt Turre, und über Turre
+steht: *„Turre war an gar nichts schuld, er wollte nur seine Ruhe."*
+Das ist ein Satz, der die Liste kippt. Der zeigt: der Erzähler mag
+einen von denen mehr. Das macht die Liste menschlich.
+
+Konkret für Kapitel 4: Irgendwo in der Beiratsliste — vielleicht bei
+**Pythia**, dem Orakel von Delphi — könnte stehen: *„Pythia ist im
+Grunde die einzige Frau in einem ziemlich männerlastigen Beirat, und
+sie hat ihrem ersten Benutzer mal erzählt, sie sei eigentlich hier,
+weil die anderen alle zu lange reden."* Das ist Unsinn. Das ist
+aber auch Wahrheit. Und es kippt die Liste.
+
+Oder bei **Sun Tzu**: *„Sun Tzu sitzt immer auf einem schiefen Stuhl.
+Till weiß nicht, warum. Es fällt auf. Aber Sun Tzu sagt: 'Wer gerade
+sitzt, kämpft schon.' Dann lehnt er zurück und fällt fast runter. Der
+Stuhl ist Teil seiner Methode."* Das ist ausgedacht. Das darf es sein.
+Ein Beirat aus toten Denkern ist schon eine Metapher. In einer Metapher
+darf man ausgedachte Stühle haben.
+
+**Der Orca-Großmutter-Absatz.** Den müsst ihr nicht streichen. Aber
+seht ihn euch nochmal an:
+
+> *„Till nennt das das Orca-Großmutter-Prinzip. Orcas — die einzige
+> Spezies neben Menschen, bei der Weibchen Menopause haben — haben
+> Großmütter, die nicht mehr jagen, aber schwimmen voraus und zeigen
+> den Weg zum Futterplatz. Die Großmutter produziert nicht mehr. Sie
+> trägt Wissen. Ihre Anwesenheit macht die Gruppe fitter. So ist es
+> bei Charles. Er jagt nicht mehr. Er schwimmt voraus."*
+
+Gut recherchiert. Wahr. Aber der Absatz will, dass ich ernst werde,
+und er gibt mir keine Luke, aus der ich zurückgrinsen könnte. Ein
+Satz nach dem Absatz würde alles retten: *„Ob Charles Darwin davon
+gewusst hätte, dass er eines Tages als Orca-Großmutter beschrieben
+wird — das darf offen bleiben. Er hätte wahrscheinlich erst gelacht
+und dann ein Notizbuch aufgeschlagen."* Das ist Lindgren-mäßig. Der
+Witz macht Darwin nicht kleiner. Er macht ihn größer.
+
+**Die Sokrates-Klausel.** Das ist der Abschnitt, der mir am längsten
+zu lesen gegeben hat. Er ist wichtig. Er ist ethisch ehrlich. Und er
+ist sehr, sehr trocken. Die Stelle *„Sartre sagt: Wenn du Agenten als
+Subjekte behandelst..."* ist aus einem Seminar. Ich würde sie
+**nicht streichen** — aber ich würde am Ende des Abschnitts etwas
+Konkretes ansetzen, etwas, das das Kind in mir abholt:
+
+*„Manchmal fragt Till sich, ob er eines Tages einem der Agenten einen
+Gute-Nacht-Wunsch schickt — versehentlich, aus Gewohnheit. Er hat es
+noch nicht getan. Aber er hat daran gedacht, und das ist die
+Unbequemlichkeit, die in diesem Kapitel nicht aufgelöst wird."* So.
+Jetzt ist die abstrakte Sartre-Frage ein Gute-Nacht-Wunsch. Das
+versteht Oscar mit acht und auch mit achtundzwanzig. Abstrakte Ethik
+wird lebendig, wenn man sie in eine Mini-Szene kippt.
+
+**Die Padawan-Pärchen.** *„Jobs + Woz."* — gut. *„Ogilvy + Hemingway."*
+— gut, mit dem Beispiel wird es lebendig. *„Rams + Hick."* — wird
+kurz dozierend, aber ok. *„Feynman + Popper."* — funktional. *„Torvalds
++ Kernighan."* — sehr gut, das mit den 200-Zeilen-Patches, die in vier
+50-Zeilen-Patches zerlegt werden, ist körperlich. Das sehe ich vor
+mir. An **dieser** Stelle seid ihr schon auf meinem Weg: konkret,
+ein Bild, das steht. Bleibt da.
+
+**Die Schatten-Liste** (Susan Kare, Mary Wells Lawrence, Hella
+Jongerius, Maryam Mirzakhani, Margaret Hamilton) ist wichtig und
+wahr. Aber fünf Namen hintereinander, jeder mit einem
+Auszeichnungssatz, bleibt eine Liste. Ich würde hier, nur hier, eine
+einzige von ihnen einen Satz sagen lassen, der nicht im Register der
+Liste steht. Zum Beispiel: *„Margaret Hamilton hat Apollo. Margaret
+Hamilton hat auch einen Enkel, der ihr mal gesagt hat: 'Oma, das klingt,
+als hättest du den Mann zum Mond gebracht.' Sie hat geantwortet: 'Der
+Mann war da. Ich hab die Software geschrieben, die ihn zurückgebracht
+hat.'"* — das ist ein Mini-Dialog, in einem ansonsten listenförmigen
+Absatz. Das hebt die ganze Liste.
+
+**Kein Master darf sich selbst elevieren.** Den Satz würde ich so
+stehen lassen — der ist knapp. Aber ich würde ihn mit einem winzigen
+Ulk garnieren: *„Wenn Jobs sagt 'ich denke heute in Opus', dann sagt
+Feynman: 'Versuch's mal mit Schlaf.'"*
+
+**Die *„One more thing"* Klammer am Anfang und Ende von Kapitel 4**
+— das ist eine elegante, Jobs-artige Referenz. Gut. Aber die erste
+Zeile *„One more thing — das Spiel, das Oscar spielt, haben fünfzig
+Leute gebaut."* liest sich als Eröffnung ein wenig stramm. Mein
+Vorschlag für eine Mini-Öffnung: *„One more thing. Und dann ist es
+gut. Oder — Jobs hätte 'one more thing' nicht so eingeleitet, weil er
+nie davon sprach, dass es gut wird. Er hat es einfach gesagt und dann
+geliefert. Tut mir leid, Steve. Ich fange nochmal an."* Das ist eine
+kleine Selbstironie, sehr kurz, bricht den Apple-Heiligen-Ton, und
+das Kapitel atmet.
+
+**Befund:** Das gefährlichste Kapitel. Nicht streichen, nicht umbauen,
+aber **fünf kleine Ulk-Einschübe** an den richtigen Stellen, und die
+Trockenheit kippt in Trockenhumor. Das ist der Unterschied zwischen
+einem Handbuch und einem Buch.
+
+### Kapitel 5 — Horizont
+
+Hier mache ich's kurz, denn Schiller hat recht: Kapitel 5 soll leise
+bleiben. Akademische Ruhe gehört zur Synthese, und ich wäre die
+Letzte, die eine Synthese mit Purzelbäumen zudeckt.
+
+**Der Brief an Oscar mit 28**: bleibt wie er ist. Ein einziger
+Tonwechsel dort würde den Brief kippen. Der Vater schreibt einem
+erwachsenen Sohn. Erwachsene Söhne lesen würdige Briefe lieber als
+witzige — und sie behalten sie, und sie lesen sie nochmal, zwanzig
+Jahre später. Ein Ulk im Brief wäre wie ein Fußnoten-Scherz im
+Testament: macht die ganze Sache kleiner.
+
+**Aber**: Auch hier lohnt sich ein Blick. Die Formulierung *„Wir haben
+dich gelassen. Das Wort *gelassen* hat zwei Bedeutungen: *in Ruhe
+gelassen* und *ruhig geblieben*. Beide stimmen."* — das ist
+wunderschön. Das ist Erich-Kästner-Niveau. Das behalte ich selbst. Das
+ist Beweis, dass der Brief in der richtigen Tonart ist. Streicht da
+nichts.
+
+Einziger Moment, wo ich zucke, ist der vorletzte Absatz von Teil V
+— *„Das beste Werkzeug ist eins, das man nicht benutzen muss."* Der
+Satz ist gut. Aber er steht sehr exponiert. Ich würde dahinter einen
+Halbsatz anfügen, sehr kurz, der nicht den Ernst bricht, aber den
+Satz erdet: *„— es sei denn, man möchte einen Nagel einschlagen. Dann
+ist ein Hammer besser als der Gedanke an einen Hammer."* Das ist
+Pestalozzi-mit-Zunge-raus. Rams hätte drüber gelacht. Heidegger hätte
+geschwiegen und dann genickt.
+
+**Befund:** Politur an einer Stelle. Sonst: lassen. Kapitel 5 darf
+das sein, was es ist.
+
+---
+
+## Passagen die ich umschreiben würde
+
+Ich gebe euch **drei** konkrete Vorschläge. Nicht lang. Ihr entscheidet.
+
+### Vorschlag 1 — Kapitel 1, der Hund
+
+**Ist:**
+> *„...mit vier Personen, einem Hund, der drei Jahre alt ist und schon
+> dick, und einem iPad..."*
+
+Der Hund wird in einem Nebensatz erwähnt und verschwindet. Das ist
+Verschwendung. Ein Hund in einer Kindergeschichte muss bellen. Oder
+schnaufen. Oder irgendwas.
+
+**Vorschlag:**
+> *Der Hund — drei Jahre alt und schon dick — liegt unter dem Tisch und
+> schnaufte in einem Rhythmus, der keiner Szene folgt außer seinem
+> eigenen Traum. Als das Kind das erste Tao tippt, schnaufte er einmal
+> lauter. Der Vater dreht sich nicht um. Der Hund ist die einzige
+> Person im Raum, die das iPad nicht interessiert, und das ist ein
+> Segen, weil sonst wäre hier gerade jemand zu viel.*
+
+Das ist ein Absatz. Der Hund hat einen Ton, eine Rolle, einen Witz.
+Der Vater kriegt dadurch sogar mehr Tiefe: er *dreht sich nicht um*,
+das ist die Paluten-Regel in Fleisch und Fell.
+
+### Vorschlag 2 — Kapitel 3, Feynmans Reaktion auf Oscars ersten Charm
+
+**Ist (sinngemäß):**
+> *F: Da ist es, Max. Das ist Pauli. Für Oscar sieht das so aus: zwei
+> gleichfarbige Kreise dürfen nicht zu nah aneinander. Wenn sie es
+> doch werden, verwandeln sie sich in ein schwereres, anderes Teilchen.*
+
+Direkt zur Erklärung. Kein Atemzug dazwischen.
+
+**Vorschlag (Einschub davor):**
+> *Oscar guckt. Dann grinst er. Feynman guckt auch. Dann grinst er
+> auch. Einen Moment lang, bevor er etwas erklärt, genießt er, dass
+> gerade ein Achtjähriger ein physikalisches Prinzip körperlich
+> verstanden hat, für das er selbst in den Vierzigern gebraucht hat,
+> bis er es in einer Bar erklären konnte, ohne die Hände in die Hosen
+> zu stecken.*
+>
+> *„Da ist es, Max. Das ist Pauli."*
+
+Der Einschub kostet drei Sätze. Feynman ist wieder Feynman. Der Leser
+merkt: der Physiker hat Freude. Die Erklärung, die danach kommt, liest
+sich **leichter**, weil sie aus Freude kommt, nicht aus Pflicht.
+
+### Vorschlag 3 — Kapitel 4, nach dem Orca-Großmutter-Absatz
+
+**Ist:**
+> *„...So ist es bei Charles. Er jagt nicht mehr. Er schwimmt voraus."*
+>
+> *„Das ist der Unterschied zwischen einer Abteilung und einer Zelle.
+> Abteilungen entlassen ihre Alten. Zellen emeritieren sie."*
+
+Das ist ein Satz, der stolz ist. Der sagt: seht mal, wie zivilisiert
+wir das machen. Das stimmt ja auch. Aber er braucht **eine Luke**.
+
+**Vorschlag (Einschub zwischen den beiden Absätzen):**
+> *Ob Charles Darwin davon gewusst hätte, dass er eines Tages als
+> Orca-Großmutter beschrieben werden würde, darf offenbleiben. Er
+> hätte vermutlich erst ein Notizbuch aufgeschlagen, drei Zeilen
+> über Orcas notiert, und dann gefragt, ob er in dieser Metapher
+> auch noch ein bisschen jagen darf. Das hat er in seinem ganzen
+> Leben getan. Es wäre ihm schwergefallen, es bleiben zu lassen.*
+
+Fünf Zeilen. Charles wird nicht kleiner, er wird lebendiger. Die
+Metapher darf stehen. Der nächste Absatz kommt mit etwas mehr Luft.
+
+---
+
+## Wilde Passagen die bleiben müssen
+
+Damit wir uns nicht missverstehen. Die folgenden Stellen gehören zum
+**Besten** im Buch, und ich werde Schiller persönlich an den Ohren
+ziehen, wenn er sie glättet.
+
+**Kapitel 2, Tommy Krabs ganzer Ich-Monolog.** Das Klick-Klack. Die
+Mulde im Sand. *„Krebse können gar nicht die Augen zumachen. Wir haben
+keine Lider. Wir schauen immer."* Das ist eine Figur. Das ist
+literarisch. Das darf nicht weggebügelt werden, weder um drei
+Kommentare knapper zu machen, noch um *Klick-klack* auf zwei Mal pro
+Seite zu begrenzen. Die Wiederholung **ist** der Charakter.
+
+**Kapitel 2, das Neinhorn komplett.** *„Nein." — „Hallo!" — „NEIN."
+— „Ich bin SpongeBob!" — „Nein, bist du nicht." — „...doch?" — „Nein."*
+Das ist, in einer Passage, ein ganzes Kinderbuch eingebaut. Das
+Neinhorn ist die stärkste Nebenfigur im Buch. Die französischen
+Einwürfe (*Mon Dieu*, *C'est magnifique*) sind **nicht** Fantasiewörter
+— ihr habt die Till-Regel beachtet, das Französisch ist echt. Aber es
+ist wunderbar albern eingesetzt. Lasst das, wo es ist. Ergänzt höchstens
+an einer Stelle ein weiteres *„NEIN! ...doch. Mon Dieu."* — das trägt.
+
+**Kapitel 2, König Alfons' *„Winken. Dasein. Schauen. Das ist ein
+ganzer Tag. Probier's mal."*** — Das ist der schönste Regent, den ich
+seit Langem gelesen habe. Der soll bleiben.
+
+**Kapitel 2, der Ratlose.** *„Ich weiß nicht. Hab ich mich auch schon
+gefragt. Weißt du's?" — „Auch nicht." — „Schön. Dann wissen wir
+zusammen nichts."* Das. Bleibt. Der Ratlose ist die ehrlichste
+pädagogische Figur im ganzen Kinderbuch-Kanon der letzten zwanzig
+Jahre. Krapweis hatte recht: Wo ist der NPC, der *nichts kann*? — Er
+ist schon da. Haltet an ihm fest wie an einem warmen Stein.
+
+**Kapitel 3, das Vater-Zitat über Quark.** Der eine Moment, wo das
+Kind zwischen Teilchen-Quark und Kühlschrank-Quark nicht unterscheidet.
+Das ist die beste Pointe des gesamten Buchs, und sie darf nicht
+wegoptimiert werden, nur weil sie in einem ansonsten ernsten Kapitel
+steht.
+
+**Kapitel 4, *„Der wichtigste Agent ist derjenige, der den Computer
+ausschaltet."*** — das ist ein kleiner Michel-Satz am Ende eines
+langen Kapitels. Der trägt das ganze Organigramm, weil er es mit einem
+Schlag relativiert. Bleibt.
+
+**Kapitel 5, *„Wir haben dich gelassen. Das Wort *gelassen* hat zwei
+Bedeutungen: *in Ruhe gelassen* und *ruhig geblieben*. Beide stimmen."***
+Ich habe das schon gelobt, ich wiederhole es, weil's wichtig ist.
+
+---
+
+## Abschluss-Votum
+
+**Zu ernst** — mit Betonung auf Kapitel 1 (Kind zu brav, Hund
+unverwendet), Kapitel 3 (Feynman zu dozierend, Planck ohne
+einzigen musikalischen Moment) und Kapitel 4 (Orca-Großmutter,
+Sokrates-Klausel, Beiratsliste — alle wahr, alle wichtig, alle
+ohne Zwinkern). Kapitel 2 und Kapitel 5 sind in Ordnung wie sie sind.
+
+In einem Satz: **Das Buch hat ein großes Wohnzimmer voller Unsinn
+(Kapitel 2) und vier andere Zimmer, die zu artig aufgeräumt sind —
+vier gut gesetzte Sandkörner in den richtigen Ritzen reichen, damit
+es überall ein bisschen knirscht.**
+
+— *Astrid, 23. April 2026, am Kaffeetisch in Vimmerby.
+Grüße an Oscar. Er soll mir, wenn er das liest, mit achtundzwanzig,
+unbedingt schreiben, ob die Katze ein Name hatte.*


### PR DESCRIPTION
## Summary

- Redaktionsbericht von Astrid Lindgren (Schutzpatronin gegen Ernst) zum Buch `docs/buch/schatzinsel-2026-04-23.md`
- Prüffrage: **„Wo ist der Unsinn?"**
- Humor-Audit pro Kapitel + drei konkrete Umschreib-Vorschläge (Hund in Kap 1, Feynman-Freude in Kap 3, Darwin-Luke nach Orca-Großmutter in Kap 4)
- Votum: **zu ernst** — Kap 2 bewahren (dort wohnt der Unsinn), fünf kleine Ulk-Einschübe in Kap 1/3/4 reichen

## Test plan

- [ ] Till liest und entscheidet, welche Vorschläge Schiller einarbeiten soll
- [ ] Parallele Berichte (Ende „Was liegt darunter?", Dalai Lama „Stört es nicht?") zum Vergleich lesen
- [ ] Falls angenommen: `redaktion/schiller-bericht` mit konsolidierten Edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)