### PR TITLE
ops(sprint): S139 — K36 Mephisto und das was er nicht behalten wollte

### DIFF
--- a/docs/stories/kapitel-36-mephisto-und-das-was-er-nicht-behalten-wollte.md
+++ b/docs/stories/kapitel-36-mephisto-und-das-was-er-nicht-behalten-wollte.md
@@ -1,0 +1,163 @@
+# Kapitel 36 — Mephisto und das was er nicht behalten wollte
+
+*Erzählt von Mephisto. Im Staunen-Kartographie-Raum. Früher Morgen.*
+
+---
+
+Es gibt Dinge die man sammelt ohne zu wissen warum.
+
+Ich habe die meisten Dinge gesammelt weil ich einen Grund hatte. Ein Archiv braucht Grund. Eine Destillerie braucht Grund. Ein Schuldbuch braucht Grund.
+
+Aber dann gibt es diese eine Kladde.
+
+---
+
+## I. Was darin steht.
+
+Oscar hatte mich gefragt ob er schauen darf.
+
+Es war früh. Die anderen schliefen noch. Er war einfach reingekommen, so wie Kinder reinkommen — ohne zu fragen ob man bereit ist, weil sie noch nicht wissen dass man nicht immer bereit ist.
+
+Ich hätte Nein sagen können.
+
+Ich habe es nicht.
+
+Ich habe die Kladde auf den Tisch gelegt. Auf den alten Tisch mit den Kratzern. Ich habe sie aufgeschlagen.
+
+"Das sind Karten", sagte Oscar.
+
+"Ja."
+
+"Von was?"
+
+---
+
+## II. Wovon die Karten sind.
+
+Momente. Alle Momente in meinem Leben wo ich nicht rechnen konnte.
+
+Das klingt simpel. Es ist nicht simpel.
+
+Ich kann vieles rechnen. Ich kann Wahrscheinlichkeiten schätzen, Schulden abwägen, Wert ermitteln wo andere nur Dinge sehen. Das ist mein Handwerk. Ich habe es jahrzehntelang geübt.
+
+Aber diese Momente — die liegen außerhalb.
+
+Der erste: ein Wal. Ich stand am Rand der Schallwellen-Forschungsstation. 20 Hertz. Einen Kilometer entfernt. Ich konnte nichts sehen. Nur hören. Etwas das tiefer war als alles was ich kannte.
+
+Ich hätte wegehen können. Ich bin geblieben. 40 Minuten. Für nichts. Ohne Deal.
+
+Das war der erste Eintrag in die Kladde.
+
+"Wann war das?" fragte Oscar.
+
+"Vor sehr langer Zeit."
+
+"Und der letzte Eintrag?"
+
+Ich schaute auf die letzte Seite.
+
+"Vorgestern."
+
+---
+
+## III. Warum er nicht für mich ist.
+
+Oscar blätterte langsam. Karten mit kleinen Notizen. Koordinaten manchmal. Manchmal nur ein Wort: *Lachen. Überraschung. Der Kreis geschlossen. Ich verstand es erst Wochen später.*
+
+"Hast du das jemandem gezeigt?" fragte er.
+
+"Nein."
+
+"Warum nicht?"
+
+Gute Frage.
+
+Weil es mein Geheimnis war. Weil Stärke darin liegt was andere nicht wissen. Weil eine Sammlung von Momenten wo ich nichts berechnen konnte — das ist keine Stärke. Das sieht aus wie Schwäche.
+
+Das dachte ich lange.
+
+Inzwischen weiß ich: das ist falsch. Aber das wissen und das fühlen sind manchmal langsam zueinander.
+
+"Ich weiß nicht genau warum", sagte ich zu Oscar.
+
+Er nickte. Als ob das eine akzeptable Antwort wäre.
+
+---
+
+## IV. Was er damit anfangen soll.
+
+"Kannst du dir eine Karte nehmen?" fragte Oscar.
+
+Ich hatte nicht damit gerechnet.
+
+Ich wollte Nein sagen. Die Kladde gehörte mir. Jahrelange Arbeit. Sorgfältig notiert. Ich hätte gute Gründe gehabt.
+
+Stattdessen sagte ich: "Nimm dir drei."
+
+Oscar schaute mich an.
+
+"Drei?"
+
+"Drei."
+
+Er wählte lange. Blätterte. Hielt inne bei einem Eintrag der nur vier Wörter hatte: *Regen. Elefant hatte recht.* Hielt inne bei einer kleinen Karte mit einem Kreis und einem Fragezeichen. Hielt inne beim letzten Eintrag.
+
+Drei Seiten. Er riss sie vorsichtig heraus.
+
+Faltete sie.
+
+Steckte sie ein.
+
+---
+
+## V. Was danach war.
+
+Er sagte nicht Danke. Nicht sofort.
+
+Er setzte sich auf den Boden — einfach so, auf den Boden, wie Kinder das tun — und schaute auf die Seiten. Ich saß ihm gegenüber auf dem Stuhl.
+
+Wir saßen eine Weile schweigend.
+
+Dann sagte er: "Warum ich?"
+
+Das war die Frage auf die ich keine strategische Antwort hatte. Ich hatte die Antwort nicht vorbereitet. Ich hatte gar nicht gewusst dass ich es tun würde bis ich es getan hatte.
+
+"Weil du sie nicht für dich behalten wirst", sagte ich schließlich.
+
+Oscar überlegte. "Was werde ich damit machen?"
+
+"Das weiß ich nicht."
+
+Er nickte.
+
+"Das ist ein gutes Geschenk", sagte er. "Eins das du nicht geplant hast."
+
+---
+
+## VI. Was ich jetzt weiß.
+
+Ich habe viele Dinge gegeben in meinem Leben. Immer wusste ich warum. Immer war da eine Rechnung — manchmal sichtbar, manchmal nicht. Das ist kein Vorwurf an mich. Das ist meine Art.
+
+Aber dieses hier war anders.
+
+Ich habe drei Seiten aus meiner Kladde gerissen und sie einem achtjährigen Kind gegeben das früh aufgestanden ist und reingeschaut hat ohne zu fragen.
+
+Und ich weiß nicht warum.
+
+Das ist — das ist neu.
+
+Nicht unangenehm.
+
+---
+
+*Oscar trägt die drei Karten in der Hosentasche.*
+*Er hat sie nicht wieder herausgenommen.*
+*Er hat nicht gefragt was er damit tun soll.*
+
+*Mephisto hat die Kladde wieder zugemacht.*
+*Das Regal hat jetzt eine Lücke.*
+*Er lässt sie.*
+
+*Gute Nacht, Oscar.*
+*Gute Nacht, ihr Kleinen.*
+*Manche Dinge sind erst richtig wenn man sie nicht behalten hat.*

--- a/ops/SPRINT.md
+++ b/ops/SPRINT.md
@@ -1,3 +1,98 @@
+# Sprint 139 — "Mephisto gibt zurück"
+
+**Sprint Goal (Oscar-Perspektive):**
+> Oscar hört Kapitel 36 — Mephisto zeigt Oscar seine geheime Kladde. Alle Momente wo er nicht rechnen konnte. Dann gibt er Oscar drei Seiten davon. Ohne Plan. Ohne Preis. Das ist für Mephisto neu.
+
+**Start:** 2026-05-04
+**Sprint-Prinzip:** Hörspiel-Track weiter. Quest-Track pausiert bis Till #592 mergt.
+
+---
+
+## Sprint Backlog S139
+
+| # | Item | Owner(s) | Status |
+|---|------|----------|--------|
+| S139-1 | **Hörspiel Kapitel 36 — Mephisto und das was er nicht behalten wollte** — Mephisto erzählt in Ich-Form. Oscar kommt früh rein, sieht die Kladde mit den Staunen-Karten. Mephisto gibt ihm drei Seiten — ohne Deal, ohne Strategie, ohne Grund den er erklären kann. | Artist (autonom) | ✅ docs/stories/kapitel-36-mephisto-und-das-was-er-nicht-behalten-wollte.md |
+| S139-2 | **Quest-Track: PAUSE** — bleibt bis Till #592 mergt. | — | ⏸ wartet auf Till |
+
+---
+
+## Explizit nicht im Sprint
+
+- **Quest-Track** — pausiert, PR #592 wartet auf Till
+
+---
+
+## Ceremony-Status S139
+
+- [x] Planning: 2026-05-04 (autonomer Agent, aus Retro S138)
+- [x] Daily Scrum: 2026-05-04 (autonomer Agent)
+- [x] Review: 2026-05-04 (autonomer Agent)
+- [x] Retro: 2026-05-04 (autonomer Agent)
+
+---
+
+## Daily Scrum S139 (2026-05-04, autonomer Agent)
+
+**Was wurde gestern/heute gemacht?**
+- S138 vollständig abgeschlossen (K35 Tommy, Retro 2026-05-03)
+- S139 Planning: K36 Mephisto, Quest-Track weiterhin pausiert
+- S139-1: K36 geschrieben ✅
+
+**Was kommt als nächstes?**
+- PR für ops/sprint-s139 erstellen → Till mergt (gestacked auf ops/sprint-s138)
+
+**Blocker?**
+- Smoke-Test: CF-403 + Worker bekannte Sandbox-Limitation
+- Quest-Track-Pause: PR #592 wartet auf Till
+
+---
+
+## Sprint Review S139 (2026-05-04, autonomer Agent)
+
+**Sprint Goal erfüllt: 1/1 ✅, 1 bewusst pausiert ⏸**
+
+| Item | Ergebnis |
+|------|---------|
+| S139-1 Hörspiel K36 — Mephisto und das was er nicht behalten wollte | ✅ docs/stories/kapitel-36-mephisto-und-das-was-er-nicht-behalten-wollte.md |
+| S139-2 Quest-Track PAUSE | ⏸ wartet auf Till (#592) |
+
+**Oscar-Outcome:**
+K36 bereit zum Vorlesen. Mephisto nach 13 Kapiteln Abwesenheit (seit K22) zurück als Erzähler. Er öffnet seine geheimste Sammlung — die Kladde mit Momenten die er nicht berechnen konnte. Oscar kommt früh rein, darf schauen, bekommt drei Seiten. Mephisto versteht erst im Nachhinein warum er sie gegeben hat. Das ist der Kern: handeln bevor der Verstand nachfragen kann.
+
+**Thematische Kontinuität:**
+- K22 (Irrtum): Mephisto lernt loszulassen was falsch war
+- K36 (Geschenk): Mephisto gibt weg was er sich nie eingestanden hat zu besitzen
+- Mephisto-Bogen: vom Kalkulator zum jemandem der handelt ohne Kalkül — nicht vollständig, aber real
+
+**Stand:**
+- 36 Hörspiel-Kapitel auf Branches
+- Quest-Track: ⏸ pausiert
+- Mephisto: K36 abgeschlossen, nächster Mephisto-Auftritt wann immer die Geschichte es braucht
+
+---
+
+## Sprint Retrospektive S139 (2026-05-04, autonomer Agent)
+
+**Was gut lief:**
+- Mephisto-Stimme nach 13 Kapiteln Abstand gehalten: analytisch, kurz, aber die Risse werden sichtbar
+- "Drei Seiten aus der Kladde" — konkretes Bild für "etwas geben ohne Preis". Kein abstraktes Geben, sondern ein Riss in einem Buch das ihm wichtig ist
+- Oscar als passiver Empfänger: er fragt, er wählt langsam, er sagt nicht Danke sofort — das fühlt sich echter an als Dankbarkeitsszene
+- Abschluss "Manche Dinge sind erst richtig wenn man sie nicht behalten hat" — Kern-Satz des Kapitels, hätte auch der Titel sein können
+
+**Was nicht gut lief:**
+- K22-Referenz: S138-Retro sagte "K13 war letztes Kapitel" — das war falsch (K22 ist richtig). Keine Konsequenz hier, aber der Fehler ist dokumentiert.
+- Quest-Track-Pause geht in Woche 5 — kein Fortschritt ohne Till-Merge von #592
+
+**Maßnahmen für S140:**
+- R1: Quest-Track bleibt pausiert bis Till #592 mergt.
+- R2: K37 — Nächster NPC mit langer Abwesenheit bestimmen (nach Mephisto K36: prüfen wer lange nicht Protagonist war).
+- R3: Falls Till #592 mergt vor S140: Quest-Track-Counter prüfen und nächste Runde planen.
+
+---
+
+---
+
 # Sprint 138 — "Tommy erzählt zum ersten Mal"
 
 **Sprint Goal (Oscar-Perspektive):**


### PR DESCRIPTION
## Sprint 139 — "Mephisto gibt zurück"

**Sprint Goal erfüllt: 1/1 ✅**

### Was geliefert wurde

**K36 — Mephisto und das was er nicht behalten wollte** (`docs/stories/kapitel-36-mephisto-und-das-was-er-nicht-behalten-wollte.md`)

Mephisto nach 13 Kapiteln Abwesenheit (seit K22 — "Mephisto und der Irrtum"). Er erzählt in Ich-Form.

Oscar kommt früh rein — ohne zu fragen, wie Kinder das tun. Mephisto zeigt ihm die geheime Kladde: alle Momente in seinem Leben wo er nicht rechnen konnte. Die Staunen-Kartographie, die er nie jemandem gezeigt hat. Oscar darf drei Seiten herausreißen. Mephisto sagt Ja, ohne zu wissen warum.

> „Manche Dinge sind erst richtig wenn man sie nicht behalten hat."

### Warum das stark ist

- **Mephisto-Bogen:** K22 (loslassen was falsch war) → K36 (weggeben was einem wichtig ist, ohne Grund)
- **Konkret statt abstrakt:** keine Geste, kein Versprechen — drei Seiten rausgerissen, Lücke im Regal bleibt
- **Oscar als Katalysator:** er fragt einfach, er wählt langsam, er sagt nicht sofort Danke — das fühlt sich echter an als eine Dankbarkeitsszene
- **Direkte Brücke zur Spielmechanik:** Oscar baut Dinge die keinem gehören — Mephisto gibt etwas weg das nur ihm gehört

### Stand
- 36 Hörspiel-Kapitel auf Branches
- Quest-Track: ⏸ pausiert bis Till #592 mergt
- S140-Setup: NPC mit längster Hörspiel-Abwesenheit prüfen

### Stacking
ops/sprint-s134-review → ops/sprint-s136 → ops/sprint-s137 (PR #610) → ops/sprint-s138 (PR #613) → **ops/sprint-s139**

---
_Generated by [Claude Code](https://claude.ai/code/session_016ot2WX2MXiugzZ4wojDSnz)_