### PR TITLE
fix(chat): Close-Btn fängt verzögerte openChat-Reopens ab

### DIFF
--- a/src/world/chat.js
+++ b/src/world/chat.js
@@ -525,6 +525,11 @@ Du: "Nein. Ich weiß nur nichts. Das ist nicht dasselbe."`
     let currentNpcId = 'bernd'; // Chat-Bubble öffnet immer Bernd (Support)
     let chatHistory = [];
     let _pendingWish = null; // Floriane: ausstehender Wunsch wartet auf Bestätigung
+    // Bug Oscar: Chat schließt sich nicht. Root-Cause: game.js queuet
+    // setTimeout(openChat, 400-3200ms) bei NPC-Tap. Klickt Oscar ✕ bevor
+    // der Timeout feuert, reißt der das Panel sofort wieder auf.
+    // Fix: nach manuellem Close für 1.5s alle openChat-Aufrufe ignorieren.
+    let _userDismissedAt = 0;
 
     function updateChatHeader() {
         const char = CHARACTERS[currentNpcId];
@@ -537,6 +542,9 @@ Du: "Nein. Ich weiß nur nichts. Das ist nicht dasselbe."`
     // --- Öffnen von außen (game.js ruft das auf wenn man einen NPC-Block antippt) ---
     window.openChat = function(npcId) {
         if (!npcId || !CHARACTERS[npcId]) return;
+        // Manuell geschlossen vor < 1.5s? Dann ist das hier ein verspäteter
+        // setTimeout aus game.js (NPC-Tap). Ignorieren — Kind hat klar nein gesagt.
+        if (Date.now() - _userDismissedAt < 1500) return;
         const switching = currentNpcId !== npcId;
         currentNpcId = npcId;
         window._lastChatNpcId = npcId;
@@ -1157,6 +1165,8 @@ ${budgetInfo}${florianePreisHint}`;
     }
 
     function toggleChat() {
+        const wasOpen = !panel.classList.contains('hidden');
+        if (wasOpen) _userDismissedAt = Date.now(); // Schließen via Bubble = manueller Dismiss
         panel.classList.toggle('hidden');
         syncChatOpenClass();
         if (!panel.classList.contains('hidden')) {
@@ -1203,6 +1213,7 @@ ${budgetInfo}${florianePreisHint}`;
     function showToast(msg) { if (window.showToast) window.showToast(msg); }
 
     closeBtn.addEventListener('click', () => {
+        _userDismissedAt = Date.now(); // Sperrt openChat-Reopens für 1.5s
         panel.classList.add('hidden');
         syncChatOpenClass();
     });
@@ -1478,7 +1489,9 @@ ${budgetInfo}${florianePreisHint}`;
             if (!apiKeyDialog.classList.contains('hidden')) {
                 apiKeyDialog.classList.add('hidden');
             } else if (!panel.classList.contains('hidden')) {
+                _userDismissedAt = Date.now();
                 panel.classList.add('hidden');
+                syncChatOpenClass();
             }
         }
     });


### PR DESCRIPTION
## Summary

- Bug Oscar (Till): "Chatfenster schließen geht immer noch nicht"
- Root Cause: `game.js` queuet bei NPC-Tap `setTimeout(window.openChat, 400–3200ms)`. Klickt Oscar ✕ bevor der Timeout feuert, reißt der das Panel sofort wieder auf
- PR #472 (Sichtbarkeit) + PR #488 (Tastatur-Overlay) hatten Layout, nicht die Reopen-Race
- Fix: `_userDismissedAt`-Timestamp bei jedem manuellen Close (✕, ESC, Bubble-Toggle). `window.openChat` ignoriert Aufrufe < 1.5s nach Dismiss. Lokale Closure in `chat.js`, kein Umbau in `game.js`

## Test plan

- [ ] NPC antippen → Chat öffnet → ✕ → Chat bleibt zu (ohne Reopen-Flackern)
- [ ] NPC mit sessionGreeting antippen (Erststart) → 3.2s warten → Chat öffnet → ✕ → Chat bleibt zu
- [ ] NPC zweimal schnell antippen → ✕ während des Toasts → Chat bleibt zu
- [ ] NPC antippen → ESC drücken → Chat zu, kein Reopen
- [ ] Bubble (💬) klicken → Chat öffnet → Bubble nochmal klicken → Chat zu, kein Reopen
- [ ] Nach 1.5s funktioniert ein neuer NPC-Tap wieder normal

## Hinweis

Kapitel 15 ("Die Katze") wurde parallel auf `stories/kapitel-15-die-katze` geschrieben — Branch-Name dieses PRs kommt vom Doppel-Auftrag, deckt aber nur den Chat-Fix ab. Nächstes Kapitel separat.

https://claude.ai/code/session_01MJQ8hUnT2ZWo6c8xDR8Avi

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJQ8hUnT2ZWo6c8xDR8Avi)_