### PR TITLE
fix(ui): 4 Tesla-Regressions — Mute-Btn, Code-Ebene-Btn, Chat-Overflow, Tastatur-Overlay

### DIFF
--- a/ops/tests/critical-path.spec.js
+++ b/ops/tests/critical-path.spec.js
@@ -241,6 +241,98 @@ test.describe('Critical Path — NPC-Chat', () => {
         await expect(page.locator('#chat-panel')).toHaveClass(/hidden/, { timeout: 3000 });
     });
 
+    // Oscar-Bug 1+2: Mute-Button und Code-Ebene-Button waren auf Tesla weg.
+    // Root Cause: Progressive Disclosure (game.js) versteckte view-group bis
+    // Stufe 4 (hasRecipe) und overflow-group bis Stufe 5 (completedQuest).
+    // Fix: view-group immer sichtbar, overflow-group ab Stufe 2.
+    test('Mute-Button sichtbar + klickbar bei frischem State (Tesla Oscar-Bug)', async ({ page }) => {
+        await page.setViewportSize({ width: 1920, height: 1200 });
+        await startGame(page, 1); // Stufe 1 = frisch, keine Blöcke
+
+        // Progressive Disclosure läuft alle 2s — Zeit geben
+        await page.waitForTimeout(2500);
+
+        const muteBtn = page.locator('#mute-btn');
+        await expect(muteBtn, 'Mute-Button sichtbar bei Stufe 1').toBeVisible();
+        const box = await muteBtn.boundingBox();
+        expect(box.width, 'Mute-Btn Breite ≥ 44px (Apple HIG)').toBeGreaterThanOrEqual(44);
+        expect(box.height, 'Mute-Btn Höhe ≥ 44px').toBeGreaterThanOrEqual(44);
+        // Im Viewport
+        expect(box.x + box.width, 'Mute-Btn im Viewport (rechts)').toBeLessThanOrEqual(1920);
+
+        // Klick darf Fehler werfen
+        await muteBtn.click();
+    });
+
+    test('Code-Ebene-Button erreichbar über Overflow-Menü ab Stufe 2', async ({ page }) => {
+        await page.setViewportSize({ width: 1920, height: 1200 });
+        await startGame(page, 2); // Stufe 2 = min. 1 Block gelegt
+
+        await page.waitForTimeout(2500);
+
+        // Overflow-Trigger sichtbar
+        const moreBtn = page.locator('#toolbar-more-btn');
+        await expect(moreBtn, 'Overflow-Trigger sichtbar ab Stufe 2').toBeVisible();
+        await moreBtn.click();
+
+        // Code-View-Btn im geöffneten Dropdown sichtbar
+        const codeBtn = page.locator('#code-view-btn');
+        await expect(codeBtn).toBeVisible({ timeout: 2000 });
+        const codeBox = await codeBtn.boundingBox();
+        expect(codeBox.width, 'Code-Btn klickbar').toBeGreaterThanOrEqual(44);
+        expect(codeBox.x + codeBox.width, 'Code-Btn im Viewport').toBeLessThanOrEqual(1920);
+    });
+
+    // Oscar-Bug 3: Chat-Panel Overflow rechts auf Tesla.
+    // Nicht auf 1920×1200 reproduzierbar — defensive max-width:100vw als Guard.
+    test('Chat-Panel bleibt im Viewport (max-width-Guard)', async ({ page }) => {
+        await page.setViewportSize({ width: 1920, height: 1200 });
+        await startGame(page, 2);
+
+        await page.locator('#chat-bubble').click();
+        await expect(page.locator('#chat-panel')).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(400); // Transition abwarten
+
+        const panel = await page.locator('#chat-panel').boundingBox();
+        expect(panel.x + panel.width, 'Panel-Rechts ≤ Viewport-Breite')
+            .toBeLessThanOrEqual(1920);
+    });
+
+    // Oscar-Bug 4: Virtuelle Tastatur verdeckte Chat-Input.
+    // Fix: visualViewport-Resize → Panel-Höhe anpassen. Input-Focus → scrollIntoView.
+    test('Input-Focus triggert scrollIntoView (Tastatur-Robustheit)', async ({ page }) => {
+        await page.setViewportSize({ width: 1920, height: 1200 });
+        await startGame(page, 2);
+
+        await page.locator('#chat-bubble').click();
+        await expect(page.locator('#chat-panel')).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(400);
+
+        // Spy auf scrollIntoView vor Focus
+        const scrolled = await page.evaluate(async () => {
+            const input = document.getElementById('chat-input');
+            let called = false;
+            const orig = input.scrollIntoView.bind(input);
+            input.scrollIntoView = (opts) => { called = true; return orig(opts); };
+            input.focus();
+            input.dispatchEvent(new FocusEvent('focus'));
+            // Handler hat setTimeout(300ms)
+            await new Promise(r => setTimeout(r, 500));
+            return called;
+        });
+        expect(scrolled, 'scrollIntoView bei Input-Focus aufgerufen').toBe(true);
+
+        // visualViewport-Handler installiert — Höhe passt sich an simulierten Resize an
+        const heightAfterShrink = await page.evaluate(async () => {
+            const panel = document.getElementById('chat-panel');
+            // Simuliere VV-Resize durch Event-Dispatch (echtes Shrinken geht mit Playwright nicht)
+            window.visualViewport.dispatchEvent(new Event('resize'));
+            await new Promise(r => setTimeout(r, 100));
+            return panel.offsetHeight > 0;
+        });
+        expect(heightAfterShrink, 'Panel reagiert auf VV-Resize').toBe(true);
+    });
+
 });
 
 test.describe('Easter Eggs', () => {

--- a/src/core/game.js
+++ b/src/core/game.js
@@ -5658,8 +5658,12 @@
         if (harvest) harvest.style.display = stufe >= 2 ? '' : 'none';
         if (fill) fill.style.display = stufe >= 3 ? '' : 'none';
         if (craftGroup) craftGroup.style.display = stufe >= 4 ? '' : 'none';
-        if (viewGroup) viewGroup.style.display = stufe >= 4 ? '' : 'none';
-        if (overflowGroup) overflowGroup.style.display = stufe >= 5 ? '' : 'none';
+        // view-group (Wetter, Theme, Mute) immer sichtbar — Mute ist Basic-Accessibility.
+        // Oscar-Tesla-Bug: hasRecipe-Gate verhinderte Mute-Zugriff obwohl er seit Wochen spielt.
+        if (viewGroup) viewGroup.style.display = '';
+        // overflow-group (⋯) ab Stufe 2: drei-Punkte-Menü ist selbst-versteckend,
+        // gibt Zugriff auf Code-View/Iso/Genre ohne den Screen zu überfrachten.
+        if (overflowGroup) overflowGroup.style.display = stufe >= 2 ? '' : 'none';
         if (discoveryGroup) discoveryGroup.style.display = stufe >= 3 ? '' : 'none';
 
         // Chat-Bubble

--- a/src/world/chat.js
+++ b/src/world/chat.js
@@ -1229,7 +1229,6 @@ ${budgetInfo}${florianePreisHint}`;
         vv.addEventListener('resize', adjustPanelForKeyboard);
         vv.addEventListener('scroll', adjustPanelForKeyboard);
         // Auch bei Close zurücksetzen
-        const origCloseHandler = closeBtn.onclick;
         closeBtn.addEventListener('click', () => {
             panel.style.height = '';
         });

--- a/src/world/chat.js
+++ b/src/world/chat.js
@@ -1207,6 +1207,43 @@ ${budgetInfo}${florianePreisHint}`;
         syncChatOpenClass();
     });
 
+    // === Virtuelle Tastatur nicht über Chat-Input legen ===
+    // Bug: Oscar tippt im Tesla, die Bildschirmtastatur überdeckt die untere
+    // Hälfte des Chat-Panels — Input-Feld + letzte Nachrichten weg.
+    // Fix: visualViewport API kürzt Panel-Höhe auf sichtbare Fläche, und
+    // scrollIntoView hält das Input-Feld im Blick.
+    if (window.visualViewport) {
+        const vv = window.visualViewport;
+        const adjustPanelForKeyboard = () => {
+            // Nur wenn Chat offen ist
+            if (panel.classList.contains('hidden')) {
+                panel.style.height = '';
+                return;
+            }
+            // Viewport-Höhe minus Header-Offset (52px) minus safe-area-top.
+            // vv.height = sichtbare Fläche nach Tastatur-Einblendung.
+            const top = parseFloat(getComputedStyle(panel).top) || 52;
+            const newHeight = Math.max(200, vv.height - top + vv.offsetTop);
+            panel.style.height = newHeight + 'px';
+        };
+        vv.addEventListener('resize', adjustPanelForKeyboard);
+        vv.addEventListener('scroll', adjustPanelForKeyboard);
+        // Auch bei Close zurücksetzen
+        const origCloseHandler = closeBtn.onclick;
+        closeBtn.addEventListener('click', () => {
+            panel.style.height = '';
+        });
+    }
+
+    // Input-Focus: scroll Input ins Sichtbare (Tastatur-Robustheit)
+    input.addEventListener('focus', () => {
+        // setTimeout gibt der virtuellen Tastatur Zeit zu erscheinen,
+        // bevor wir scrollen — sonst ist das Ziel schon wieder verdeckt.
+        setTimeout(() => {
+            input.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }, 300);
+    });
+
     // Chat-Bubble (💬 FAB) öffnet den Chat
     const chatBubble = document.getElementById('chat-bubble');
     if (chatBubble) {

--- a/style.css
+++ b/style.css
@@ -1515,6 +1515,8 @@ body.chat-open #chat-bubble {
     top: calc(52px + env(safe-area-inset-top, 0px));
     right: 0;
     width: 320px;
+    /* Defensive: nie breiter als Viewport (Tesla/PWA/Split-Screen-Guard) */
+    max-width: 100vw;
     height: calc(100vh - 52px - env(safe-area-inset-top, 0px));
     background: white;
     border-radius: 16px 0 0 16px;


### PR DESCRIPTION
## Oscar-Feedback Tesla-Morgen 2026-04-24

Till direkt aus Oscars Tesla-Nutzung:
1. "mute button ist weg"
2. "code ebene button auch"
3. "chatfenster overflow nach rechts im tesla"
4. "tastatur (bildschirm) blockiert die hälfte des fensters"

## Root Cause (ehrlicher Befund)

**Die Auftrags-Hypothese „Regression durch PR #472 (Bernd-Chat-X-Fix)" ist empirisch falsch.** PR #472 hat nur 3 `#chat-header`-Selektoren angefasst, keinen Toolbar-Code. Browser-Verify mit Playwright hat das klar gezeigt.

**Die echte Ursache** (Browser-verifiziert auf 1920×1200):

| Bug | Wirkliche Ursache |
|-----|--------------------|
| 1 Mute weg | Progressive Disclosure (`src/core/game.js:5661-5662`) versteckt `#view-group` bis Stufe 4 (`hasRecipe=true`). Oscar kann Wochen spielen und Stufe nie erreichen. |
| 2 Code-Ebene weg | Gleiche Disclosure-Gate auf `#overflow-group` bis Stufe 5 (`completedQuest>0`). |
| 3 Chat-Overflow rechts | **Nicht reproduzierbar** auf 1920×1200 Landscape, auch nicht mit langen Texten. Till hat was gesehen → evtl. PWA/Split-Screen. Defensive Guard hinzugefügt. |
| 4 Tastatur-Overlay | Kein `visualViewport`-Handler im Code (grep: 0 Treffer). Panel behält volle `100vh` wenn Keyboard aufpoppt → verdeckt Input + letzte Nachrichten. |

## Fixes (atomar, minimal-invasiv)

- **Commit 1** `src/core/game.js`: `view-group` immer sichtbar, `overflow-group` ab Stufe 2 (statt 5). Dropdown-Inhalt bleibt hinter `⋯`-Trigger versteckt — kein Overwhelm für neue Spieler.
- **Commit 2** `style.css`: `max-width: 100vw` auf `#chat-panel` als defensive Guard.
- **Commit 3** `src/world/chat.js`: `visualViewport.resize/scroll` → Panel-Höhe angleichen. `chat-input` `focus` → `scrollIntoView({ block: 'center' })` mit 300ms-Delay.
- **Commit 4** `ops/tests/critical-path.spec.js`: 4 neue Regression-Tests (Tesla-Viewport 1920×1200).

## Offene Produkt-Frage für Till

Oscars localStorage im Tesla scheint jeden Morgen fresh zu sein (`blocksPlaced=0`). Ist das:
- (a) gewollt (Tesla-Incognito/Clear-Cache-Policy)?
- (b) ein Persistenz-Bug (PWA-Cache-Strategy)?

Wenn (b), braucht es einen separaten Sprint-Eintrag. Dieser PR fixt symptomatisch, nicht die Root-Cause-Persistenz.

## Was NICHT angefasst wurde

- PR #472 Bernd-X-Button-Fix bleibt intakt (`#chat-character { min-width: 0 }`, `#chat-close-btn { flex-shrink: 0 }`, `.chat-npc-name` sr-only).
- Toolbar-HTML unverändert — nur Disclosure-JS angepasst.
- Keine Refactors, kein Redesign.

## Test Plan

- [ ] `npm run typecheck` → grün (verifiziert)
- [ ] `npm run test:e2e` → alle 4 neuen Regression-Tests grün
- [ ] Oscar fährt morgen Tesla → Mute-Btn sichtbar, Chat-Input sichtbar beim Tippen

🤖 Generated with [Claude Code](https://claude.com/claude-code)