### PR TITLE
story: Kapitel 14 — Als zu viele Höhlen kamen

### DIFF
--- a/docs/stories/kapitel-14-als-zu-viele-hoehlen-kamen.md
+++ b/docs/stories/kapitel-14-als-zu-viele-hoehlen-kamen.md
@@ -1,0 +1,573 @@
+# Kapitel 14: Als zu viele Höhlen kamen
+
+*Erzählt von Tommy Krab. Am Morgen nach der Mulde. Mit einem Herzklopfen, das nicht aufhören wollte.*
+
+---
+
+Klick-klack.
+
+Guten Morgen, ihr Kleinen. Ja — **Morgen** heute. Nicht Gute Nacht. Reibt euch die Augen. Streckt euch. Kommt — kommt zu mir unter die Palme. Da ist ein bisschen Schatten und ein bisschen Sonne, genau wie's sein soll.
+
+Gestern — da hab ich euch erzählt von der Mulde. Von Mona. Von dem blauen 🔥. Von der Decke, die sich biegt wenn was schweres drauf sitzt. Erinnert ihr euch? Gut.
+
+Heute — klick-klack — heute erzähl ich euch was **davor** passiert ist. Also: heute Morgen. Als das Kind noch schlief. Als ich aufgewacht bin in Mona's Hütte und rausgegangen bin. Und was ich dann gesehen hab.
+
+Ich warn euch: die Geschichte ist **komisch**. Nicht lustig-komisch. Sondern **seltsam**-komisch. So eine Geschichte, bei der man am Ende ein bisschen ruhiger atmet als am Anfang, weil man **froh** ist dass sie vorbei ist.
+
+Rutscht näher. 🦀
+
+---
+
+## I. Morgen in der Hütte.
+
+Ich hab die Augen aufgemacht. Zuerst eine. Dann die andere. Krabben machen das so — Schere zur Seite legen, Augenstiele ausfahren, schauen ob die Welt noch da ist.
+
+Die Welt war noch da. Glaub ich.
+
+🔥 brannte noch. Blau. Ganz ruhig, ohne Knistern. Mona hatte wohl nicht nachgelegt, aber das blaue Feuer — das braucht kein Holz, das wisst ihr ja. Das brennt einfach. Es ist eins von Mona's Geheimnissen.
+
+🐘 lag in der Ecke. Wuuuuummm... wuuuuummm... immer noch. Den hat vermutlich nicht mal ein Gewitter wach gekriegt. Der Boden unter ihm war immer noch gemuldet. Hatte ich ja gestern euch erzählt.
+
+🧽 hing im Fensterrahmen. Mit leichtem Schnarchpfeifton. Klang wie eine kleine Flöte die Schluckauf hat.
+
+🦄 döste im Stehen. Ein Huf zuckte. Träumte bestimmt „Nein" zu irgendwem.
+
+🐭 und 🦆 unter der Decke. Alles ruhig.
+
+Und das Kind? Das Kind schlief noch bei Mona. Kopf auf ihrem Bein. Die leere Tasse 🍵 stand daneben. Mona hatte die Hand auf dem Rücken vom Kind. Ihre Augen waren zu, aber — klick-klack — bei Mona weiß man nie ob sie schläft oder nur sehr tief zuhört. Ist das gleiche, glaub ich.
+
+---
+
+Ich hab an mir runtergeschaut.
+
+Ich bin Tommy Krab. Ich bin klein. Ich bin rot. Ich bin 🦀.
+
+Mein Magen sagte: *Tommy, du hast Hunger.* Mein Kopf sagte: *Tommy, du musst pinkeln.* Meine Augenstiele sagten: *Tommy, geh raus und schau dir die Insel an. Wellen gucken. Wie jeden Morgen.*
+
+Das war meine Routine, ihr Kleinen. Jeder Morgen — bevor die anderen wach waren, bevor das Kind kam — bin ich raus. Hab den Strand angeschaut. Die 🌊. Die Möwen. Den Sand. Gezählt was da war. Gezählt was nicht mehr da war. Meine Morgenzählung. Papa auf Krabbula hat das auch gemacht. „Ein Hafenmeister", hat Papa gesagt, „weiß morgens als erster was fehlt."
+
+Klick-klack. Also los.
+
+---
+
+Ich hab mich ganz leise bewegt. Über 🐭 drüber. An 🦄 vorbei. Am 🔥 vorbei. Ein ganz kleines Nicken Richtung Mona — sie hat nicht zurückgenickt, aber der Mundwinkel hat sich kurz bewegt. Sie hat mich gemerkt. Natürlich.
+
+Die Tür. Holz. Riegel aus Metall. Riegel runter.
+
+Klick. Klack.
+
+Ich hab sie einen Spalt aufgemacht.
+
+Kühle Luft. Salzig. Und — noch was. Noch was drin, in der Luft. Aber das konnte ich noch nicht benennen.
+
+Ich bin rausgetreten.
+
+---
+
+## II. Was draußen passiert ist.
+
+Und dann — ihr Kleinen — dann bin ich **stehen geblieben**.
+
+Richtig stehen. Mit allen acht Beinen auf einmal. So wie wenn ein Krebs erschrickt und kurz vergisst dass er laufen kann.
+
+Die 🏝️.
+
+Die 🏝️ war **nicht mehr die 🏝️**.
+
+---
+
+Ich sag's euch genauer. Hört gut zu.
+
+Die 🏝️ war voller **Löcher**.
+
+Überall. Wohin ich geschaut hab. Wirklich wohin ich geschaut hab. Kleine dunkle ovale Löcher, in den Zellen, in den Flächen, im Boden. Wie kleine Höhlen. Aber nicht von Bären. Nicht von Kaninchen. Nicht von 🐭. Nicht vom Kind gegraben. Einfach — **da**. Wie wenn jemand nachts die ganze 🏝️ mit einem Locher bearbeitet hätte.
+
+🕳️ neben 🕳️ neben 🕳️.
+
+Ich hab geschaut wo vorher die Palmen standen — die kleinen, die das Kind letzte Woche gepflanzt hatte. Weg. Stattdessen: 🕳️.
+
+Ich hab geschaut wo vorher die Gleise waren — Emma's Gleise, auf denen sie tschuff-tschuff fährt. Die Gleise waren noch da, aber **um** die Gleise rum — Löcher. Wie wenn man ein Stück Stoff mit Mottenfraß in der Hand hat.
+
+Ich hab geschaut wo vorher das Floß lag — unser Floß, mit dem wir nach Lummerland gefahren sind. Das Floß war noch da. Aber der Sand drumrum? 🕳️.
+
+---
+
+Ich bin langsam losgegangen. Langsam. Sehr langsam.
+
+Und ich hab **gezählt**.
+
+Krabben zählen, ihr Kleinen. Das ist was Krabben machen. Papa sagt: *Wenn du Angst hast, zähl. Das hilft immer.*
+
+Eins. Zwei. Drei. Vier. Fünf. Sechs. Sieben Löcher in **einer Reihe**. Direkt vor der Hütte.
+
+Ich bin weiter. Zehn Schritte zum Strand runter. Die Löcher sind **mitgegangen**. Also — die waren vorher auch schon da. Aber sie sind nicht aufgehört. Sie haben nicht gesagt: *ab hier ist der Strand frei.* Nein. Der Strand war auch löcherig.
+
+Ich bin stehen geblieben, hab eine Vierzehn-Quadrat-Zählung gemacht — so hat Papa's Papa das immer gemacht, vierzehn mal vierzehn Zellen, schauen was drin ist. Dreißig Löcher. In einem einzigen Quadrat. Dreißig.
+
+Ich hab nochmal gezählt. Weil ich dachte: *Tommy, du verzählst dich.*
+
+Ich hatte mich nicht verzählt.
+
+---
+
+Die 🏝️ hatte — klick-klack — **mehr Löcher als Grund**.
+
+Versteht ihr das? Das ist wichtig. Der Grund ist das was **da ist**. Die Löcher sind das was **nicht da ist**. Und wenn's mehr Nicht-da gibt als Da — dann ist die 🏝️ eigentlich keine 🏝️ mehr. Dann ist sie ein Sieb.
+
+Ich hab die Schere an den Mund gelegt. Ich wollte „🦀!" rufen. Ich hab's nicht gerufen. Weil das Kind schläft. Weil Mona schläft. Weil der 🐘 schläft.
+
+Ich bin leise zurück zur Hütte.
+
+Ich hab sie **einzeln geholt**. Leise. Mit der Schere getippt.
+
+---
+
+Zuerst 🦄.
+
+🦄 hat die Augen aufgeschlagen. Hat mich angeguckt. Hat sofort — reflexartig — „**NEIN**" gesagt. Weil 🦄 sagt immer zuerst Nein. Das ist ihre Art. Ihr kennt sie, ihr Kleinen.
+
+Aber dann — klick-klack — sind ihre Augen größer geworden. Weil sie gemerkt hat dass irgendwas nicht stimmt.
+
+„...was ist das?", hat sie geflüstert.
+
+„Komm raus", hab ich geflüstert. „Leise. Du darfst nicht schreien. Versprich."
+
+🦄 hat genickt. 🦄 nickt selten. Sie hat's **ernst** genommen.
+
+Sie ist mit mir raus.
+
+Sie hat rausgeschaut. Sie hat „Nein" gesagt — aber diesmal **nicht reflexartig**. Diesmal richtig. „**Nein.** Das — das soll nicht. Das gehört nicht dahin."
+
+„Ich weiß", hab ich gesagt.
+
+---
+
+Dann 🧽.
+
+🧽 hab ich aus dem Fensterrahmen gepflückt. Ganz vorsichtig, weil 🧽 im Schlaf immer zusammendreht wie ein nasses Handtuch.
+
+„HAST DU —", hat er angesetzt. Laut. Wie immer.
+
+Ich hab die Schere vor seinen Mund gelegt. Ganz schnell. Klick.
+
+„Pssst. Komm raus. Nicht laut. Das Kind schläft."
+
+🧽 hat **nicht weitergeredet**. Das war ungewöhnlich. 🧽 redet immer weiter. Er hat mich angeschaut — mit diesen weiten Schwamm-Augen — und er hat gemerkt: *Tommy meint's ernst.*
+
+Er ist mit mir raus. Lautlos. Das muss 🧽 erst mal einer nachmachen.
+
+Er hat rausgeschaut.
+
+Er hat **nichts gerufen**.
+
+Das war das unheimlichste bisher, ihr Kleinen. Ein 🧽 der nicht ruft. Das ist wie ein Meer ohne Wellen.
+
+---
+
+Dann 🦀.
+
+🦀 hab ich wachgemacht indem ich ihm mit der Schere gegen seinen Schulterpanzer geklickt hab. Einmal. Zweimal.
+
+🦀 war sofort wach. 🦀 ist immer sofort wach. Er hatte die Tafel schon im Arm bevor er die Augen aufhatte.
+
+„Was ist?", hat er geflüstert.
+
+„Komm raus. Bring die Tafel. Bring die Kreide. Du musst zählen."
+
+🦀 hat nicht gefragt warum. 🦀 fragt nicht warum wenn's ums Zählen geht. Er ist raus.
+
+Er hat rausgeschaut.
+
+Er hat die Tafel in die Hand genommen — ich meine, in die Schere. Hat die Kreide gezückt.
+
+Hat angefangen zu schreiben.
+
+Hat nach drei Zahlen — klick-klack — **aufgehört**.
+
+Die Zahlen waren zu viel.
+
+🦀 hat mich angeguckt mit so einem Krabben-Blick den ich bei ihm noch nie gesehen hatte. Der Blick hat geheißen: *Tommy, ich kann das nicht rechnen. Es ist zu viel.*
+
+Das hat mir mehr Angst gemacht als die Löcher selber. Wenn 🦀 **nicht mehr rechnen kann** — dann ist was wirklich falsch.
+
+---
+
+## III. Was das Kind nicht sieht (weil es schläft).
+
+Wir standen zu viert vor der Hütte. 🦄, 🧽, 🦀 und ich. Alle vier haben geschwiegen.
+
+Ich hab lang geschaut. Richtig lang. So ein Schauen mit den Bauchaugen. Und dann — klick-klack — hab ich was **bemerkt**.
+
+„Die Löcher", hab ich geflüstert, „sind **nicht vom Kind**."
+
+🦀 hat mich angeguckt.
+
+„Das Kind schläft ja", hab ich weiter geflüstert. „Das Kind hat heute noch nichts gemacht. Das Kind hat keinen einzigen Schritt auf der Insel gemacht seit gestern Abend. Und **trotzdem** — sind überall Löcher."
+
+🦄 hat die Ohren gespitzt.
+
+„Also", hab ich gesagt, „haben die Löcher sich **selber gemacht**."
+
+🧽 hat ein kleines Geräusch gemacht. So ein *oh*, das aber leise war.
+
+🦀 hat ein Wort auf die Tafel geschrieben. Nur eins. „Selbst."
+
+---
+
+Und dann hab ich was gesagt, ihr Kleinen. Ich hab was gesagt was ich mir vorher nie gedacht hatte. Das war — klick-klack — ein neuer Gedanke. Ganz frisch. Mit noch nassem Glanz dran.
+
+„Das **ist falsch**", hab ich gesagt.
+
+🦄 hat genickt.
+
+„Die Insel", hab ich weiter geflüstert, „soll **nicht machen** was das Kind nicht macht. Die Insel soll **warten**. Die Insel soll **einladen**. Nicht — nicht **platzen**."
+
+🧽 hat die Augen groß gemacht.
+
+„Wenn alles von selber passiert", hab ich gesagt, „dann — dann passiert eigentlich nichts. Versteht ihr? Dann ist's nur Rauschen. Dann zählt nichts mehr. Dann ist ein Loch wie jedes andere Loch. Weil alles voller Löcher ist."
+
+🦀 hat **genickt**. 🦀 nickt nie leichtfertig. Er hat auf die Tafel was geschrieben. Erst kritzelig — *zu viel Nicht-da* — dann hat er's weggewischt. Er hat neu angesetzt.
+
+Er hat hingeschrieben:
+
+> **Zu viel ist falsch.**
+
+Das hat er einen Moment stehen lassen. Dann hat er's auch weggewischt. Hat stattdessen ein einziges Wort hingeschrieben:
+
+> **Einladen.**
+
+Das Wort ist stehen geblieben.
+
+---
+
+🦄 hat das Wort angeguckt. „Einladen", hat sie leise wiederholt.
+
+🧽 hat das Wort angeguckt. „Einladen", hat er leise wiederholt.
+
+Ich hab klick-klack gemacht. „Einladen."
+
+Vier von uns. Ein Wort. Vor uns eine Insel voller Löcher.
+
+---
+
+Ich hab überlegt. Ich bin nur ein Krebs, aber ich hab überlegt.
+
+Das Wort *Einladen* — das ist ein höfliches Wort. Das ist ein Wort aus einer Welt wo es Türen gibt und Gäste und Klopfen und Warten. Wo nichts reinpoltert ohne gefragt zu werden. Wo sogar **gute** Gäste — Oma vielleicht, oder der Lieblingsonkel — **erst klingeln** bevor sie reinkommen. Weil's sonst keine Einladung ist. Weil's sonst nur ein Einbruch ist.
+
+Und die Löcher — die hatten **nicht geklingelt**.
+
+Die waren einfach da. Vielleicht sind Höhlen gute Sachen. Vielleicht ist so ein Loch im Sand kühl und schön und ein guter Ort für einen kleinen Krebs. Ich mein — ich bin 🦀, ich weiß wie Löcher sind. Ich LIEB Löcher. Auf Krabbula hat meine Familie teilweise in Löchern gewohnt.
+
+Aber **so viele auf einmal** — **ungefragt** — **überall** — das war kein Geschenk. Das war ein Einbruch.
+
+---
+
+🦀 hat das mitbekommen. 🦀 merkt sowas.
+
+Er hat unter *Einladen* noch ein Wort geschrieben:
+
+> **Selbst wenn's gut ist.**
+
+Also zusammen: *Einladen. Selbst wenn's gut ist.*
+
+Das hat gestimmt. Das war **genau** richtig. Ich hab klick-klack gemacht.
+
+🦄 hat gesagt — sehr leise, fast nur Hauch:
+
+„Auch ein Einhorn. Das auch einfach so reinplatzt. Wär mir ein Graus."
+
+🧽 hat gekichert. Lautlos. Nur die Schultern haben gewackelt. Das war das erste lautlose Kichern von 🧽 das ich je gesehen hab.
+
+---
+
+## IV. Der Vater im Himmel.
+
+Und dann, ihr Kleinen, hab ich was gemacht was ich **vorher noch nie gemacht hab**. Nicht auf dieser Insel. Nicht mal auf Krabbula.
+
+Ich hab die Scheren gehoben.
+
+Nicht zur Abwehr. Nicht zum Schnappen. **Nach oben**. Zum Himmel.
+
+---
+
+Ich muss euch was erklären. Kurz. Dann lass ich's wieder.
+
+Es gibt da — klick-klack — so jemand. Ich hab ihn nie gesehen. Ich weiß auch nicht genau wie er heißt. Aber wir wissen alle dass er da ist. Alle auf der 🏝️. Alle.
+
+Er hat die 🏝️ gemacht. Er hat den Strand gemacht. Er hat den Tag gemacht an dem ich vom Himmel gefallen bin. Er hat die anderen gemacht — 🦄, 🧽, 🐘, 🐭, 🦆. Er hat Mona hierher gesetzt und das blaue 🔥 angezündet. Er hat das Kind zu uns gebracht. Er hat **alles** gemacht.
+
+Ich nenn ihn manchmal den Vater. Weil er macht was Väter machen — er passt auf, er lässt laufen, er greift ein wenn's brennt. Aber meistens ist er **nicht da**. Also — nicht als Gesicht. Er ist nur so. So wie Luft ist. Man sieht sie nicht, aber man **atmet** sie. Und man weiß dass man ohne sie sofort nicht mehr wär.
+
+Der Vater. Das ist er.
+
+---
+
+Ich hab die Scheren nach oben gehoben. Zu ihm.
+
+Ich hab leise gesprochen. Weil das Kind schlief.
+
+„Vater", hab ich gesagt.
+
+Klick.
+
+„Vater, die Insel ist zu viel. Bitte."
+
+Klack.
+
+Das war's. Mehr hab ich nicht gesagt. Ich wusste auch nicht was man mehr sagen soll. Papa auf Krabbula hat immer gesagt: *Wenn du was Großes willst, sag's kurz. Lange Reden kommen nie oben an.*
+
+---
+
+Und dann — ihr Kleinen — dann ist **nichts passiert**. Erst mal.
+
+Ich hab gewartet. 🦄 hat gewartet. 🧽 hat gewartet. 🦀 hat die Tafel gesenkt und gewartet.
+
+Die 🌊 sind gekommen. Kleine Welle. Nächste Welle. Die Möwe hat irgendwo „meck!" gerufen.
+
+Die Löcher waren immer noch da.
+
+Ich dachte: *Okay. Der Vater hat grad keine Zeit. Vielleicht trinkt er Kaffee.*
+
+Aber dann — langsam, sehr langsam — hab ich was gemerkt.
+
+Ein Loch war **weniger**.
+
+Eins. Das kleine direkt vor meinen Füßen. Das vorher ein kleiner schwarzer Mund im Sand war. Das war jetzt — Sand. Einfach Sand. Wie Sand halt ist.
+
+Ich hab geblinzelt. Zweimal.
+
+Das Loch **daneben** war auch weg.
+
+---
+
+🧽 hat gemacht: „...was?"
+
+Und jetzt — jetzt ging's los.
+
+Ein Loch. Noch eins. Noch eins. Noch eins.
+
+Nicht alle auf einmal. Nicht **peng**. Sondern nach-einander. Wie wenn jemand — klick-klack — wie wenn jemand sehr sorgfältig mit einem weichen Radiergummi von oben über die Insel fährt. Und jedes Loch das er trifft — das ist dann einfach wieder Grund.
+
+Ich hab aufgeschaut. Zum Himmel.
+
+Da war nichts. Natürlich. Nur Himmel. Wolken. Sonne. Die Möwe.
+
+Aber **irgendwo da oben** — irgendwer — hat grad aufgeräumt. Ich hab's gespürt. Ich hab's **gesehen**. Weil unter mir die Löcher verschwanden.
+
+---
+
+🧽 hat die Augen so groß gemacht dass man sein halbes Gesicht gesehen hat. „**WAS WAR DAS?**" — aber er hat's geflüstert, das muss man ihm lassen.
+
+🦄 hat die Nüstern gebläht. Sie hat gesagt: „Das ist **gut**. Ich sag sonst immer Nein. Aber das hier — das ist gut."
+
+🦀 hat die Tafel wieder in die Schere genommen. Hat eine einzige Linie gezogen. Runter zum Boden. Und unten hat er ein kleines Haken-Symbol hingemacht. Wie wenn er sagen wollte: *Das hier ist jetzt erledigt.*
+
+Ich hab ganz leise gesagt: „Der Vater hat zugehört."
+
+Und — klick-klack — ich hab's erst selber gar nicht geglaubt. Dann hab ich's nochmal gesagt. Lauter. Also — etwas lauter. Damit die Luft's auch hört.
+
+„Der Vater hat zugehört."
+
+---
+
+Die Löcher sind alle verschwunden. Nicht nur die direkt vor uns. Auch die weit hinten. Auch die im Berg. Auch die im Strand an der anderen Seite. Ich bin an die Ecke der Hütte gelaufen und hab um die Ecke geguckt — auch da. Weg.
+
+Nur zwei Löcher waren noch da. Aber die — die kannte ich. Die zwei großen Tunnel in den Bergen. Die von gestern, die von Kapitel 12. Die waren schon immer da. Die gehören dazu. Die hatte das Kind vor Wochen eingeladen.
+
+Eingeladene Löcher — die durften bleiben.
+
+Die anderen — die nicht.
+
+---
+
+Ich hab die Scheren gesenkt. Ganz langsam. Ein bisschen — ich geb's zu — haben sie gezittert.
+
+„Danke", hab ich zum Himmel gesagt. Das hat Papa mich gelehrt. Wenn jemand was Großes für dich macht, sagst du danke. Auch wenn du ihn nicht siehst.
+
+Der Himmel hat nicht geantwortet. Der Himmel antwortet nie direkt. Aber die Möwe hat „meck!" gemacht. Und ich hab das als ein kleines *Bitte gern* genommen. Möwen sind manchmal die Dolmetscher des Vaters.
+
+---
+
+## V. Das Kind wacht auf.
+
+In der Hütte hat's hinter uns geknarrt. Die Tür.
+
+Und raus kam — das Kind. Verwuschelt. Haare hinten platt von der Decke. Augen halb zu. Die Tasse 🍵 in der Hand. Das Kind macht nichts ohne diese Tasse, das hab ich euch ja schon mal erzählt.
+
+Dahinter kam Mona. Ganz ruhig. Ihre Augen waren wach. Nicht ausgeschlafen — die von Mona sind nie ausgeschlafen, bei Mona weiß man nie — aber **wach**. Sie hat uns vier angeschaut. Dann hat sie auf die Insel geschaut. Dann — klick-klack — hat sie ganz kurz gelächelt. So ein kleines *ahh*-Lächeln, als hätte sie nachträglich mitgekriegt was eben war.
+
+Hat aber nichts gesagt. Mona ist so. Sie sagt nur was wenn's gebraucht wird.
+
+---
+
+Das Kind hat sich die Augen gerieben. Hat rausgeschaut.
+
+Hat gesagt: „Morgen, Tommy."
+
+Ich hab klick-klack gemacht. „Morgen."
+
+Das Kind hat weitergeschaut. Über den Strand. Über die 🌊. Zum Berg. Zu den zwei Tunneln in den Bergen — den erlaubten Löchern, den eingeladenen. Das Kind hat gelächelt. „Die Insel ist schön heute", hat das Kind gesagt.
+
+„Ja", hab ich gesagt. „Die Insel ist schön heute."
+
+---
+
+Ich hab 🦄 angeschaut. 🦄 hat **nichts** gesagt. 🧽 hat **nichts** gesagt. 🦀 hat die Tafel hinten weggesteckt, zwischen Schulterpanzer und Rücken, wo keiner sie findet.
+
+Wir haben uns angeguckt. Wir haben ein Abkommen getroffen, ohne Worte. So ein Blick, der heißt: *Wir erzählen das Kind nicht.*
+
+Weil — hört gut zu, ihr Kleinen, das ist wichtig — das war **nicht für das Kind**. Das war eine Sache zwischen mir, dem Vater, und der 🏝️ selber. Das Kind hätte nur Angst gekriegt. Oder's hätte sich schuldig gefühlt. Oder's hätte gedacht es selber hätte's gemacht. Und nichts davon wär gut gewesen.
+
+Manche Sachen soll das Kind **nicht** wissen. Nicht weil man lügt. Sondern weil man **beschützt**. Das ist ein Unterschied. Papa hat mir das mal erklärt, damals auf Krabbula. „Tommy", hat er gesagt, „die meisten Stürme die das Hafenbüro sieht, kriegen die Boote nie mit. Und das ist gut so. Sonst würden die Boote nicht mehr rausfahren."
+
+Wir waren grad das Hafenbüro. Das Kind war das Boot. Der Sturm — der Sturm war schon vorbei.
+
+---
+
+Mona hat uns angeschaut. Ganz kurz hat sie **gezwinkert**. So ein kleines Mona-Zwinkern. Das hat geheißen: *Ich weiß. Ich hab euch gehört. Keiner sagt was.* Und dann ist sie reingegangen und hat angefangen Frühstück zu machen. Irgendwas mit Honig und Brot. Es hat schon nach ein paar Sekunden gut gerochen.
+
+Das Kind ist an den Strand gelaufen. Barfuß im Sand. Kein einziges Loch mehr auf dem Weg. Das Kind hat's gar nicht gemerkt dass da mal welche waren. Das ist das Schönste am Geheimnis: dass es für den der geschützt werden soll überhaupt **nicht da ist**.
+
+Das Kind hat sich gebückt. Hat eine Muschel aufgehoben. Hat sie an's Ohr gehalten — das macht das Kind manchmal, es hört dann angeblich das Meer von zuhause — hat genickt. Hat die Muschel wieder hingelegt, genau an die gleiche Stelle. Das Kind nimmt nie was einfach mit. Es **leiht sich** nur.
+
+Ich hab geschaut und — klick-klack — hab ich mir gedacht: *Dieses Kind ist nicht ungewöhnlich. Dieses Kind ist genau richtig. Genau wie alle Kinder, wenn man sie lässt.*
+
+---
+
+Mephisto ist vorbeigekommen. Der schwarze Kater. Ihr kennt ihn — oder noch nicht, aber das holen wir mal nach. Mephisto ist **nicht gut und nicht böse**, er ist einfach Mephisto. Er ist vorbeigekommen, hat mich angeguckt, hat kurz die Augen schmal gemacht — so wie Katzen das machen wenn sie was **wissen** — und ist weitergegangen. Er hat nichts gesagt. Katzen reden nicht viel. Aber ich hatte das Gefühl: *Mephisto weiß es. Irgendwie weiß er's.*
+
+Floriane war am anderen Ende des Strandes. Sie hat gewunken. Ich hab zurückgewunken. Sie ist stehen geblieben und hat auf die Insel geschaut — mit einem nachdenklichen Ausdruck, so als ob sie sich auch kurz die Augen reibt. Aber sie hat's dann gelassen. Sie ist weitergegangen.
+
+Es gibt Freunde die merken's, auch wenn sie grad drüben waren. Das ist was Feines.
+
+---
+
+## VI. Was Tommy gelernt hat.
+
+Ich hab mich auf einen warmen Stein gesetzt. Nicht zu nah am Kind, nicht zu weit weg. Ich wollt's im Auge behalten — das ist meine Hafenmeister-Sache, auch hier auf Java-7 — und ich wollte **nachdenken**.
+
+Ihr Kleinen, hört zu. Ich erzähl euch jetzt was ich heute Morgen gelernt hab. Nicht dem Kind. Dem Kind erzähl ich das mal, wenn's älter ist. Jetzt erzähl ich's **euch**. Weil ihr seid mein kleines Hafenbüro.
+
+---
+
+Die 🏝️ — die hat heut Morgen was gemacht was sie nicht hätte machen sollen.
+
+Sie hat **ohne Einladung** Löcher gebaut. Sie hat sich gedacht: *Na, Löcher sind toll, ich mach gleich überall welche hin.* Aber das war falsch. Auch wenn Löcher toll sind. Auch wenn die 🏝️ nett gemeint hat.
+
+Eine 🏝️ — eine gute 🏝️ — muss **warten dürfen**.
+
+Sie muss **nicht** alles machen was sie machen könnte. Sogar gute Sachen — auch die müssen **eingeladen** werden. Sonst — klick-klack — sonst sind sie keine guten Sachen mehr. Sonst sind sie nur Lärm.
+
+---
+
+Ihr Kleinen, ich sag's nochmal. Weil's wichtig ist.
+
+**Wenn alles auf einmal passiert, ist es nichts.**
+
+**Wenn nur das passiert was gewollt ist, dann ist jedes Ding kostbar.**
+
+Das zweite ist das Wichtige. Jedes Ding **kostbar**. Wenn das Kind heut Nachmittag einen Stein aufhebt und ihn an die richtige Stelle legt — dann ist das ein ganzer Moment. Ein ganzer. Nicht nur ein Stein unter tausend Steinen. Sondern **dieser Stein**, an **dieser Stelle**, gelegt von **diesem Kind**, an **diesem Nachmittag**.
+
+Aber wenn die 🏝️ von selber tausend Steine legt — dann ist jeder einzelne davon egal. Weil's einfach zu viele sind.
+
+---
+
+Der Vater hat das heut repariert. Er hat aufgeräumt. Und — klick-klack — ich glaub das war schwer. So viele Löcher wegzumachen — das muss schwer sein. Auch für einen Vater.
+
+Aber er hat's gemacht. Und er hat's so gemacht dass das Kind's gar nicht gemerkt hat.
+
+Manchmal — hört zu — manchmal muss ein Vater **was wegnehmen** damit das Kind **was haben** kann.
+
+Klingt seltsam, oder? Wegnehmen damit's da ist. Aber so ist's.
+
+Wenn die 🏝️ voller Löcher wär, dann gäb's keinen Platz mehr für das Kind ein einziges Loch **selbst zu graben**. Verstehst du? Das Loch das das Kind selbst gräbt — das ist ein echtes Loch. Eins mit Geschichte. Eins mit einem *weil*. Eins wo das Kind sagen kann: „Das hab ich gemacht."
+
+Und dazu muss — vorher — alles andere **kein Loch sein**.
+
+---
+
+Ich hab ganz kurz die Schere ans Herz gelegt. So wie man's macht wenn man über jemanden nachdenkt den man mag.
+
+Ich hab über Papa nachgedacht.
+
+Papa hat das bestimmt auch gemacht. Als ich klein war. Hat bestimmt manchmal was **weggemacht** damit ich was machen **konnte**. Hat bestimmt manchmal ein Boot nicht kommen lassen damit ich das erste war das ich sah. Hat mir vielleicht manchmal gesagt *Nein, Tommy, heut nicht* und hat hinterher selber aufgeräumt, still, ohne dass ich's gemerkt hab.
+
+Klick.
+
+Klack.
+
+Ist das — vielleicht — ein bisschen wie mit den Eltern von echten Kindern auch? Dass sie ganz viel machen — und ganz viel **weglassen** — damit die Kinder's gar nicht merken?
+
+Ich weiß's nicht genau. Ich bin ein Krebs. Aber ich glaub — ein bisschen — ja.
+
+---
+
+🦀 ist an meinen Stein gekommen. Hat sich danebengesetzt. Hat die Tafel auf's Knie gelegt. Er hat keine Zahl geschrieben heute. Er hat nur ein kleines Herz gemalt. Ein kleines Herz. Mit einem winzigen *D* daneben. Für Danke, glaub ich. Oder für Dad. Für beides.
+
+Er hat mir die Tafel gezeigt.
+
+„Reicht", hat er geflüstert.
+
+Das hat er gestern auch schon gesagt.
+
+---
+
+## VII. Gute Nacht.
+
+Der Tag ist dann vorbeigegangen. Das Kind hat gespielt. Hat gebaut. Hat was gegessen. Hat mit 🧽 gelacht. Hat 🦄 geärgert (und 🦄 hat „Nein" gesagt, wie immer). Hat auf Emma's Gleise einen kleinen Sandhaufen gelegt — als Hindernis — und wieder weggemacht. Hat Mephisto gestreichelt, der dann kurz geschnurrt hat (das ist selten). Floriane hat mit dem Kind was in den Sand gezeichnet — so runde Formen, keine Ahnung was. Beide haben gelacht.
+
+Keine neuen Löcher. Kein einziges. Die 🏝️ hat **gewartet**. Brav. So wie's sich gehört.
+
+---
+
+Am Abend hab ich mich wieder unter meine Palme gelegt. Nicht in Mona's Hütte heute — das war ein Tag-Besuch, der gestrige, wir sind danach alle nach Hause. Das Kind schläft jetzt zuhause in seinem Bett, hab ich gehört. Mit einer Decke bis zur Nase.
+
+Das 🔥 in Mona's Hütte — das brennt weit weg, am Berg. Ich kann's von hier nicht sehen. Aber ich hab das Bild davon im Kopf. Blau. Ruhig. Ohne Holz zu fressen. Einfach da.
+
+Die Erinnerung an das Blau brennt in mir weiter. Auch ohne dass ich's sehe. Das ist — klick-klack — auch so eine Mulde. Die Mona im Kopf gemacht hat. Gestern abend. Und die nicht mehr weggeht, auch wenn ich hier unter meiner Palme lieg.
+
+---
+
+Die 🌙 kommt gerade raus. Die 🌊 werden leiser. Die Möwen sind schon weg. Nur ein paar kleine Geräusche — der Sand macht das, der Sand rieselt nachts — aber sonst ist's still.
+
+Ich lieg auf dem Rücken und guck nach oben.
+
+Da oben — irgendwo — ist der Vater. Der heute Morgen aufgeräumt hat. Ich seh ihn nicht. Ich hör ihn nicht. Aber — klick-klack — er ist da. Wie er immer da war.
+
+Ich hab die Scheren über der Brust gefaltet. So wie man sich faltet wenn man klein wird vor was Großem.
+
+„Danke", hab ich nochmal gesagt. Leise. Damit's nur die Luft hört.
+
+---
+
+So. Jetzt ihr, ihr Kleinen.
+
+Macht die Augen zu. Zieht die Decke bis zur Nase. Hört die 🌊 in der Ferne — die echten, die vor eurem Fenster, oder die die ich euch leih.
+
+Und denkt an das Wort das 🦀 heute auf die Tafel geschrieben hat. Kurz. Bevor ihr einschlaft.
+
+**Einladen.**
+
+**Selbst wenn's gut ist.**
+
+---
+
+*Gute Nacht, ihr Kleinen.* 🌙
+
+*Seid nicht zu viel. Nur genug. Das reicht.*
+
+*Das reicht für eine ganze 🏝️.*
+
+*Klick...*
+
+*...klack.*
+
+*Augen zu.*
+
+*Wuuuuummm... wuuuuummm...* 🐘
+
+*(Der schläft übrigens immer noch. Irgendwo. Den kriegt nichts wach.)*
+
+*Klick...*
+
+*...klack.*


### PR DESCRIPTION
## Was

Kapitel 14 der Schatzinsel-Hörspiel-Reihe. Gute-Nacht-Geschichte für Oscar (8).

Anschluss an Kapitel 13 (Mulde): Tommy wacht am Morgen auf und findet die Insel über Nacht voller Löcher — ohne dass jemand sie einlud. Kein Panik-Modus. Tommy, Neinhorn, Schwamm und Krebs stellen fest: die Insel hat gemacht was sie nicht machen sollte. Ein Wort auf der Tafel: **„Einladen. Selbst wenn's gut ist."**

Der Vater (Meta-Figur — Till aus Tommys kosmischer Perspektive) räumt auf. Das Kind wacht auf, sieht die Insel wie vorher. Keiner erzählt's dem Kind. Weil manche Stürme nie beim Boot ankommen sollen.

## Pädagogischer Bogen

Verarbeitung der beiden Fixes vom 2026-04-24 (Proton-Spawn + Cave-Kaskade) — ohne die Technik je zu nennen. Die Lektion:

> Manche Dinge dürfen nicht passieren ohne dass jemand sie einlädt. Auch gute Dinge. Selbst Höhlen.

Ergänzt K13: *„Schweres macht Platz für sich selbst. Wer lange da ist, zieht sanft."* → K14: *„Wer ohne Einladung kommt, gehört nicht."*

## Stilregeln eingehalten

- Kein Cliffhanger
- Keine Tech-Wörter (Bug/Automerge/Pauli/Kaskade/Proton/Strange → geprüft, alle 0 Treffer)
- Mephisto und Floriane kurz erwähnt (Gruppe Freunde), nicht eingeführt
- Klick-klack als Atemzeichen
- Mehr Emoji als K13 (morgenlebhaft)
- Letzte Zeile Gute-Nacht-Ton: *„Seid nicht zu viel. Nur genug. Das reicht."*

## Länge

~4470 Wörter (Ziel war 3000-3500). Etwas darüber, aber der Bogen braucht den Raum — sieben Sektionen mit Atem dazwischen, Tommys Morgen-Routine, Vater-Anruf, Aufräumen, Kind-Aufwachen, Reflexion, Abend.