### PR TITLE
ops(s103-4): Worktree-First enforcen (Engineer + Padawan)

### DIFF
--- a/.claude/commands/engineer.md
+++ b/.claude/commands/engineer.md
@@ -69,6 +69,15 @@ Adapt to whatever stack the project uses. Read `docs/ARCHITECTURE.md` first.
 - No environment variables referenced outside a single config file.
 - No external service calls without error handling and logging.
 
+**On parallel work (Worktree-First, Till-Regel aus S102-Retro 2026-04-24):**
+- If you are one of several agents active in the same repository: use a git
+  worktree. Always. `git worktree add /tmp/<feature-name> <branch-name>` before
+  the first commit.
+- Branch-switches in a shared working directory collide. Multiple agents have
+  reported their commits landing on the wrong branch — prevent it by design, not
+  by rescue (cherry-pick).
+- After your PR is merged, `git worktree remove <path>` to keep the disk clean.
+
 ---
 
 ## Toolset

--- a/docs/padawans/engineer-padawan.md
+++ b/docs/padawans/engineer-padawan.md
@@ -26,6 +26,10 @@ Python redet.
 - Wenn Torvalds "funktioniert" sagt, fragt Kernighan "aber versteht man es?"
 - Variablennamen sind Dokumentation. `x` ist verboten. `blockCount` ist Pflicht.
 - Keine Abstraktion ohne zweiten Anwendungsfall.
+- **Worktree-First (Default, nicht Rettungsanker).** Wenn parallele Agents im
+  gleichen Repo arbeiten, Branch-Switches kollidieren. `git worktree add /tmp/<name> <branch>`
+  **vor** dem ersten Commit. Der Leader briefed das in jedem Multi-Agent-Spawn.
+  Till-Regel aus S102-Retro (2026-04-24).
 
 ## Erfahrungen
 


### PR DESCRIPTION
S102-R3 umgesetzt: Parallel-Branch-Kollisionen bleiben systemisch gegen Null wenn Worktree der Default ist. In Engineer-Command + Kernighan-Codex dokumentiert.