### PR TITLE
feat(recipes): Myon- + Tau-Neutrino-Rezepte (Gen-Upgrade-Pfad vervollständigt)

### DIFF
--- a/ops/tests/automerge.test.js
+++ b/ops/tests/automerge.test.js
@@ -479,3 +479,106 @@ describe('INSEL_CRAFTING_RECIPES — Baryon-Craft', () => {
     });
 });
 
+// === Neutrino-Gen-Upgrade (PR #495-Follow-up) ===
+// Nach Entfernung der Pauli-Selbstaufwertungs-Regeln im Auto-Merge
+// (neutrino²→neutrino_mu, neutrino_mu²→neutrino_tau, caves-überall-Bug)
+// müssen Craft-Rezepte den Gen-Upgrade-Pfad für Neutrinos abdecken.
+// Progressive Disclosure: Gen2 erst nach muon, Gen3 erst nach tau.
+describe('INSEL_CRAFTING_RECIPES — Neutrino-Gen-Upgrade', () => {
+    let ctx;
+    let recipes;
+    let materials;
+
+    beforeEach(() => {
+        ctx = createBrowserContext();
+        loadScript(path.join(WORLD, 'materials.js'), ctx);
+        loadScript(path.join(WORLD, 'recipes.js'), ctx);
+        recipes = ctx.INSEL_CRAFTING_RECIPES;
+        materials = ctx.INSEL_MATERIALS;
+    });
+
+    it('Myon-Neutrino-Recipe existiert: 2 neutrino → 1 neutrino_mu', () => {
+        const r = recipes.find(x => x.result === 'neutrino_mu');
+        assert.ok(r, 'Myon-Neutrino-Craft-Recipe fehlt');
+        assert.equal(r.ingredients.neutrino, 2);
+        assert.equal(r.resultCount, 1);
+    });
+
+    it('Tau-Neutrino-Recipe existiert: 2 neutrino_mu → 1 neutrino_tau', () => {
+        const r = recipes.find(x => x.result === 'neutrino_tau');
+        assert.ok(r, 'Tau-Neutrino-Craft-Recipe fehlt');
+        assert.equal(r.ingredients.neutrino_mu, 2);
+        assert.equal(r.resultCount, 1);
+    });
+
+    it('Myon-Neutrino-Recipe hat Progressive-Disclosure-Gate: requires=["muon"]', () => {
+        const r = recipes.find(x => x.result === 'neutrino_mu');
+        assert.ok(r);
+        // Cross-vm Array-Prototype: per Element vergleichen statt deepEqual.
+        assert.ok(Array.isArray(r.requires) || r.requires.length !== undefined, 'requires muss Array-ähnlich sein');
+        assert.equal(r.requires.length, 1);
+        assert.equal(r.requires[0], 'muon', 'Gen2-Neutrino erst nach Muon-Erlebnis sichtbar');
+    });
+
+    it('Tau-Neutrino-Recipe hat Progressive-Disclosure-Gate: requires=["tau"]', () => {
+        const r = recipes.find(x => x.result === 'neutrino_tau');
+        assert.ok(r);
+        assert.ok(Array.isArray(r.requires) || r.requires.length !== undefined, 'requires muss Array-ähnlich sein');
+        assert.equal(r.requires.length, 1);
+        assert.equal(r.requires[0], 'tau', 'Gen3-Neutrino erst nach Tau-Erlebnis sichtbar');
+    });
+
+    it('alle Neutrino-Recipe-Ingredients sind gültige Materials', () => {
+        const keys = ['neutrino_mu', 'neutrino_tau'];
+        for (const key of keys) {
+            const r = recipes.find(x => x.result === key);
+            for (const ing of Object.keys(r.ingredients)) {
+                assert.ok(
+                    materials[ing],
+                    `Neutrino-Recipe ${key}: Ingredient "${ing}" ist kein Material`
+                );
+            }
+        }
+    });
+
+    it('Neutrino-Recipes-Ergebnisse sind als Materials definiert (spin=0.5)', () => {
+        assert.ok(materials.neutrino_mu, 'neutrino_mu muss existieren');
+        assert.equal(materials.neutrino_mu.spin, 0.5);
+        assert.ok(materials.neutrino_tau, 'neutrino_tau muss existieren');
+        assert.equal(materials.neutrino_tau.spin, 0.5);
+    });
+});
+
+// === Regression: Neutrino-Pauli-Kaskade bleibt im Auto-Merge deaktiviert ===
+// Sicherstellen, dass die Gen-Upgrade-Rezepte NICHT versehentlich wieder
+// als Auto-Merge-Regel eingeführt werden (Caves-überall-Bug-Klasse).
+describe('INSEL_AUTOMERGE — Neutrino-Pauli-Kaskade bleibt deaktiviert', () => {
+    let ctx;
+    let checkMerge;
+
+    beforeEach(() => {
+        ctx = createBrowserContext();
+        loadScript(path.join(WORLD, 'materials.js'), ctx);
+        loadScript(path.join(WORLD, 'automerge.js'), ctx);
+        checkMerge = ctx.INSEL_AUTOMERGE.checkMerge;
+    });
+
+    it('Neutrino + Neutrino allein → KEIN Auto-Merge zu neutrino_mu', () => {
+        const grid = makeGrid(5, 5, [
+            [2, 2, 'neutrino'],
+            [2, 3, 'neutrino'],
+        ]);
+        const result = checkMerge(grid, 2, 3, 5, 5);
+        assert.equal(result, null, 'Gen1→Gen2 nur via Recipe, nicht via Auto-Merge');
+    });
+
+    it('Neutrino_mu + Neutrino_mu allein → KEIN Auto-Merge zu neutrino_tau', () => {
+        const grid = makeGrid(5, 5, [
+            [2, 2, 'neutrino_mu'],
+            [2, 3, 'neutrino_mu'],
+        ]);
+        const result = checkMerge(grid, 2, 3, 5, 5);
+        assert.equal(result, null, 'Gen2→Gen3 nur via Recipe, nicht via Auto-Merge');
+    });
+});
+

--- a/src/world/recipes.js
+++ b/src/world/recipes.js
@@ -21,6 +21,13 @@ window.INSEL_CRAFTING_RECIPES = [
     { name: 'Elektron',    result: 'electron', resultCount: 1, ingredients: { lightning: 1, metal: 1 },      desc: 'Blitz + Metall = Elektron (Strom ist Elektronenfluss!)' },
     { name: 'Myon',        result: 'muon',     resultCount: 1, ingredients: { electron: 1, star: 1 },        desc: 'Elektron + Stern = Myon (kosmische Strahlung!)' },
     { name: 'Tau',         result: 'tau',      resultCount: 1, ingredients: { electron: 1, antimatter: 1 },  desc: 'Elektron + Antimaterie = Tau (schwerstes Lepton!)' },
+    // Neutrino-Gen-Upgrade (PR #495-Follow-up): Pauli-Selbstaufwertung im
+    // Auto-Merge wurde entfernt (Caves-überall-Bug). Gen2/Gen3-Neutrinos
+    // sind nur noch via Craft erreichbar. Progressive Disclosure: erst
+    // sichtbar, wenn das passende geladene Lepton (muon/tau) bereits
+    // entdeckt wurde — pädagogischer Lernweg.
+    { name: 'Myon-Neutrino', result: 'neutrino_mu',  resultCount: 1, ingredients: { neutrino: 2 },    requires: ['muon'], desc: '2 Neutrinos fusionieren zu Myon-Neutrino (Gen 2, Pauli-Druck)' },
+    { name: 'Tau-Neutrino',  result: 'neutrino_tau', resultCount: 1, ingredients: { neutrino_mu: 2 }, requires: ['tau'],  desc: '2 Myon-Neutrinos fusionieren zu Tau-Neutrino (Gen 3, Pauli-Druck)' },
     // Stufe 5→10.000: Der Kreislauf der 5 Elemente
     // Holz nährt Feuer (Holz brennt)
     { name: 'Glut',     result: 'fire',  resultCount: 3, ingredients: { wood: 2, fire: 1 }, desc: 'Holz brennt! 2 Holz + Feuer = 3 Feuer' },


### PR DESCRIPTION
## Warum

PR #495 hat alle Pauli-Selbstaufwertungs-Regeln aus dem Auto-Merge entfernt, um den **Caves-überall-Bug** zu fixen (Chain-Kaskade: `strange²→cave` flutete das Grid). Damit verschwanden auch die Gen-Upgrades für Neutrinos:

- ~~`neutrino² → neutrino_mu`~~ (raus)
- ~~`neutrino_mu² → neutrino_tau`~~ (raus)

Für die anderen Gen-Upgrades gibt es bereits Craft-Rezepte (Quark-Ladder via `charm`/`strange`, Leptonen via `electron`/`muon`/`tau`). **Für Neutrinos fehlten die Rezepte komplett** — Gen 2 und Gen 3 Neutrinos waren für Oscar unerreichbar.

Kernighan-Agent hat das im PR #495-Body als Bug gemeldet. Das ist der Follow-up.

## Was

Zwei neue Craft-Rezepte in `src/world/recipes.js`, direkt nach den Lepton-Rezepten (Zeile 24–29):

```js
{ name: 'Myon-Neutrino', result: 'neutrino_mu',  resultCount: 1, ingredients: { neutrino: 2 },    requires: ['muon'], desc: '2 Neutrinos fusionieren zu Myon-Neutrino (Gen 2, Pauli-Druck)' },
{ name: 'Tau-Neutrino',  result: 'neutrino_tau', resultCount: 1, ingredients: { neutrino_mu: 2 }, requires: ['tau'],  desc: '2 Myon-Neutrinos fusionieren zu Tau-Neutrino (Gen 3, Pauli-Druck)' },
```

### Physikalische Motivation

Analog zu den geladenen Leptonen gibt es drei Neutrino-Generationen: ν_e, ν_μ, ν_τ. In der Natur entsteht das Myon-Neutrino aus Myon-Zerfällen, das Tau-Neutrino aus Tau-Zerfällen. Für unser Spiel modellieren wir den Gen-Upgrade per Pauli-Druck: zwei identische Gen-N-Neutrinos im Kraft-Bereich → Gen-N+1 (Ladung bleibt 0, Spin bleibt 1/2).

### Progressive Disclosure

`requires: ['muon']` bzw. `requires: ['tau']` — das Recipe ist erst sichtbar, wenn Oscar das passende geladene Lepton schon entdeckt hat. Pädagogischer Lernweg: erst Myon erleben, dann Myon-Neutrino freischalten. Analog zu Baryon-Rezepten aus PR #489 (`requires: ['charm']` bzw. `['strange']`).

Die bestehende `recipeUnlocked()`-Logik in `src/core/game.js:1602` verarbeitet das Feld schon — keine Code-Änderung nötig.

## Tests

8 neue Tests in `ops/tests/automerge.test.js`:

**INSEL_CRAFTING_RECIPES — Neutrino-Gen-Upgrade** (6 Tests)
- Myon-Neutrino-Recipe existiert: `2 neutrino → 1 neutrino_mu`
- Tau-Neutrino-Recipe existiert: `2 neutrino_mu → 1 neutrino_tau`
- Progressive-Disclosure-Gate: `requires=['muon']` bzw. `['tau']`
- Ingredient-Validität (alle als Material definiert)
- Ergebnis-Materials existieren mit `spin=0.5`

**INSEL_AUTOMERGE — Neutrino-Pauli-Kaskade bleibt deaktiviert** (2 Tests)
- `neutrino + neutrino` im Auto-Merge → `null` (Regression gegen Caves-Bug-Klasse)
- `neutrino_mu + neutrino_mu` im Auto-Merge → `null`

## Test plan

- [x] `npm run test:unit` — 95/95 grün
- [x] `npx tsc --noEmit` — keine Errors
- [x] Recipes-Diff minimal-invasiv: 7 Zeilen in `recipes.js` (2 neue Rezepte + 5 Zeilen Kommentar)
- [x] Keine Änderungen in `automerge.js` — Auto-Merge-Verhalten unverändert
- [ ] Manuell: Oscar spielt bis Muon, sieht Myon-Neutrino-Rezept im Crafter
- [ ] Manuell: Oscar crafted Myon-Neutrino, erreicht Tau, sieht Tau-Neutrino-Rezept

🤖 Generated with [Claude Code](https://claude.com/claude-code)