### PR TITLE
fix(physik): Baryon-Grid-Triplet entfernt (Oscar-Bug „protons spawned everywhere")

### DIFF
--- a/ops/tests/automerge.test.js
+++ b/ops/tests/automerge.test.js
@@ -53,42 +53,44 @@ describe('INSEL_AUTOMERGE — Baryon-Triplets', () => {
 
     // === Baryon-Bildung ===
 
-    it('Yang+Yang+Yin (clustered) → Proton', () => {
-        // Yang an (2,2), Yang an (2,3), Yin an (3,2) — der platzierte Block ist Yin
+    // AUDIT 2026-04-24: Baryon-Grid-Triplet entfernt (Till-Bug „protons
+    // spawned everywhere"). Yang+Yang+Yin formt KEIN Proton mehr im
+    // Grid-Match — nur noch via Craft-Recipe (siehe recipes.test.js).
+    // Stattdessen: Pair-Merge Yang+Yin→Qi greift normal.
+
+    it('Yang+Yang+Yin (clustered) → Qi (Pair-Merge, NICHT Proton-Triplet)', () => {
         const grid = makeGrid(5, 5, [
             [2, 2, 'yang'],
             [2, 3, 'yang'],
             [3, 2, 'yin'],
         ]);
         const result = checkMerge(grid, 3, 2, 5, 5);
-        assert.ok(result, 'merge result expected');
-        assert.equal(result.result, 'proton', 'Yang+Yang+Yin should form Proton');
-        assert.equal(result.type, 'triplet');
+        assert.ok(result, 'Pair-Merge Yang+Yin→Qi erwartet');
+        assert.notEqual(result.result, 'proton', 'Grid-Triplet für Baryonen ist deaktiviert');
+        assert.equal(result.result, 'qi');
     });
 
-    it('Yang+Yin+Yin (clustered) → Neutron', () => {
+    it('Yang+Yin+Yin (clustered) → Qi oder Strange, aber NICHT Neutron', () => {
         const grid = makeGrid(5, 5, [
             [2, 2, 'yin'],
             [2, 3, 'yin'],
             [3, 2, 'yang'],
         ]);
         const result = checkMerge(grid, 3, 2, 5, 5);
-        assert.ok(result, 'merge result expected');
-        assert.equal(result.result, 'neutron', 'Yang+Yin+Yin should form Neutron');
-        assert.equal(result.type, 'triplet');
+        assert.ok(result);
+        assert.notEqual(result.result, 'neutron', 'Grid-Triplet für Baryonen ist deaktiviert');
     });
 
-    it('Permutations-Invarianz: Yang-Yin-Yang (different layout) → Proton', () => {
-        // diagonale Anordnung, Yin in der Mitte
+    it('Diagonale Yang-Yin-Yang: Pair-Merges erlaubt, aber NICHT Proton-Triplet', () => {
         const grid = makeGrid(5, 5, [
             [1, 1, 'yang'],
             [2, 2, 'yin'],
             [1, 3, 'yang'],
         ]);
-        // trigger beim Yin-Center
         const result = checkMerge(grid, 2, 2, 5, 5);
-        assert.ok(result, 'merge result expected');
-        assert.equal(result.result, 'proton');
+        if (result) {
+            assert.notEqual(result.result, 'proton');
+        }
     });
 
     // === Nicht-Kollision mit Wu-Xing-Metal ===
@@ -134,30 +136,30 @@ describe('INSEL_AUTOMERGE — Baryon-Triplets', () => {
         }
     });
 
-    // === Rule-Order: Triplet schlägt Pair-Merges ===
+    // === Rule-Order nach Baryon-Entfernung (2026-04-24) ===
+    // Pair-Merges greifen jetzt sofort, keine Triplet-Priorität mehr für Baryonen.
+    // Wu-Xing-Triplet (fire+wood+water→metal) hat weiterhin Priorität.
 
-    it('Yang+Yang+Yin: Triplet schlägt Yang+Yin→Qi Pair-Merge', () => {
-        // Wenn Yin zwischen 2 Yangs gesetzt wird: es gäbe Pair-Match (Yang+Yin→Qi)
-        // UND Triplet-Match (Proton). Triplet muss gewinnen.
+    it('Yang+Yang+Yin: Pair Yang+Yin→Qi greift (nicht mehr Proton)', () => {
         const grid = makeGrid(5, 5, [
             [2, 1, 'yang'],
             [2, 3, 'yang'],
-            [2, 2, 'yin'],   // Yin in der Mitte zwischen 2 Yangs
+            [2, 2, 'yin'],
         ]);
         const result = checkMerge(grid, 2, 2, 5, 5);
         assert.ok(result);
-        assert.equal(result.result, 'proton', 'Triplet must win over pair Yang+Yin→Qi');
+        assert.equal(result.result, 'qi', 'Yang+Yin→Qi greift normal');
     });
 
-    it('Yang+Yin+Yin: Triplet schlägt Yin×Yin→Strange Pair-Merge', () => {
+    it('Yang+Yin+Yin: Pair Yang+Yin→Qi oder Yin²→Strange, NICHT Neutron', () => {
         const grid = makeGrid(5, 5, [
             [2, 1, 'yin'],
             [2, 3, 'yin'],
-            [2, 2, 'yang'],  // Yang in der Mitte zwischen 2 Yins
+            [2, 2, 'yang'],
         ]);
         const result = checkMerge(grid, 2, 2, 5, 5);
         assert.ok(result);
-        assert.equal(result.result, 'neutron', 'Triplet must win over pair Yin×Yin→Strange');
+        assert.notEqual(result.result, 'neutron', 'Baryon-Triplet deaktiviert');
     });
 
     // === Einzel-Pair darf noch funktionieren ===
@@ -317,7 +319,7 @@ describe('INSEL_AUTOMERGE — Standardmodell komplett', () => {
         assert.equal(result.result, 'neutrino');
     });
 
-    it('Regression: Yang+Yang+Yin → Proton (Baryon-Triplet nicht gebrochen)', () => {
+    it('Regression 2026-04-24: Yang+Yang+Yin → Qi (NICHT Proton, Grid-Triplet entfernt)', () => {
         const grid = makeGrid(5, 5, [
             [2, 1, 'yang'],
             [2, 3, 'yang'],
@@ -325,7 +327,7 @@ describe('INSEL_AUTOMERGE — Standardmodell komplett', () => {
         ]);
         const result = checkMerge(grid, 2, 2, 5, 5);
         assert.ok(result);
-        assert.equal(result.result, 'proton');
+        assert.equal(result.result, 'qi', 'Yang+Yin→Qi greift; Baryon nur via Craft-Recipe');
     });
 
     it('Regression: Yang + Yin → Qi (allein, ohne drittes Quark)', () => {

--- a/src/world/automerge.js
+++ b/src/world/automerge.js
@@ -92,32 +92,17 @@
             msg: '⚪ Rot + Grün + Blau → Metall! Alle Farben zusammen!'
         },
         // Baryonen — gebundene Quark-Tripletts.
-        // Gen1-only: NUR yang/yin, NICHT charm/strange/mountain/cave.
+        // AUDIT 2026-04-24 (Till-Bug: „protons spawned everywhere"):
+        // Die Grid-Triplet-Regeln für Baryonen wurden entfernt. Begründung:
+        // Tao-Decay (passiv, 1/√42 pro Tick) spamt Yang+Yin über das Grid.
+        // Jede 3er-Konstellation in 8-Nachbarschaft wurde sofort zu
+        // Proton/Neutron — ohne Oscars Intention. Protonen überall.
         //
-        // Hauptweg für Oscar: Craft-Recipe (src/world/recipes.js) — 2 Yang + 1 Yin.
-        // Grund: der Pair-Merge Yang+Yang → Charm greift sofort auf Kanten-
-        // Nachbarschaft, bevor das dritte Quark platziert werden kann. Der
-        // Grid-Triplet-Match hier ist emergent bonus für diagonale Setups.
+        // HAUPTWEG (einziger Weg) ab jetzt: Craft-Recipe in recipes.js.
+        //   - 2 Yang + 1 Yin → Proton
+        //   - 1 Yang + 2 Yin → Neutron
         //
-        // FARBLADUNG — spielerisch abstrahiert.
-        // Reale Baryonen brauchen drei verschiedene Farbladungen (R/G/B),
-        // damit die Kombination farbneutral ist (QCD-Confinement: freie
-        // farbgeladene Teilchen existieren nicht). Yang/Yin haben im Spiel
-        // aber KEINE Farb-Varianten — wir modellieren die Dreiheit allein
-        // über die Flavor-Kombination (uud/udd). Eine Mechanik mit drei
-        // Farb-Yangs/Yins würde die Quark-Ladder (Yang² → Charm) komplett
-        // umbauen — aus Spielbarkeits-Gründen ausgespart. Abstraktion,
-        // nicht Korrektheit. Audit: Till, 2026-04-22.
-        {
-            materials: ['yang', 'yang', 'yin'],
-            result: 'proton',
-            msg: '🔴 Yang + Yang + Yin → Proton! (uud)'
-        },
-        {
-            materials: ['yang', 'yin', 'yin'],
-            result: 'neutron',
-            msg: '⭕ Yang + Yin + Yin → Neutron! (udd)'
-        },
+        // FARBLADUNG — spielerisch abstrahiert (via Flavor uud/udd).
     ];
 
     function getNeighbors(r, c, rows, cols) {


### PR DESCRIPTION
Tao-Decay spamte Yang/Yin, jeder 3er-Cluster wurde Proton. Grid-Triplet entfernt, Baryonen nur noch via Craft-Recipe. 72/72 Tests grün.